### PR TITLE
Disable PyTorch Compile Multiprocessing

### DIFF
--- a/nemo_curator/filters/code.py
+++ b/nemo_curator/filters/code.py
@@ -103,9 +103,6 @@ class NumberOfLinesOfCodeFilter(DocumentFilter):
 class TokenizerFertilityFilter(DocumentFilter):
 
     def __init__(self, path_to_tokenizer=None, min_char_to_token_ratio=2.5):
-        import os
-
-        os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
         from nemo.collections.common.tokenizers import SentencePieceTokenizer
 
         if path_to_tokenizer is None:

--- a/nemo_curator/filters/code.py
+++ b/nemo_curator/filters/code.py
@@ -105,7 +105,7 @@ class TokenizerFertilityFilter(DocumentFilter):
     def __init__(self, path_to_tokenizer=None, min_char_to_token_ratio=2.5):
         import os
 
-        os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = 1
+        os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
         from nemo.collections.common.tokenizers import SentencePieceTokenizer
 
         if path_to_tokenizer is None:

--- a/nemo_curator/filters/code.py
+++ b/nemo_curator/filters/code.py
@@ -18,7 +18,6 @@ import warnings
 import numpy as np
 from bs4 import BeautifulSoup
 from comment_parser import comment_parser
-from nemo.collections.common.tokenizers import SentencePieceTokenizer
 
 from nemo_curator.filters.doc_filter import DocumentFilter, import_filter
 from nemo_curator.utils.constants import regex_alpha, regex_alphanum
@@ -104,6 +103,8 @@ class NumberOfLinesOfCodeFilter(DocumentFilter):
 class TokenizerFertilityFilter(DocumentFilter):
 
     def __init__(self, path_to_tokenizer=None, min_char_to_token_ratio=2.5):
+        from nemo.collections.common.tokenizers import SentencePieceTokenizer
+
         if path_to_tokenizer is None:
             raise ValueError(
                 "Must provide a valid path to a SentencePiece " "tokenizer"

--- a/nemo_curator/filters/code.py
+++ b/nemo_curator/filters/code.py
@@ -103,6 +103,9 @@ class NumberOfLinesOfCodeFilter(DocumentFilter):
 class TokenizerFertilityFilter(DocumentFilter):
 
     def __init__(self, path_to_tokenizer=None, min_char_to_token_ratio=2.5):
+        import os
+
+        os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = 1
         from nemo.collections.common.tokenizers import SentencePieceTokenizer
 
         if path_to_tokenizer is None:

--- a/nemo_curator/modules/__init__.py
+++ b/nemo_curator/modules/__init__.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+
+os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
 
 from .add_id import AddId
 from .exact_dedup import ExactDuplicates

--- a/nemo_curator/modules/__init__.py
+++ b/nemo_curator/modules/__init__.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 import os
 
+# Disables multiprocessing in torch.compile calls.
+# Without this, Dasks multiprocessing combined with PyTorch's
+# gives errors like "daemonic processes are not allowed to have children"
+# See https://github.com/NVIDIA/NeMo-Curator/issues/31
 os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
 
 from .add_id import AddId


### PR DESCRIPTION
Addresses #31 by disabling multiprocessing for PyTorch according to advice gathered from [this issue](https://github.com/pytorch/pytorch/issues/123329). Essentially, we need to set `os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"` before PyTorch is imported and [this variable](https://github.com/pytorch/pytorch/blob/main/torch/_inductor/config.py#L397) is initialized. I also moved the nemo import statement to inside of the filter so that any performance impact is minimized (though I observed no speed degradation in my tests).