### PR TITLE
Rerun flaky PyTest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
           pip install wheel cython
           pip install --no-cache-dir .
           pip install pytest
+          pip install pytest-rerunfailures
       - name: Run tests
         run: |
           python -m pytest -v --cpu

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -124,6 +124,7 @@ class TestDownload:
             start_snapshot = "2021-10"
             urls = get_common_crawl_urls(start_snapshot, end_snapshot, news=True)
 
+    @pytest.mark.flaky(reruns=3)
     def test_uneven_common_crawl_range(self):
         start_snapshot = "2021-03"
         end_snapshot = "2021-11"


### PR DESCRIPTION
Sometimes when running our CI we will randomly run into a
```
FAILED tests/test_download.py::TestDownload::test_uneven_common_crawl_range - json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This PR marks the test as flaky and attempts to rerun it a couple times. I got the idea from when I was working on the Dask-SQL project and opened a PR https://github.com/dask-contrib/dask-sql/pull/1021. LMK if this looks useful for us.