### PR TITLE
Allow multiple filenames per partition when separating by metadata

### DIFF
--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -409,10 +409,10 @@ def single_partition_write_with_filename(df, output_file_dir, output_type="jsonl
     assert "filename" in df.columns
 
     if len(df) > 0:
-        empty_partition = True
+        empty_partition = False
     else:
         warnings.warn(f"Empty partition found")
-        empty_partition = False
+        empty_partition = True
 
     if is_cudf_type(df):
         import cudf
@@ -421,34 +421,50 @@ def single_partition_write_with_filename(df, output_file_dir, output_type="jsonl
     else:
         success_ser = pd.Series([empty_partition])
 
-    if empty_partition:
-        filename = df.filename.iloc[0]
-        num_filenames = len(df.filename.unique())
-        if num_filenames > 1:
+    if not empty_partition:
+        filenames = df.filename.unique()
+        filenames = list(filenames.values_host) if is_cudf_type(df) else list(filenames)
+        num_files = len(filenames)
+        if num_files > 1 and output_type != "jsonl":
             raise ValueError(
-                f"More than one filename found in partition: {num_filenames}"
+                f"""
+                Found more than one filename({num_files}) in source partition which is not
+                supported for filetypes other than jsonl.
+                Consider using `files_per_partition=1` during read to ensure a single filename
+                source per partition of data.
+                """
             )
-        filename = Path(filename).stem
-        output_file_path = os.path.join(output_file_dir, filename)
-        if output_type == "jsonl":
-            output_file_path = output_file_path + ".jsonl"
-            if isinstance(df, pd.DataFrame):
-                df.to_json(
-                    output_file_path, orient="records", lines=True, force_ascii=False
-                )
+        for filename in filenames:
+            out_df = df[df.filename == filename] if num_files > 1 else df
+            filename = Path(filename).stem
+            output_file_path = os.path.join(output_file_dir, filename)
+            if output_type == "jsonl":
+                output_file_path = output_file_path + ".jsonl"
+                if isinstance(df, pd.DataFrame):
+                    out_df.to_json(
+                        output_file_path,
+                        orient="records",
+                        lines=True,
+                        force_ascii=False,
+                        mode="a",
+                    )
+                else:
+                    # See open issue here: https://github.com/rapidsai/cudf/issues/15211
+                    # df.to_json(
+                    #     output_file_path, orient="records", lines=True, engine="cudf", force_ascii=False
+                    # )
+                    out_df.to_json(
+                        output_file_path,
+                        orient="records",
+                        lines=True,
+                        force_ascii=False,
+                        mode="a",
+                    )
+            elif output_type == "parquet":
+                output_file_path = output_file_path + ".parquet"
+                out_df.to_parquet(output_file_path)
             else:
-                # See open issue here: https://github.com/rapidsai/cudf/issues/15211
-                # df.to_json(
-                #     output_file_path, orient="records", lines=True, engine="cudf", force_ascii=False
-                # )
-                df.to_json(
-                    output_file_path, orient="records", lines=True, force_ascii=False
-                )
-        elif output_type == "parquet":
-            output_file_path = output_file_path + ".parquet"
-            df.to_parquet(output_file_path)
-        else:
-            raise ValueError(f"Unknown output type: {output_type}")
+                raise ValueError(f"Unknown output type: {output_type}")
 
     return success_ser
 

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -425,15 +425,6 @@ def single_partition_write_with_filename(df, output_file_dir, output_type="jsonl
         filenames = df.filename.unique()
         filenames = list(filenames.values_host) if is_cudf_type(df) else list(filenames)
         num_files = len(filenames)
-        if num_files > 1 and output_type != "jsonl":
-            raise ValueError(
-                f"""
-                Found more than one filename({num_files}) in source partition which is not
-                supported for filetypes other than jsonl.
-                Consider using `files_per_partition=1` during read to ensure a single filename
-                source per partition of data.
-                """
-            )
         for filename in filenames:
             out_df = df[df.filename == filename] if num_files > 1 else df
             filename = Path(filename).stem
@@ -446,7 +437,6 @@ def single_partition_write_with_filename(df, output_file_dir, output_type="jsonl
                         orient="records",
                         lines=True,
                         force_ascii=False,
-                        mode="a",
                     )
                 else:
                     # See open issue here: https://github.com/rapidsai/cudf/issues/15211
@@ -458,7 +448,6 @@ def single_partition_write_with_filename(df, output_file_dir, output_type="jsonl
                         orient="records",
                         lines=True,
                         force_ascii=False,
-                        mode="a",
                     )
             elif output_type == "parquet":
                 output_file_path = output_file_path + ".parquet"

--- a/tests/test_seperate_by_metadata.py
+++ b/tests/test_seperate_by_metadata.py
@@ -1,0 +1,78 @@
+import os
+
+import pandas as pd
+import pytest
+from dask import dataframe as dd
+from dask.dataframe.utils import assert_eq
+
+from nemo_curator.datasets import DocumentDataset
+from nemo_curator.utils.distributed_utils import write_to_disk
+from nemo_curator.utils.file_utils import separate_by_metadata
+
+
+@pytest.fixture
+def tmp_path_w_data(tmp_path):
+    def _write_data(num_files):
+        out_path = tmp_path / "jsonl"
+        df = pd.DataFrame(
+            {
+                "id": [1, 2, 300, 4, -1],
+                "text": ["abc", "aba", "abb", "aba", "abc"],
+                "metadata": ["doc", "code", "test", "code", "doc"],
+            }
+        )
+        dfs = []
+        for i in range(num_files):
+            partition = df.copy()
+            partition["filename"] = f"f{i}.jsonl"
+            dfs.append(partition)
+
+        df = dd.concat(dfs)
+        write_to_disk(
+            df=df,
+            output_file_dir=str(out_path),
+            write_to_filename=True,
+            output_type="jsonl",
+        )
+        return out_path
+
+    return _write_data
+
+
+@pytest.mark.parametrize(
+    "backend", ["pandas", pytest.param("cudf", marks=pytest.mark.gpu)]
+)
+class TestMetadataSep:
+
+    @pytest.mark.parametrize("files_per_partition", [1, 3])
+    def test_metadatasep(self, tmp_path_w_data, files_per_partition, backend):
+        data_dir = tmp_path_w_data(5)
+        output_dir = data_dir / "metadata_sep"
+        df = DocumentDataset.read_json(
+            str(data_dir),
+            backend=backend,
+            files_per_partition=files_per_partition,
+            add_filename=True,
+        ).df
+        separate_by_metadata(
+            df=df,
+            output_dir=str(output_dir),
+            metadata_field="metadata",
+            output_type="jsonl",
+        ).compute()
+
+        found_metadata = set(os.listdir(output_dir))
+        expected_metadata = {"code", "doc", "test"}
+        assert found_metadata == expected_metadata
+
+        dfs = []
+        for metadata in expected_metadata:
+            meta_df = DocumentDataset.read_json(
+                str(output_dir / metadata),
+                backend=backend,
+                files_per_partition=1,
+                add_filename=True,
+            ).df
+            dfs.append(meta_df)
+        got_df = dd.concat(dfs)
+        assert_eq(got_df, df, check_index=False)


### PR DESCRIPTION
## Description
Closes #89 
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Adds an option to handle scenarios where there are multiple filenames in a single partition when writing with filename. 
This is typically true when files are read in with `files_per_partition` > 1.

## Usage
<!-- Potentially add a usage example below -->
```python
dataset = DocumentDataset.read_json(path, files_per_partition=5, include_filename=True)
write_to_disk(dataset.df, output_file_dir=path, write_to_filename=True)
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
