### PR TITLE
Fix metadata inference with pandas and dask

### DIFF
--- a/nemo_curator/modules/filter.py
+++ b/nemo_curator/modules/filter.py
@@ -11,11 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pandas as pd
+from dask import dataframe as dd
 from dask.typing import no_default
 
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.utils.module_utils import is_batched
+
+
+# Override so that pd.NA is not passed during the metadata inference
+@dd.extensions.make_array_nonempty.register(pd.StringDtype)
+def _(dtype):
+    return pd.array(["a", "b"], dtype=dtype)
 
 
 class Score:

--- a/nemo_curator/modules/filter.py
+++ b/nemo_curator/modules/filter.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pandas as pd
-from dask import dataframe as dd
+from dask.dataframe.extensions import make_array_nonempty
 from dask.typing import no_default
 
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.utils.module_utils import is_batched
 
-
 # Override so that pd.NA is not passed during the metadata inference
-@dd.extensions.make_array_nonempty.register(pd.StringDtype)
-def _(dtype):
-    return pd.array(["a", "b"], dtype=dtype)
+make_array_nonempty.register(
+    pd.StringDtype,
+    lambda x: pd.array(["a", "b"], dtype=x),
+)
 
 
 class Score:

--- a/nemo_curator/modules/task.py
+++ b/nemo_curator/modules/task.py
@@ -302,6 +302,8 @@ class TaskDecontamination:
         return filtered_ngrams
 
     def _remove_ngrams_partition(self, partition, task_ngrams, ngrams_freq_sorted):
+        text_type = partition[self.text_field].dtype
+
         document_fn = partial(
             self._remove_ngrams,
             task_ngrams=task_ngrams,
@@ -318,7 +320,15 @@ class TaskDecontamination:
 
         partition[self.text_field] = split_text
         filtered_partition = partition[valid_documents_mask]
-        return filtered_partition.explode(self.text_field, ignore_index=True)
+        exploded_partition = filtered_partition.explode(
+            self.text_field, ignore_index=True
+        )
+        # After exploding, the string datatype can become an "object" type
+        exploded_partition[self.text_field] = exploded_partition[
+            self.text_field
+        ].astype(text_type)
+
+        return exploded_partition
 
     def _remove_ngrams(self, document, task_ngrams, ngrams_freq_sorted):
         """


### PR DESCRIPTION
Prevents Dask from passing `pd.NA` to the filters for type inference on the scoring and filtering functions. Also fixes some issues with task decontamination working with pandas 2.0 strings and exploding.

With task decontamination, we convert the document text column (dtype=string) to a list of split documents (dtype=object). When calling explode on this column of split documents, the column maintains its object datatype even though now it's only strings. We need to recast the column for newer versions of pandas/dask where string and object are different datatypes.