### PR TITLE
Fix error in jusText

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,9 @@ setup(
         "fasttext==0.9.2",
         "pycld2",
         "justext==3.0.1",
+        # lxml_html_clean has difficulty installing in jusText
+        # installing explicitly to prevent errors/lag with jusText
+        "lxml_html_clean",
         "resiliparse",
         "ftfy==6.1.1",
         "warcio==1.7.4",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
jusText depends on `lxml` and `lxml_html_clean`. Both should be possible to install through `lxml[html_clean]`, which is what jusText does. However, pip is (sometimes) unable to find the `[html_clean]` extra. To prevent errors going forward, I am installing this directly in our `setup.py`.

## Usage
<!-- Potentially add a usage example below -->
N/A
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
