### PR TITLE
Skip explicit comms shuffle for dask-cuda 24.06

### DIFF
--- a/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
+++ b/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
@@ -25,7 +25,10 @@ from nemo_curator.utils.fuzzy_dedup_utils.output_map_utils import (
     get_agg_text_bytes_df,
 )
 
-USE_EXCOMMS = Version(dask_cuda.__version__) >= Version("23.10")
+dask_cuda_version = Version(dask_cuda.__version__)
+USE_EXCOMMS = (
+    dask_cuda_version >= Version("23.10") and dask_cuda_version < Version("24.06")
+) or dask_cuda_version >= Version("24.08")
 
 
 def write_partitioned_file(df, output_path, partition_on, batch_id):


### PR DESCRIPTION
## Description
dask-cuda 24.06 + explicit comms leads to incorrect results in some cases as mentioned in #134 and will be fixed via https://github.com/rapidsai/dask-cuda/pull/1356.

This disables going via explicit comms shuffle with dask-cuda 24.06 to avoid potentially incorrect results.

## Usage
N/A
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
