### PR TITLE
Fix 177. Improve score_document and _line_statistics performance

### DIFF
--- a/nemo_curator/filters/code.py
+++ b/nemo_curator/filters/code.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import csv
+import statistics
 import warnings
 
-import numpy as np
 from bs4 import BeautifulSoup
 from comment_parser import comment_parser
 
@@ -94,7 +94,7 @@ class NumberOfLinesOfCodeFilter(DocumentFilter):
         self._name = "num_lines"
 
     def score_document(self, source):
-        return len(source.split("\n"))
+        return source.count("\n") + 1
 
     def keep_document(self, score):
         return self._min_lines <= score <= self._max_lines
@@ -263,7 +263,7 @@ class PerExtensionFilter(DocumentFilter):
     def _line_statistics(self, source):
         lengths = [len(x) for x in source.split("\n")]
         max_length = max(lengths)
-        mean_length = np.mean(lengths)
+        mean_length = statistics.fmean(lengths)
 
         return max_length, mean_length
 


### PR DESCRIPTION
Hi!

I have noticed a couple of small changes in the code that can improve its performance:

By refactoring score_document as suggested, it will run between 2x and 3x faster, and will reduce by half the memory footprint.

By refactoring '_line_statistics' as suggested, it can run about 21% faster.

Hope it helps!

Regards,
Miguel