### PR TITLE
Make id field optional for filtering

### DIFF
--- a/nemo_curator/scripts/filter_documents.py
+++ b/nemo_curator/scripts/filter_documents.py
@@ -126,7 +126,10 @@ def main(args):
 
         # Write scores to separate directory
         if args.output_document_score_dir:
-            if args.id_field in filtered_dataset.df.columns:
+            if (
+                args.id_field is not None
+                and args.id_field in filtered_dataset.df.columns
+            ):
                 output_df = filtered_dataset.df[[args.id_field, *score_fields]]
             else:
                 output_df = filtered_dataset.df[score_fields]
@@ -207,7 +210,7 @@ def attach_args(
     parser.add_argument(
         "--id-field",
         type=str,
-        required=True,
+        default=None,
         help="The name of the field within each object of the dataset "
         "file that assigns a unqiue ID to each document. "
         "If this is specified and found within the object, a list of all "


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Makes the id field optional for the `filter_docments` utility. It is only used if the user wants to attach each score to the corresponding id when writing out scores separately, so this does not need to be specified most of the time.

## Usage
<!-- Potentially add a usage example below -->
N/A
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
