### PR TITLE
Remove flaky PyTest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,6 @@ jobs:
           pip install wheel cython
           pip install --no-cache-dir .
           pip install pytest
-          pip install pytest-rerunfailures
       - name: Run tests
         run: |
           python -m pytest -v --cpu

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -124,6 +124,22 @@ class TestDownload:
             start_snapshot = "2021-10"
             urls = get_common_crawl_urls(start_snapshot, end_snapshot, news=True)
 
+    @pytest.mark.skip(reason="Skipping until we figure out how to get this to a non flaky state")
+    def test_uneven_common_crawl_range(self):
+        start_snapshot = "2021-03"
+        end_snapshot = "2021-11"
+        urls = get_common_crawl_urls(start_snapshot, end_snapshot)
+
+        assert (
+            urls[0]
+            == "https://data.commoncrawl.org/crawl-data/CC-MAIN-2021-10/segments/1614178347293.1/warc/CC-MAIN-20210224165708-20210224195708-00000.warc.gz"
+        )
+        assert (
+            urls[-1]
+            == "https://data.commoncrawl.org/crawl-data/CC-MAIN-2021-04/segments/1610704847953.98/warc/CC-MAIN-20210128134124-20210128164124-00799.warc.gz"
+        )
+        assert len(urls) == 143840
+
     def test_no_urls(self):
         with pytest.raises(ValueError):
             output_format = {

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -124,7 +124,9 @@ class TestDownload:
             start_snapshot = "2021-10"
             urls = get_common_crawl_urls(start_snapshot, end_snapshot, news=True)
 
-    @pytest.mark.skip(reason="Skipping until we figure out how to get this to a non flaky state")
+    @pytest.mark.skip(
+        reason="Skipping until we figure out how to get this to a non flaky state"
+    )
     def test_uneven_common_crawl_range(self):
         start_snapshot = "2021-03"
         end_snapshot = "2021-11"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -124,22 +124,6 @@ class TestDownload:
             start_snapshot = "2021-10"
             urls = get_common_crawl_urls(start_snapshot, end_snapshot, news=True)
 
-    @pytest.mark.flaky(reruns=5)
-    def test_uneven_common_crawl_range(self):
-        start_snapshot = "2021-03"
-        end_snapshot = "2021-11"
-        urls = get_common_crawl_urls(start_snapshot, end_snapshot)
-
-        assert (
-            urls[0]
-            == "https://data.commoncrawl.org/crawl-data/CC-MAIN-2021-10/segments/1614178347293.1/warc/CC-MAIN-20210224165708-20210224195708-00000.warc.gz"
-        )
-        assert (
-            urls[-1]
-            == "https://data.commoncrawl.org/crawl-data/CC-MAIN-2021-04/segments/1610704847953.98/warc/CC-MAIN-20210128134124-20210128164124-00799.warc.gz"
-        )
-        assert len(urls) == 143840
-
     def test_no_urls(self):
         with pytest.raises(ValueError):
             output_format = {


### PR DESCRIPTION
Removes changes from https://github.com/NVIDIA/NeMo-Curator/pull/218. Since `test_uneven_common_crawl_range` is very flaky, we skip it for now. I will also open an issue for possibly re-adding it in the future.