### PR TITLE
Fix indexing in PII Modifier

### DIFF
--- a/nemo_curator/filters/classifier_filter.py
+++ b/nemo_curator/filters/classifier_filter.py
@@ -37,7 +37,7 @@ class FastTextQualityFilter(DocumentFilter):
         self._name = "fasttext_quality_filter"
 
     @batched
-    def score_document(self, df):
+    def score_document(self, df: pd.Series):
         model_attr = f"{self._name}_{self._model_path}"
         try:
             model = load_object_on_worker(model_attr, self._load_model, {})
@@ -56,7 +56,7 @@ class FastTextQualityFilter(DocumentFilter):
         return df.apply(_score_document)
 
     @batched
-    def keep_document(self, df):
+    def keep_document(self, df: pd.Series):
         return np.random.pareto(self._alpha, size=len(df)) > 1 - df
 
     def _load_model(self):
@@ -82,7 +82,7 @@ class FastTextLangId(DocumentFilter):
         dask.config.set({"dataframe.convert-string": False})
 
     @batched
-    def score_document(self, df):
+    def score_document(self, df: pd.Series):
         model_attr = f"{self._name}_{self._model_path}"
         try:
             model = load_object_on_worker(model_attr, self._load_model, {})

--- a/nemo_curator/modifiers/__init__.py
+++ b/nemo_curator/modifiers/__init__.py
@@ -15,6 +15,7 @@
 from .c4 import BoilerPlateStringModifier
 from .doc_modifier import DocumentModifier
 from .fasttext import FastTextLabelModifier
+from .pii_modifier import PiiModifier
 from .unicode_reformatter import UnicodeReformatter
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "BoilerPlateStringModifier",
     "FastTextLabelModifier",
     "UnicodeReformatter",
+    "PiiModifier",
 ]

--- a/nemo_curator/modifiers/pii_modifier.py
+++ b/nemo_curator/modifiers/pii_modifier.py
@@ -85,8 +85,8 @@ class PiiModifier(DocumentModifier):
             logging.error(
                 f"Encountered error {str(e)} in partition {partition_info['number']}"
             )
-            return pd.Series([True])
-        output: pd.Series = pd.Series(output)
+            return pd.Series([True], index=text.index)
+        output: pd.Series = pd.Series(output, text.index)
         return output
 
     def load_deidentifier(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -282,6 +282,23 @@ class TestFilterModule:
             expected_scores == scores.compute()
         ), f"Expected {expected_scores} but got {scores}"
 
+    def test_chain_filter(self, letter_count_data):
+        letter_count_filter = LetterCountFilter(min_count=4)
+        length_filter = BatchedLengthFilter(min_length=8, max_length=11)
+        filters = Sequential(
+            [
+                ScoreFilter(letter_count_filter, text_field="documents"),
+                ScoreFilter(length_filter, text_field="documents"),
+            ]
+        )
+        filtered_data = filters(letter_count_data)
+
+        expected_indices = [2]
+        expected_data = DocumentDataset(letter_count_data.df.loc[expected_indices])
+        assert all_equal(
+            expected_data, filtered_data
+        ), f"Expected {expected_data} but got {filtered_data}"
+
 
 class TestHeuristicFilters:
     def test_nonalpha(self):

--- a/tests/test_pii_accuracy.py
+++ b/tests/test_pii_accuracy.py
@@ -150,12 +150,14 @@ class BatchedLengthFilter(DocumentFilter):
 
 class TestPIIModule:
     def test_filter_chain(self):
-        pipeline = [
-            nc.ScoreFilter(BatchedLengthFilter(min_length=0, max_length=25)),
-            nc.Modify(
-                PiiModifier(language="en", anonymize_action="mask", device="cpu")
-            ),
-        ]
+        pipeline = nc.Sequential(
+            [
+                nc.ScoreFilter(BatchedLengthFilter(min_length=0, max_length=25)),
+                nc.Modify(
+                    PiiModifier(language="en", anonymize_action="mask", device="cpu")
+                ),
+            ]
+        )
         inputs = [
             "Alice is an engineer",
             "Bob is an engineer",


### PR DESCRIPTION
Fixes an issue reported by @Maghoumi. When the PII Modifier takes in a partition that has been partially filtered, it does not respect the subset of the partition that was given to it. It overrides the index, and the modifications get applied to elements they were not supposed to.