### PR TITLE
Stricter check for query planning.

### DIFF
--- a/examples/fuzzy_deduplication.py
+++ b/examples/fuzzy_deduplication.py
@@ -16,7 +16,6 @@ import argparse
 import time
 
 import dask
-from dask import dataframe as dd
 
 from nemo_curator import FuzzyDuplicates, FuzzyDuplicatesConfig
 from nemo_curator.datasets import DocumentDataset
@@ -49,6 +48,8 @@ def main(args):
 
         t0 = time.time()
         if filetype == "parquet":
+            from dask import dataframe as dd
+
             input_dataset = DocumentDataset(
                 dd.read_parquet(
                     dataset_dir,

--- a/examples/slurm/start-slurm.sh
+++ b/examples/slurm/start-slurm.sh
@@ -67,6 +67,7 @@ export CUDF_SPILL="1"
 export RMM_SCHEDULER_POOL_SIZE="1GB"
 export RMM_WORKER_POOL_SIZE="72GiB"
 export LIBCUDF_CUFILE_POLICY=OFF
+export DASK_DATAFRAME__QUERY_PLANNING=False
 
 
 # =================================================================

--- a/nemo_curator/__init__.py
+++ b/nemo_curator/__init__.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import dask
 
 # Disable query planning if possible
 # https://github.com/NVIDIA/NeMo-Curator/issues/73
-QUERY_PLANNING = dask.config.get("dataframe.query-planning")
-if QUERY_PLANNING is True or QUERY_PLANNING is None:
+if dask.config.get("dataframe.query-planning") is True or "dask-expr" in sys.modules:
     raise NotImplementedError(
         """
         NeMo Curator does not support query planning yet.

--- a/nemo_curator/__init__.py
+++ b/nemo_curator/__init__.py
@@ -18,7 +18,7 @@ import dask
 
 # Disable query planning if possible
 # https://github.com/NVIDIA/NeMo-Curator/issues/73
-if dask.config.get("dataframe.query-planning") is True or "dask-expr" in sys.modules:
+if dask.config.get("dataframe.query-planning") is True or "dask_expr" in sys.modules:
     raise NotImplementedError(
         """
         NeMo Curator does not support query planning yet.

--- a/nemo_curator/__init__.py
+++ b/nemo_curator/__init__.py
@@ -16,11 +16,17 @@ import dask
 
 # Disable query planning if possible
 # https://github.com/NVIDIA/NeMo-Curator/issues/73
-if dask.config.get("dataframe.query-planning") is True:
+QUERY_PLANNING = dask.config.get("dataframe.query-planning")
+if QUERY_PLANNING is True or QUERY_PLANNING is None:
     raise NotImplementedError(
-        "NeMo Curator does not support query planning yet. "
-        "Please disable query planning before importing "
-        "`nemo_curator`, `dask.dataframe` or `dask_cudf`."
+        """
+        NeMo Curator does not support query planning yet.
+        Please disable query planning before importing
+        `dask.dataframe` or `dask_cudf`. This can be done via:
+        `export DASK_DATAFRAME__QUERY_PLANNING=False`, or
+        importing `dask.dataframe/dask_cudf` after importing
+        `nemo_curator`.
+        """
     )
 else:
     dask.config.set({"dataframe.query-planning": False})

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,7 +18,7 @@ import dask
 
 # Disable query planning if possible
 # https://github.com/NVIDIA/NeMo-Curator/issues/73
-if dask.config.get("dataframe.query-planning") is True or "dask-expr" in sys.modules:
+if dask.config.get("dataframe.query-planning") is True or "dask_expr" in sys.modules:
     raise NotImplementedError(
         """
         NeMo Curator does not support query planning yet.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,11 +16,17 @@ import dask
 
 # Disable query planning before any tests are loaded
 # https://github.com/NVIDIA/NeMo-Curator/issues/73
-if dask.config.get("dataframe.query-planning") is True:
+QUERY_PLANNING = dask.config.get("dataframe.query-planning")
+if QUERY_PLANNING is True or QUERY_PLANNING is None:
     raise NotImplementedError(
-        "NeMo Curator does not support query planning yet. "
-        "Please disable query planning before importing "
-        "`nemo_curator`, `dask.dataframe` or `dask_cudf`."
+        """
+        NeMo Curator does not support query planning yet.
+        Please disable query planning before importing
+        `dask.dataframe` or `dask_cudf`. This can be done via:
+        `export DASK_DATAFRAME__QUERY_PLANNING=False`, or
+        importing `dask.dataframe/dask_cudf` after importing
+        `nemo_curator`.
+        """
     )
 else:
     dask.config.set({"dataframe.query-planning": False})

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import dask
 
-# Disable query planning before any tests are loaded
+# Disable query planning if possible
 # https://github.com/NVIDIA/NeMo-Curator/issues/73
-QUERY_PLANNING = dask.config.get("dataframe.query-planning")
-if QUERY_PLANNING is True or QUERY_PLANNING is None:
+if dask.config.get("dataframe.query-planning") is True or "dask-expr" in sys.modules:
     raise NotImplementedError(
         """
         NeMo Curator does not support query planning yet.


### PR DESCRIPTION
## Description
Importing newer versions of dask (tested with 2024.5) set `dataframe.query-planning` to None instead of `True` or `False`, but the `None` case defaults to using query planning. This PR extends the check to `None` to raise relevant errors w/ newer versions of dask.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
N/A
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
