### PR TITLE
Fix nemo_curator import in CPU only environment when GPU packages are installed.

### DIFF
--- a/nemo_curator/utils/gpu_utils.py
+++ b/nemo_curator/utils/gpu_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GPU_INSTALL_STRING = """Install GPU packages via `pip install --extra-index-url https://pypi.nvidia.com nemo_curator[cuda12x]`
+GPU_INSTALL_STRING = """Install GPU packages via `pip install --extra-index-url https://pypi.nvidia.com nemo-curator[cuda12x]`
 or use `pip install --extra-index-url https://pypi.nvidia.com ".[cuda12x]"` if installing from source"""
 
 

--- a/nemo_curator/utils/import_utils.py
+++ b/nemo_curator/utils/import_utils.py
@@ -237,7 +237,7 @@ def safe_import(module, *, msg=None, alt=None):
     """A function used to import modules that may not be available
 
     This function will attempt to import a module with the given name, but it
-    will not throw an ModuleNotFoundError if the module is not found. Instead, it will
+    will not throw an ImportError if the module is not found. Instead, it will
     return a placeholder object which will raise an exception only if used.
 
     Parameters
@@ -259,7 +259,7 @@ def safe_import(module, *, msg=None, alt=None):
     """
     try:
         return importlib.import_module(module)
-    except ModuleNotFoundError:
+    except ImportError:
         exception_text = traceback.format_exc()
         logger.debug(f"Import of {module} failed with: {exception_text}")
     except Exception:
@@ -303,7 +303,7 @@ def safe_import_from(module, symbol, *, msg=None, alt=None):
     try:
         imported_module = importlib.import_module(module)
         return getattr(imported_module, symbol)
-    except ModuleNotFoundError:
+    except ImportError:
         exception_text = traceback.format_exc()
         logger.debug(f"Import of {module} failed with: {exception_text}")
     except AttributeError:
@@ -346,7 +346,7 @@ def gpu_only_import(module, *, alt=None):
 
     return safe_import(
         module,
-        msg=f"{module} is not installed in non GPU-enabled installations. {GPU_INSTALL_STRING}",
+        msg=f"{module} is not enabled in non GPU-enabled installations or environemnts. {GPU_INSTALL_STRING}",
         alt=alt,
     )
 
@@ -379,6 +379,6 @@ def gpu_only_import_from(module, symbol, *, alt=None):
     return safe_import_from(
         module,
         symbol,
-        msg=f"{module}.{symbol} is not installed in non GPU-enabled installations. {GPU_INSTALL_STRING}",
+        msg=f"{module}.{symbol} is not enabled in non GPU-enabled installations or environments. {GPU_INSTALL_STRING}",
         alt=alt,
     )


### PR DESCRIPTION
Fixes #109 

## Description
#27 Added support for installing a CPU only build of nemo_curator that works in cpu environments. However it didn't account for the case where the GPU version of curator was installed but the package was being used in CPU only environments. 

One case this happens is when using the NeMo-FW container in CPU only environments. This pr extends the safe_import mechanism to fail on `importError` instead of `ModuleNotFoundError` for cases where the module was present but import failed due to missing GPUs.

One downside to this approach is that there's an implicit assumption that the importError on GPU packages stem from a missing GPU environment or missing packages, so we may wrongly classify other issues on import of these packages into the same bucket.

## Usage
<!-- Potentially add a usage example below -->
```bash
pip install nemo-curator[cuda12x]
```
```python
import nemo_curator # in a cpu only environment passes

nemo_curator.FuzzyDuplicates() # raises relevant error message to be present in GPU environments.
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
