### PR TITLE
Fuzzy Dedup:  Use text_field instead of hardcoded text column

### DIFF
--- a/nemo_curator/__init__.py
+++ b/nemo_curator/__init__.py
@@ -20,4 +20,12 @@ from .modules import *
 # to a string without this option.
 # See https://github.com/NVIDIA/NeMo-Curator/issues/33
 # This also happens when reading and writing to files
-dask.config.set({"dataframe.convert-string": False})
+
+# Disable query planning
+# https://github.com/NVIDIA/NeMo-Curator/issues/73
+dask.config.set(
+    {
+        "dataframe.convert-string": False,
+        "dataframe.query-planning": True,
+    }
+)

--- a/nemo_curator/__init__.py
+++ b/nemo_curator/__init__.py
@@ -26,6 +26,6 @@ from .modules import *
 dask.config.set(
     {
         "dataframe.convert-string": False,
-        "dataframe.query-planning": True,
+        "dataframe.query-planning": False,
     }
 )

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -1207,7 +1207,7 @@ class JaccardSimilarity:
 
     @staticmethod
     def _get_max_num_rows_to_process_once(df, text_field):
-        nbytes = df["text"].str.byte_count().sum()
+        nbytes = df[text_field].str.byte_count().sum()
         # Number of exmploded bytes
         exploded_bytes = nbytes * 5 * 2
         max_chars_allowed = 2_147_483_647


### PR DESCRIPTION
One of the functions in jaccard computation for Fuzzy dedup assume the text field of the dataset to be called `text` and doesn't use the `text_field` information provided. 

Additionally, explicitly set query planning to false.