### PR TITLE
[Tutorials] Reduce the cluster size for the SGD + PEFT notebook

### DIFF
--- a/tutorials/peft-curation-with-sdg/config/sem_dedup_config.yaml
+++ b/tutorials/peft-curation-with-sdg/config/sem_dedup_config.yaml
@@ -13,7 +13,7 @@ embedding_max_mem_gb: 20
 
 # Clustering configuration
 clustering_save_loc: "clustering_results"
-n_clusters: 1000
+n_clusters: 20
 seed: 1234
 max_iter: 100
 kmeans_with_cos_dist: false

--- a/tutorials/peft-curation-with-sdg/main.py
+++ b/tutorials/peft-curation-with-sdg/main.py
@@ -345,7 +345,7 @@ def main():
     parser.add_argument(
         "--synth-gen-ratio",
         type=float,
-        default=0.01,
+        default=0.005,  # Use 0.5% of the real data for synthetic data generation to keep LLM calls low.
         help="The ratio of synthetic data to real data to generate. Synthetic data generation will be skipped if the value is 0.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Description
Reduce the ratio of synthetic samples to lower API calls.
Reduce the cluster size for Sem Dedupe.

- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
