### PR TITLE
Add option to skip false positive checks during Fuzzy Deduplication

### DIFF
--- a/nemo_curator/modules/__init__.py
+++ b/nemo_curator/modules/__init__.py
@@ -36,6 +36,9 @@ MinHash = gpu_only_import_from("nemo_curator.modules.fuzzy_dedup", "MinHash")
 FuzzyDuplicates = gpu_only_import_from(
     "nemo_curator.modules.fuzzy_dedup", "FuzzyDuplicates"
 )
+BucketsToEdges = gpu_only_import_from(
+    "nemo_curator.modules.fuzzy_dedup", "BucketsToEdges"
+)
 # Pytorch related imports must come after all imports that require cugraph,
 # because of context cleanup issues b/w pytorch and cugraph
 # See this issue: https://github.com/rapidsai/cugraph/issues/2718
@@ -55,6 +58,7 @@ __all__ = [
     "Filter",
     "FuzzyDuplicatesConfig",
     "FuzzyDuplicates",
+    "BucketsToEdges",
     "LSH",
     "MinHash",
     "Modify",

--- a/nemo_curator/modules/config.py
+++ b/nemo_curator/modules/config.py
@@ -84,9 +84,15 @@ class FuzzyDuplicatesConfig(BaseConfig):
             raise ValueError(
                 "Finding fuzzy duplicates requires a cache directory accessible via all workers to store intermediates"
             )
-        if not self.false_positive_check:
-            raise NotImplementedError(
-                "Skipping false positive checks is not supported at the moment"
+        if self.false_positive_check:
+            warnings.warn(
+                "Identifying false positives during the Minhash deduplication is computationally expensive."
+                " For improved performance consider setting this to False"
+            )
+        if not self.false_positive_check and self.char_ngrams < 20:
+            warnings.warn(
+                "Using a small char_ngrams value might lead to a large number of false positives during deduplication."
+                " Using a value for char_ngrams atleast 20 is recommended."
             )
         if self.num_anchors <= 0:
             raise ValueError("Number of anchors must be greater than 0")

--- a/nemo_curator/modules/config.py
+++ b/nemo_curator/modules/config.py
@@ -91,7 +91,7 @@ class FuzzyDuplicatesConfig(BaseConfig):
             )
         if not self.false_positive_check and self.char_ngrams < 20:
             warnings.warn(
-                "Using a small char_ngrams value might lead to a large number of false positives during deduplication."
+                "Using a small char_ngrams value might lead to a large number (~5%) of false positives during deduplication."
                 " Using a value for char_ngrams atleast 20 is recommended."
             )
         if self.num_anchors <= 0:

--- a/nemo_curator/modules/config.py
+++ b/nemo_curator/modules/config.py
@@ -92,7 +92,7 @@ class FuzzyDuplicatesConfig(BaseConfig):
         if not self.false_positive_check and self.char_ngrams < 20:
             warnings.warn(
                 "Using a small char_ngrams value might lead to a large number (~5%) of false positives during deduplication."
-                " Using a value for char_ngrams atleast 20 is recommended."
+                " Using a value of at least 20 for char_ngrams is recommended."
             )
         if self.num_anchors <= 0:
             raise ValueError("Number of anchors must be greater than 0")

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -611,8 +611,8 @@ class BucketsToEdges:
 
     @staticmethod
     def _combine_multiple_ids(
-        input_df: dask_cudf.DataFrame, input_id_fields: list, output_id_field: str
-    ) -> dask_cudf.DataFrame:
+        input_df: cudf.DataFrame, input_id_fields: list, output_id_field: str
+    ) -> cudf.DataFrame:
         if output_id_field in input_df.columns:
             raise ValueError(
                 f"Input df already contains column named: {output_id_field}"
@@ -633,7 +633,7 @@ class BucketsToEdges:
     def buckets_to_edges(
         self,
         buckets_df: cudf.DataFrame,
-    ) -> dask_cudf.DataFrame:
+    ) -> cudf.DataFrame:
 
         grouped_buckets = (
             buckets_df.groupby(self.bucket_field)[self.str_id_name]

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -499,7 +499,7 @@ class FuzzyDuplicates:
 
         if self.config.false_positive_check:
             # Map buckets to lower cardinality distribution
-            print(f"Stage{stage_num} (False Postive Check): Starting Map_Buckets")
+            print(f"Stage{stage_num} (False Positive Check): Starting Map_Buckets")
             ddf_mapped_buckets_w_anchors = self.map_buckets.map_buckets_with_anchors(
                 documents_df=dataset.df, buckets_df=buckets_df.df
             )
@@ -556,10 +556,10 @@ class FuzzyDuplicates:
             stage_num += 1
 
         # Connected components across buckets
-        print("Stage{stage_num}: Connected Components across buckets")
+        print(f"Stage{stage_num}: Connected Components across buckets")
         cc_path = os.path.join(self.config.cache_dir, "connected_components.parquet")
         self.connected_components.cc_workflow(cc_path)
-        print("Stage{stage_num}: Connected Components across buckets complete!")
+        print(f"Stage{stage_num}: Connected Components across buckets complete!")
         stage_num += 1
 
         return DocumentDataset(dask_cudf.read_parquet(cc_path, split_row_groups=False))

--- a/nemo_curator/scripts/fuzzy_deduplication/buckets_to_edges.py
+++ b/nemo_curator/scripts/fuzzy_deduplication/buckets_to_edges.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+
+import dask_cudf
+
+from nemo_curator import BucketsToEdges
+from nemo_curator.datasets import DocumentDataset
+from nemo_curator.log import create_logger
+from nemo_curator.utils.distributed_utils import get_client, get_num_workers
+from nemo_curator.utils.script_utils import ArgumentHelper
+
+
+def attach_args(parser=None):
+    description = """Takes the buckets generated from minhashes and converts
+    them into an edge list for the connected components algorithm. This is done by
+    assuming all documents in the same bucket are similar.
+    """
+    if not parser:
+        parser = ArgumentHelper.parse_gpu_dedup_args(description=description)
+    parser.add_argument(
+        "--input-bucket-dir",
+        type=str,
+        help="The directory containing anchor docs with bk files",
+    )
+    parser.add_argument(
+        "--input-bucket-field",
+        type=str,
+        default="_bucket_id",
+        help="Name of the column containing the bucket id",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        help="Output dir to write results",
+    )
+    return parser
+
+
+def main(args):
+    logger = create_logger(
+        rank=0,
+        log_file=os.path.join(args.log_dir, "rank_000.log"),
+        name="buckets_to_cc_log",
+    )
+
+    input_bucket_path = args.input_bucket_dir
+    OUTPUT_PATH = args.output_dir
+
+    client = get_client(**ArgumentHelper.parse_client_args(args))
+    logger.info(f"Client Created {client}")
+    logger.info(f"Num Workers = {get_num_workers(client)}")
+    logger.info(
+        "Running buckets -> EdgeList for CC",
+    )
+
+    buckets_to_edges = BucketsToEdges(
+        cache_dir=OUTPUT_PATH,
+        id_fields=["dataset_id", "doc_id"],
+        str_id_name=args.input_json_id_field,
+        bucket_field=args.input_bucket_field,
+        logger=logger,
+    )
+    st = time.time()
+    buckets_df = DocumentDataset(
+        dask_cudf.read_parquet(input_bucket_path, split_row_groups=False)
+    )
+    _ = buckets_to_edges(buckets_df)
+    et = time.time()
+    logger.info(f"Bucket to Edges conversion took = {et-st} s")
+
+
+def console_script():
+    main(attach_args().parse_args())
+
+
+if __name__ == "__main__":
+    main(attach_args().parse_args())

--- a/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
+++ b/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
@@ -66,7 +66,7 @@ def rearange_by_column_direct(
         return rearrange_by_column(
             df,
             col=col,
-            shuffle="tasks",
+            shuffle_method="tasks",
             # Prevent staged shuffling by setting max_branch
             # to the number of input partitions + 1
             max_branch=npartitions + 1,

--- a/tests/test_fuzzy_dedup.py
+++ b/tests/test_fuzzy_dedup.py
@@ -257,7 +257,7 @@ class TestFuzzyDuplicates:
         result_df = result.df.compute()
         # Drop non duplicated docs
         result_df = result_df[result_df.group.duplicated(keep=False)]
-        result_df = result_df.groupby("group").id.collect()
+        result_df = result_df.groupby("group").id.agg(list)
         # Sort to maintain uniform ordering
 
         result_df = result_df.list.sort_values()
@@ -372,6 +372,47 @@ class TestFuzzyDuplicates:
         ).columns
         assert all(f"anchor_{i}_id" in anchor_docs_df_cols for i in range(num_anchors))
 
+    @pytest.mark.parametrize("use_64_bit_hash", [False, True])
+    @pytest.mark.parametrize(
+        "num_buckets,duplicate_docs",
+        # Duplcated docs estimated from true_jaccard values
+        [
+            (10, [[4, -1], [1, 2, 300]]),
+            (3, [[4, -1], [1, 2, 300]]),
+        ],
+    )
+    def test_no_fp_check(
+        self, fuzzy_dedup_data, use_64_bit_hash, num_buckets, duplicate_docs, tmpdir
+    ):
+        config = FuzzyDuplicatesConfig(
+            cache_dir=tmpdir,
+            id_field="id",
+            text_field="text",
+            seed=42,
+            char_ngrams=5,
+            num_buckets=num_buckets,
+            hashes_per_bucket=1,
+            use_64_bit_hash=use_64_bit_hash,
+            buckets_per_shuffle=5,
+            false_positive_check=False,
+            num_anchors=2,
+            jaccard_threshold=0.39,
+        )
+        fuzzy_duplicates = FuzzyDuplicates(config=config)
+        result = fuzzy_duplicates(fuzzy_dedup_data)
+        result_df = result.df.compute()
+        # Drop non duplicated docs
+        result_df = result_df[result_df.group.duplicated(keep=False)]
+        result_df = result_df.groupby("group").id.collect()
+        # Sort to maintain uniform ordering
+
+        result_df = result_df.list.sort_values()
+        result_df = result_df.sort_values()
+        expected_df = cudf.Series(duplicate_docs, name="id")
+        expected_df = expected_df.list.sort_values()
+        expected_df = expected_df.sort_values()
+        assert_eq(expected_df, result_df, check_index=False)
+
 
 class TestFuzzyDuplicatesConfig:
     def test_bad_inputs(self, tmpdir):
@@ -381,10 +422,19 @@ class TestFuzzyDuplicatesConfig:
             UserWarning, match="Using a higher number of anchor docs might"
         ):
             FuzzyDuplicatesConfig(cache_dir=tmpdir, num_anchors=3)
+        with pytest.warns(
+            UserWarning, match="Using a small char_ngrams value might lead"
+        ):
+            FuzzyDuplicatesConfig(
+                cache_dir=tmpdir, char_ngrams=10, false_positive_check=False
+            )
+        with pytest.warns(
+            UserWarning,
+            match="Identifying false positives during the Minhash deduplication is computationally expensive",
+        ):
+            FuzzyDuplicatesConfig(cache_dir=tmpdir, false_positive_check=True)
         with pytest.raises(ValueError):
             FuzzyDuplicatesConfig(cache_dir=tmpdir, jaccard_threshold=1.2)
-        with pytest.raises(NotImplementedError):
-            FuzzyDuplicatesConfig(cache_dir=tmpdir, false_positive_check=False)
         with pytest.raises(ValueError):
             FuzzyDuplicatesConfig(cache_dir=tmpdir, buckets_per_shuffle=0)
 
@@ -393,8 +443,9 @@ class TestFuzzyDuplicatesConfig:
             "cache_dir": "./",
             "num_anchors": 2,
             "jaccard_threshold": 0.8,
-            "false_positive_check": True,
+            "false_positive_check": False,
             "buckets_per_shuffle": 1,
+            "char_ngrams": 20,
         }
         with open(tmpdir / "config.yaml", "w") as f:
             yaml.dump(yaml_params, f)

--- a/tests/test_fuzzy_dedup.py
+++ b/tests/test_fuzzy_dedup.py
@@ -182,7 +182,7 @@ class TestLSH:
         )
         buckets = lsh(self.dataset)
         buckets_df = buckets.df
-        docs_list = buckets_df.groupby("_bucket_id").id.collect()
+        docs_list = buckets_df.groupby("_bucket_id").id.agg(list)
         expected_df = cudf.Series([[1, 2], [2, 3], [4, 5]], name="id")
         assert_eq(expected_df, docs_list, check_index=False)
 
@@ -287,7 +287,7 @@ class TestFuzzyDuplicates:
         result_df = result.df.compute()
         # Drop non duplicated docs
         result_df = result_df[result_df.group.duplicated(keep=False)]
-        result_df = result_df.groupby("group")["col0"].collect()
+        result_df = result_df.groupby("group")["col0"].agg(list)
         # Sort to maintain uniform ordering
         result_df = result_df.list.sort_values()
         result_df = result_df.sort_values()
@@ -339,7 +339,7 @@ class TestFuzzyDuplicates:
         result_df = result.df.compute()
         # Drop non duplicated docs
         result_df = result_df[result_df.group.duplicated(keep=False)]
-        result_df = result_df.groupby("group").id.collect()
+        result_df = result_df.groupby("group").id.agg(list)
         # Sort to maintain uniform ordering
 
         result_df = result_df.list.sort_values()
@@ -403,7 +403,7 @@ class TestFuzzyDuplicates:
         result_df = result.df.compute()
         # Drop non duplicated docs
         result_df = result_df[result_df.group.duplicated(keep=False)]
-        result_df = result_df.groupby("group").id.collect()
+        result_df = result_df.groupby("group").id.agg(list)
         # Sort to maintain uniform ordering
 
         result_df = result_df.list.sort_values()

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -49,11 +49,7 @@ def dedup_data():
 
 
 @pytest.mark.gpu
-<<<<<<< HEAD
 class TestSemDuplicates:
-=======
-class TestSemanticDuplicates:
->>>>>>> 48fbd19 (update semdedup test class name)
     @pytest.fixture(autouse=True, scope="class")
     def gpu_client(self, request):
         with LocalCUDACluster(n_workers=1) as cluster, Client(cluster) as client:

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -49,7 +49,11 @@ def dedup_data():
 
 
 @pytest.mark.gpu
+<<<<<<< HEAD
 class TestSemDuplicates:
+=======
+class TestSemanticDuplicates:
+>>>>>>> 48fbd19 (update semdedup test class name)
     @pytest.fixture(autouse=True, scope="class")
     def gpu_client(self, request):
         with LocalCUDACluster(n_workers=1) as cluster, Client(cluster) as client:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
The existing Minhash based Fuzzy Dedup algo has a computationally expensive false positive check comprising of the `map_buckets`, `jaccard_shuffle` & `jaccard_compute` stages.

This PR aims to allow an alternative codepath allowing skipping these computationally expensive operations and directly going from LSH buckets to graph creation, allowing significant perf gains at the cost of ~1-2% tokens depending on the chose initial config and dataset.

TODO:
Add perf results

<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
fuzzy_dup_config = FuzzyDuplicatesConfig(false_positive_check=False)
...
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes (Will be handled in a followup)
