### PR TITLE
Shuffle CC result on group before writing out

### DIFF
--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -1296,6 +1296,8 @@ class ConnectedComponents:
 
         assert num_nodes == len(labels_df)
         print(f"assert num_nodes:{num_nodes}==labels_df:{len(labels_df)} passed")
+        # Ensure all docs in the same group are in the same partition
+        labels_df = labels_df.shuffle(on=["group"], ignore_index=True)
         labels_df.to_parquet(output_path, write_index=False)
         Comms.destroy()
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
This PR shuffles the `connected_components` output by group to ensure that all documents belonging to the same duplicate group/component end up in the same partition. The motivation for doing this ensure the example showcasing document removal work as intended: https://github.com/NVIDIA/NeMo-Curator/blob/main/examples/fuzzy_deduplication.py#L87.

## Usage
N/A
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
