### PR TITLE
Remove extra `parse_args()` in classifier examples

### DIFF
--- a/examples/classifiers/aegis_example.py
+++ b/examples/classifiers/aegis_example.py
@@ -63,7 +63,7 @@ def attach_args(
     argumentHelper = ArgumentHelper(parser)
     argumentHelper.add_distributed_classifier_cluster_args()
 
-    return argumentHelper.parser.parse_args()
+    return argumentHelper.parser
 
 
 if __name__ == "__main__":

--- a/examples/classifiers/domain_example.py
+++ b/examples/classifiers/domain_example.py
@@ -58,7 +58,7 @@ def attach_args(
     argumentHelper = ArgumentHelper(parser)
     argumentHelper.add_distributed_classifier_cluster_args()
 
-    return argumentHelper.parser.parse_args()
+    return argumentHelper.parser
 
 
 if __name__ == "__main__":

--- a/examples/classifiers/fineweb_edu_example.py
+++ b/examples/classifiers/fineweb_edu_example.py
@@ -57,7 +57,7 @@ def attach_args(
     argumentHelper = ArgumentHelper(parser)
     argumentHelper.add_distributed_classifier_cluster_args()
 
-    return argumentHelper.parser.parse_args()
+    return argumentHelper.parser
 
 
 if __name__ == "__main__":

--- a/examples/classifiers/quality_example.py
+++ b/examples/classifiers/quality_example.py
@@ -58,7 +58,7 @@ def attach_args(
     argumentHelper = ArgumentHelper(parser)
     argumentHelper.add_distributed_classifier_cluster_args()
 
-    return argumentHelper.parser.parse_args()
+    return argumentHelper.parser
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes minor bug discovered when reviewing https://github.com/NVIDIA/NeMo-Curator/pull/168.
