### PR TITLE
Bump min Rapids versions to 24.8

### DIFF
--- a/examples/slurm/container-entrypoint.sh
+++ b/examples/slurm/container-entrypoint.sh
@@ -57,6 +57,7 @@ if [[ $DEVICE == 'gpu' ]]; then
     --scheduler-file $SCHEDULER_FILE \
     --rmm-pool-size $RMM_WORKER_POOL_SIZE \
     --interface $INTERFACE \
+    --enable-cudf-spill \
     --rmm-async >> $WORKER_LOG 2>&1 &
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -72,11 +72,11 @@ setup(
     ],
     extras_require={
         "cuda12x": [
-            "cudf-cu12>=24.2",
-            "dask-cudf-cu12>=24.2",
-            "cuml-cu12>=24.2",
-            "cugraph-cu12>=24.2",
-            "dask-cuda>=24.2",
+            "cudf-cu12>=24.8",
+            "dask-cudf-cu12>=24.8",
+            "cuml-cu12>=24.8",
+            "cugraph-cu12>=24.8",
+            "dask-cuda>=24.8",
             "spacy[cuda12x]>=3.6.0, <4.0.0",
         ],
     },


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
Bumps min Rapids version to 24.8 which is now out with perf improvements around long strings among many others.
Also adds `--enable-cudf-spill` option to slurm setup scripts to support cudf spilling.
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
N/A
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
