### PR TITLE
[Tutorials] Fix API key missing errors in the SDG tutorial

### DIFF
--- a/tutorials/peft-curation-with-sdg/README.md
+++ b/tutorials/peft-curation-with-sdg/README.md
@@ -64,3 +64,6 @@ where `N` is the number of workers to spawn.
 
 Once the code finishes executing, the curated dataset will be available under `data/curated/final`.
 By default, the script outputs splits for training (80%), validation (10%) and testing (10%).
+
+## Next Step: Fine-tune Your Own Model
+The curated dataset from this tutorial can be readily used for model customization and fine-tuning using the [NeMo Framework](https://github.com/NVIDIA/NeMo). Please refer to the [law title generation tutorial](https://github.com/NVIDIA/NeMo/blob/main/tutorials/llm/llama-3/sdg-law-title-generation/llama3-sdg-lora-nemofw.ipynb) in the NeMo Framework repository to learn more.

--- a/tutorials/peft-curation-with-sdg/main.py
+++ b/tutorials/peft-curation-with-sdg/main.py
@@ -278,7 +278,7 @@ def run_pipeline(args, jsonl_fp):
     llm_client = AsyncOpenAIClient(
         AsyncOpenAI(
             base_url="https://integrate.api.nvidia.com/v1",
-            api_key=args.api_key,
+            api_key=args.api_key or "",
             timeout=args.api_timeout,
         )
     )


### PR DESCRIPTION
## Description
- Fixes an issue where the OpenAI client would fail to initialize if an API key is not provided.
- Add links to the NeMo FW tutorial for model fine-tuning.

## Checklist
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
