### PR TITLE
Add batched decorator

### DIFF
--- a/docs/user-guide/PersonalIdentifiableInformationIdentificationAndRemoval.rst
+++ b/docs/user-guide/PersonalIdentifiableInformationIdentificationAndRemoval.rst
@@ -51,9 +51,9 @@ You could read, de-identify the dataset, and write it to an output directory usi
     from nemo_curator.utils.distributed_utils import read_data, write_to_disk, get_client
     from nemo_curator.utils.file_utils import get_batched_files
     from nemo_curator.modules.modify import Modify
-    from nemo_curator.modifiers.pii_modifier import PiiModifierBatched
+    from nemo_curator.modifiers.pii_modifier import PiiModifier
 
-    modifier = PiiModifierBatched(
+    modifier = PiiModifier(
         language="en",
         supported_entities=["PERSON", "EMAIL_ADDRESS"],
         anonymize_action="replace",
@@ -70,7 +70,7 @@ You could read, de-identify the dataset, and write it to an output directory usi
         dataset = DocumentDataset(source_data)
         print(f"Dataset has {source_data.npartitions} partitions")
 
-        modify = Modify(modifier, batched=True)
+        modify = Modify(modifier)
         modified_dataset = modify(dataset)
         write_to_disk(modified_dataset.df,
                       "output_directory",
@@ -84,7 +84,7 @@ Let's walk through this code line by line.
 * ``for file_names in get_batched_files`` retrieves a batch of 32 documents from the `book_dataset`
 * ``source_data = read_data(file_names, file_type="jsonl", backend='pandas', add_filename=True)`` reads the data from all the files using Dask using Pandas as the backend. The ``add_filename`` argument ensures that the output files have the same filename as the input files.
 * ``dataset = DocumentDataset(source_data)``  creates an instance of ``DocumentDataset`` using the batch files. ``DocumentDataset`` is the standard format for text datasets in NeMo Curator.
-* ``modify = Modify(modifier, batched=True)`` creates an instance of the ``Modify`` class. This class can take any modifier as an argument
+* ``modify = Modify(modifier)`` creates an instance of the ``Modify`` class. This class can take any modifier as an argument
 * ``modified_dataset = modify(dataset)`` modifies the data in the dataset by performing the PII de-identification based upon the passed parameters.
 * ``write_to_disk(modified_dataset.df ....`` writes the de-identified documents to disk.
 

--- a/docs/user-guide/PersonalIdentifiableInformationIdentificationAndRemoval.rst
+++ b/docs/user-guide/PersonalIdentifiableInformationIdentificationAndRemoval.rst
@@ -80,7 +80,7 @@ You could read, de-identify the dataset, and write it to an output directory usi
 
 Let's walk through this code line by line.
 
-* ``modifier = PiiModifierBatched`` creates an instance of ``PiiModifierBatched`` class that is responsible for PII de-identification
+* ``modifier = PiiModifier`` creates an instance of ``PiiModifier`` class that is responsible for PII de-identification
 * ``for file_names in get_batched_files`` retrieves a batch of 32 documents from the `book_dataset`
 * ``source_data = read_data(file_names, file_type="jsonl", backend='pandas', add_filename=True)`` reads the data from all the files using Dask using Pandas as the backend. The ``add_filename`` argument ensures that the output files have the same filename as the input files.
 * ``dataset = DocumentDataset(source_data)``  creates an instance of ``DocumentDataset`` using the batch files. ``DocumentDataset`` is the standard format for text datasets in NeMo Curator.

--- a/examples/classifier_filtering.py
+++ b/examples/classifier_filtering.py
@@ -19,7 +19,7 @@ import fasttext
 
 import nemo_curator as nc
 from nemo_curator.datasets import DocumentDataset
-from nemo_curator.filters import BatchedFastTextQualityFilter
+from nemo_curator.filters import FastTextQualityFilter
 from nemo_curator.modifiers import FastTextLabelModifier
 from nemo_curator.utils.distributed_utils import get_client, read_data, write_to_disk
 from nemo_curator.utils.file_utils import get_all_files_paths_under
@@ -85,7 +85,7 @@ def main(args):
     # Filter data
     target_dataset = load_dataset(low_quality_data_path)
     filter_pipeline = nc.ScoreFilter(
-        BatchedFastTextQualityFilter(model_path),
+        FastTextQualityFilter(model_path),
         score_field="quality_score",
         batched=True,
         score_type=float,

--- a/examples/classifier_filtering.py
+++ b/examples/classifier_filtering.py
@@ -87,7 +87,6 @@ def main(args):
     filter_pipeline = nc.ScoreFilter(
         FastTextQualityFilter(model_path),
         score_field="quality_score",
-        batched=True,
         score_type=float,
     )
     filtered_dataset = filter_pipeline(target_dataset)

--- a/examples/find_pii_and_deidentify.py
+++ b/examples/find_pii_and_deidentify.py
@@ -18,7 +18,7 @@ import dask.dataframe
 import pandas as pd
 
 from nemo_curator.datasets import DocumentDataset
-from nemo_curator.modifiers.pii_modifier import PiiModifierBatched
+from nemo_curator.modifiers.pii_modifier import PiiModifier
 from nemo_curator.modules.modify import Modify
 from nemo_curator.utils.distributed_utils import get_client
 from nemo_curator.utils.script_utils import add_distributed_args
@@ -35,7 +35,7 @@ def console_script():
     dd = dask.dataframe.from_pandas(dataframe, npartitions=1)
     dataset = DocumentDataset(dd)
 
-    modifier = PiiModifierBatched(
+    modifier = PiiModifier(
         log_dir="./logs",
         batch_size=2000,
         language="en",
@@ -43,7 +43,7 @@ def console_script():
         anonymize_action="replace",
     )
 
-    modify = Modify(modifier, batched=True)
+    modify = Modify(modifier)
     modified_dataset = modify(dataset)
     modified_dataset.df.to_json("output_files/*.jsonl", lines=True, orient="records")
 

--- a/nemo_curator/filters/__init__.py
+++ b/nemo_curator/filters/__init__.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .classifier_filter import (
-    BatchedFastTextQualityFilter,
-    FastTextLangId,
-    FastTextQualityFilter,
-)
+from .classifier_filter import FastTextLangId, FastTextQualityFilter
 from .code import (
     AlphaFilter,
     GeneralCommentToCodeFilter,
@@ -54,7 +50,6 @@ from .heuristic_filter import (
 )
 
 __all__ = [
-    "BatchedFastTextQualityFilter",
     "DocumentFilter",
     "import_filter",
     "FastTextLangId",

--- a/nemo_curator/modifiers/pii_modifier.py
+++ b/nemo_curator/modifiers/pii_modifier.py
@@ -18,14 +18,15 @@ import pandas as pd
 
 from nemo_curator.modifiers import DocumentModifier
 from nemo_curator.pii.algorithm import DEFAULT_LANGUAGE
+from nemo_curator.utils.decorators import batched
 from nemo_curator.utils.distributed_utils import load_object_on_worker
 
-__all__ = ["PiiModifierBatched"]
+__all__ = ["PiiModifier"]
 
 DEFAULT_BATCH_SIZE = 2000
 
 
-class PiiModifierBatched(DocumentModifier):
+class PiiModifier(DocumentModifier):
     """
     This class is the entry point to using the PII de-identification module on documents stored as CSV, JSONL or
     other formats. It works with the `Modify` functionality as shown below:
@@ -34,13 +35,13 @@ class PiiModifierBatched(DocumentModifier):
     dd = dask.dataframe.from_pandas(dataframe, npartitions=1)
     dataset = DocumentDataset(dd)
 
-    modifier = PiiModifierBatched(
+    modifier = PiiModifier(
         batch_size=2000,
         language='en',
         supported_entities=['PERSON', "EMAIL_ADDRESS"],
         anonymize_action='replace')
 
-    modify = Modify(modifier, batched=True)
+    modify = Modify(modifier)
     modified_dataset = modify(dataset)
     modified_dataset.df.to_json('output_files/*.jsonl', lines=True, orient='records')
 
@@ -65,6 +66,7 @@ class PiiModifierBatched(DocumentModifier):
         self.batch_size = batch_size
         self.device = device
 
+    @batched
     def modify_document(self, text: pd.Series, partition_info: Dict = None):
         import logging
 

--- a/nemo_curator/modules/modify.py
+++ b/nemo_curator/modules/modify.py
@@ -14,16 +14,16 @@
 
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.modifiers import DocumentModifier
+from nemo_curator.utils.module_utils import is_batched
 
 
 class Modify:
-    def __init__(self, modifier: DocumentModifier, text_field="text", batched=False):
+    def __init__(self, modifier: DocumentModifier, text_field="text"):
         self.modifier = modifier
         self.text_field = text_field
-        self.batched = batched
 
     def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
-        if self.batched:
+        if is_batched(self.modifier.modify_document):
             dataset.df[self.text_field] = dataset.df[self.text_field].map_partitions(
                 self.modifier.modify_document, meta=(None, str)
             )

--- a/nemo_curator/modules/task.py
+++ b/nemo_curator/modules/task.py
@@ -51,7 +51,7 @@ class TaskDecontamination:
             tasks = [tasks]
         self.tasks = tasks
         self.text_field = text_field
-        self.max_ngram_size = 13
+        self.max_ngram_size = max_ngram_size
         self.max_matches = max_matches
         self.min_document_length = min_document_length
         self.remove_char_each_side = remove_char_each_side

--- a/nemo_curator/scripts/find_pii_and_deidentify.py
+++ b/nemo_curator/scripts/find_pii_and_deidentify.py
@@ -18,7 +18,7 @@ import time
 from pathlib import Path
 
 from nemo_curator.datasets import DocumentDataset
-from nemo_curator.modifiers.pii_modifier import PiiModifierBatched
+from nemo_curator.modifiers.pii_modifier import PiiModifier
 from nemo_curator.modules.modify import Modify
 
 # from nemo_curator.pii.algorithm import DEFAULT_LANGUAGE
@@ -43,7 +43,7 @@ def main(args):
         args.supported_entities.split(",") if args.supported_entities else None
     )
 
-    modifier = PiiModifierBatched(
+    modifier = PiiModifier(
         language=args.language,
         supported_entities=supported_entities,
         anonymize_action=args.anonymize_action,
@@ -68,7 +68,7 @@ def main(args):
         dataset = DocumentDataset(source_data)
         logging.debug(f"Dataset has {source_data.npartitions} partitions")
 
-        modify = Modify(modifier, batched=True)
+        modify = Modify(modifier)
         modified_dataset = modify(dataset)
         write_to_disk(
             modified_dataset.df,

--- a/nemo_curator/utils/decorators.py
+++ b/nemo_curator/utils/decorators.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def batched(function):
+    """
+    Marks a function as accepting a pandas series of elements instead of a single element
+
+    Args:
+        function: The function that accepts a batch of elements
+    """
+    function.batched = True
+    return function

--- a/nemo_curator/utils/module_utils.py
+++ b/nemo_curator/utils/module_utils.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def is_batched(function):
+    return hasattr(function, "batched") and function.batched

--- a/tutorials/tinystories/main.py
+++ b/tutorials/tinystories/main.py
@@ -25,7 +25,7 @@ from modifiers import QuotationUnifier
 from nemo_curator import ScoreFilter, Sequential
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.filters import RepeatingTopNGramsFilter, WordCountFilter
-from nemo_curator.modifiers.pii_modifier import PiiModifierBatched
+from nemo_curator.modifiers.pii_modifier import PiiModifier
 from nemo_curator.modifiers.unicode_reformatter import UnicodeReformatter
 from nemo_curator.modules import ExactDuplicates
 from nemo_curator.modules.modify import Modify
@@ -128,12 +128,11 @@ def redact_pii(dataset: DocumentDataset) -> DocumentDataset:
         DocumentDataset: The redacted dataset with PII replaced by a generic value.
     """
     redactor = Modify(
-        PiiModifierBatched(
+        PiiModifier(
             supported_entities=["PERSON"],
             anonymize_action="replace",
             device="cpu",
         ),
-        batched=True,
     )
     return redactor(dataset)
 


### PR DESCRIPTION
Refactors batched to be in a decorator. This frees the user from having to be knowledgable about how the underlying `DocumentFilter` or `DocumentModifier` when initializing `ScoreFilter` or `Modify` respectively.

Unit tests pass. The following scripts were manually tested and work properly.

```
examples/classifier_filtering.py
examples/find_pii_and_deidentify.py
nemo_curator/scripts/find_pii_and_deidentify.py
tutorials/tinystories/main.py
```
The examples and other scripts have been manually tested to work.