### PR TITLE
Update Readme instruction to install cython

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ You can install NeMo-Curator from PyPi, from source or get it through the NeMo F
 To install the CPU-only modules:
 
 ```bash
-pip install cython pybind11
+pip install cython
 pip install nemo-curator
 ```
 
 To install the CPU and CUDA-accelerated modules:
 
 ```bash
-pip install cython pybind11
+pip install cython
 pip install --extra-index-url https://pypi.nvidia.com nemo-curator[cuda12x]
 ```
 
@@ -114,14 +114,14 @@ pip install --extra-index-url https://pypi.nvidia.com nemo-curator[cuda12x]
     To install the CPU-only modules:
 
     ```bash
-    pip install cython pybind11
+    pip install cython
     pip install .
     ```
 
     To install the CPU and CUDA-accelerated modules:
 
     ```bash
-    pip install cython pybind11
+    pip install cython
     pip install --extra-index-url https://pypi.nvidia.com ".[cuda12x]"
     ```
 

--- a/README.md
+++ b/README.md
@@ -89,12 +89,14 @@ You can install NeMo-Curator from PyPi, from source or get it through the NeMo F
 To install the CPU-only modules:
 
 ```bash
+pip install cython pybind11
 pip install nemo-curator
 ```
 
 To install the CPU and CUDA-accelerated modules:
 
 ```bash
+pip install cython pybind11
 pip install --extra-index-url https://pypi.nvidia.com nemo-curator[cuda12x]
 ```
 
@@ -112,12 +114,14 @@ pip install --extra-index-url https://pypi.nvidia.com nemo-curator[cuda12x]
     To install the CPU-only modules:
 
     ```bash
+    pip install cython pybind11
     pip install .
     ```
 
     To install the CPU and CUDA-accelerated modules:
 
     ```bash
+    pip install cython pybind11
     pip install --extra-index-url https://pypi.nvidia.com ".[cuda12x]"
     ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[build-system]
-# Minimum requirements for the build system to execute.
-requires = ["Cython", "setuptools"]
-
-
 [tool.isort]
 profile = "black"  # black-compatible
 line_length = 88  # should match black parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["Cython", "setuptools"]
+
+
 [tool.isort]
 profile = "black"  # black-compatible
 line_length = 88  # should match black parameters

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     packages=find_packages(),
     python_requires=">=3.10, <3.11",
     install_requires=[
-        # "Cython",
         "dask[complete]>=2021.7.1",
         "distributed>=2021.7.1",
         "dask-mpi>=2021.11.0",

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.10, <3.11",
     install_requires=[
+        # "Cython",
         "dask[complete]>=2021.7.1",
         "distributed>=2021.7.1",
         "dask-mpi>=2021.11.0",
@@ -65,7 +66,6 @@ setup(
         "presidio-anonymizer==2.2.351",
         "usaddress==0.5.10",
         "nemo_toolkit[nlp]>=1.23.0",
-        "Cython",
         "crossfit @ git+https://github.com/rapidsai/crossfit.git@0cc2993",
         # Numpy 2.0 breaks with spacy https://github.com/explosion/spaCy/issues/13528
         # TODO: Remove when issue is fixed


### PR DESCRIPTION
## Description
Currently the installation using `pip install .` doesn't work. We add instructions to pre-install `cython` to make it work.

### Root cause for `cpython`
`nemo_toolkit` depends on `YouTokenToMe` (and that requires Cython to exist). This is also _addressed_ in our `.github/workflows/test.yml` 
https://github.com/NVIDIA/NeMo-Curator/blob/2e0af575e65b73b7cf9455d36a68c5dba51a6553/.github/workflows/test.yml#L40 

Even `nemo_toolkit` requires an explicit installation of `Cython` before installing `nemo_toolkit`
https://github.com/NVIDIA/NeMo/blob/a777a442c43cd2092684c8b8f06701ed62134a9f/README.md#pip

#### Future
However once `nemo_toolkit` 2.x is released we might be able to resolve this since https://github.com/NVIDIA/NeMo/pull/8322/ has been merged. In future we can also consider moving `nemo_toolkit` as an optional dependency since it's just used in a single place https://github.com/NVIDIA/NeMo-Curator/blob/2e0af575e65b73b7cf9455d36a68c5dba51a6553/nemo_curator/filters/code.py#L105

## Why not add to install_requires?
IIUC explicitly having `Cython` as a dependency in `install_requires`  within `setup.py` doesn't solve the issue because IIUC pip doesn't respect any specific order of installation, so when it's installing `nemo_toolkit`, `Cython` hasn't been installed by then.

### Alternative solution
Tried adding `build-system` to the `pyproject.toml` however that didn't work as cython was still not found during install step. 
https://github.com/NVIDIA/NeMo-Curator/pull/223/commits/ae26c3459f723e129791d971b815593d70ba23b5


## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
