### PR TITLE
Fix a few bugs in fuzzy dedup and docs

### DIFF
--- a/docs/user-guide/gpudeduplication.rst
+++ b/docs/user-guide/gpudeduplication.rst
@@ -154,7 +154,7 @@ steps (all scripts are included in the :code:`nemo_curator/scripts/` subdirector
 
                  # same as `python connected_components.py`
                  gpu_connected_component \
-                   --jaccard-pairs_path /path/to/dedup_output/jaccard_similarity_results.parquet \
+                   --jaccard-pairs-path /path/to/dedup_output/jaccard_similarity_results.parquet \
                    --output-dir /path/to/dedup_output \
                    --cache-dir /path/to/cc_cache \
                    --jaccard-threshold 0.8

--- a/nemo_curator/scripts/fuzzy_deduplication/connected_components.py
+++ b/nemo_curator/scripts/fuzzy_deduplication/connected_components.py
@@ -68,7 +68,7 @@ def attach_args(parser=None):
     )
     parser.add_argument(
         "--jaccard-threshold",
-        type=int,
+        type=float,
         default=0.8,
         help="Jaccard threshold below which we don't consider documents"
         " to be duplicate",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Fixes a few things I found while testing the dedup scripts recently.
- The arg for jaccard similarity threshold doesn't work if you specify a floating point number, since its type is int. You get this error:
  ```
  Computes connected component: error: argument --jaccard-threshold: invalid int value: '0.8'
  ```
- The docs have the arg for `--jaccard-pairs-path` misspelled to `--jaccard-pairs_path`
## Usage
<!-- Potentially add a usage example below -->
N/A
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
