### PR TITLE
Fix #91 - Incorrect reference to domain_classifier_example.py

### DIFF
--- a/docs/user-guide/DistributedDataClassification.rst
+++ b/docs/user-guide/DistributedDataClassification.rst
@@ -35,7 +35,7 @@ Usage
 NeMo Curator provides a base class ``DistributedDataClassifier`` that can be extended to fit your specfic model.
 The only requirement is that the model can fit on a single GPU.
 We have also provided two subclasses that focus on domain and quality classification.
-Let's see how ``DomainClassifier`` works in a small excerpt taken from ``examples/distributed_data_classification_examples/domain_api_example.py``:
+Let's see how ``DomainClassifier`` works in a small excerpt taken from ``examples/domain_classifier_example.py``:
 
 .. code-block:: python
 


### PR DESCRIPTION
Fix https://github.com/NVIDIA/NeMo-Curator/issues/91

There is a reference to a wrong path/file in this document.

This commit fixes it.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
