### PR TITLE
Fix issue #43 (empty files creation) and improve reading/writing speed

### DIFF
--- a/nemo_curator/utils/file_utils.py
+++ b/nemo_curator/utils/file_utils.py
@@ -181,7 +181,7 @@ def parse_str_of_num_bytes(s, return_str=False):
 def _save_jsonl(documents, output_path, start_index=0, max_index=10000, prefix=None):
     """Worker function to write out the data to jsonl files"""
 
-    def _output_json(document):
+    def _encode_text(document):
         return document.strip().encode("utf-8")
 
     def _name(start_index, npad, prefix, i):
@@ -194,7 +194,7 @@ def _save_jsonl(documents, output_path, start_index=0, max_index=10000, prefix=N
 
     output_glob_string = os.path.join(output_path, "*.jsonl")
 
-    output_files = documents.map(_output_json).to_textfiles(
+    output_files = documents.map(_encode_text).to_textfiles(
         output_glob_string,
         name_function=name,
     )

--- a/nemo_curator/utils/file_utils.py
+++ b/nemo_curator/utils/file_utils.py
@@ -182,7 +182,7 @@ def _save_jsonl(documents, output_path, start_index=0, max_index=10000, prefix=N
     """Worker function to write out the data to jsonl files"""
 
     def _output_json(document):
-        return document.strip().encode('utf-8')
+        return document.strip().encode("utf-8")
 
     def _name(start_index, npad, prefix, i):
         tag = str(start_index + i).rjust(npad, "0")
@@ -205,7 +205,10 @@ def _save_jsonl(documents, output_path, start_index=0, max_index=10000, prefix=N
             if os.path.getsize(output_file) == 0:
                 os.remove(output_file)
         except Exception as exception:
-            print(f"An exception occurred when trying to delete {output_file}.\n{exception}", flush=True)
+            print(
+                f"An exception occurred when trying to delete {output_file}.\n{exception}",
+                flush=True,
+            )
 
 
 def reshard_jsonl(

--- a/nemo_curator/utils/file_utils.py
+++ b/nemo_curator/utils/file_utils.py
@@ -222,7 +222,8 @@ def reshard_jsonl(
         output_dir: The output directory where the resharded jsonl files will be written
         output_file_size: Approximate size of output files. Must specify with a string and
             with the unit K, M or G for kilo, mega or gigabytes
-        start_index: Starting index for naming the output files
+        start_index: Starting index for naming the output files. Note: The indices may not
+            be continuous if the sharding process would output an empty file in its place
         file_prefix: Prefix to use to prepend to output file number
     """
 


### PR DESCRIPTION
This commit fixes issue #43 (empty files created when invoking reshard_jsonl method at nemo_curator.utils.file_utils.py) by double-checking the files size after being generated, and deleting them with size zero.

In addition to that, I have noticed there is no need to parse to JSON object the content of the different lines, which should be already in json format. By removing that extra-parsing, there is a significant speed up in the execution of this method.