### PR TITLE
Fix #161. Remove duplicated assigments in GeneralCommentToCodeFilter

### DIFF
--- a/nemo_curator/filters/code.py
+++ b/nemo_curator/filters/code.py
@@ -62,8 +62,8 @@ class GeneralCommentToCodeFilter(DocumentFilter):
           language: Mime string of language
         """
         self._lang = language
-        self._min_threshold = min_comment_to_code_ratio = min_comment_to_code_ratio
-        self._max_threshold = max_comment_to_code_ratio = max_comment_to_code_ratio
+        self._min_threshold = min_comment_to_code_ratio
+        self._max_threshold = max_comment_to_code_ratio
 
         self._name = "comment_ratio"
 


### PR DESCRIPTION
While reading about code filters, I have noticed a couple of duplicated assignments in the code.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
