### PR TITLE
Fix 255 - Improve separate_by_metadata performance for jsonl files

### DIFF
--- a/nemo_curator/scripts/separate_by_metadata.py
+++ b/nemo_curator/scripts/separate_by_metadata.py
@@ -40,21 +40,27 @@ def main(args):
             output_type=args.output_file_type,
             value_selection_filter=args.value_selection_filter,
             value_exclusion_filter=args.value_exclusion_filter,
-        ).compute()
+        )
 
+        # Save metadata distribution to disk
         with open(args.output_metadata_distribution, "w") as fp:
-            json.dump(metadata_distribution, fp)
+            json.dump(metadata_distribution.compute(), fp)
 
+        # Optionally, remove input directory
         if args.remove_input_dir:
             print(f"Removing all files in {args.input_data_dir}")
             shutil.rmtree(args.input_data_dir)
             print(f"Finished removing all files in {args.input_data_dir}")
 
+        # Warn the user about possible Dask messages
         print(
             f"Finished separating {args.input_metadata_field} metadata\n"
             "Dask messages from here may relate to cluster shutdown.",
             flush=True,
         )
+
+        #  Cancel any remaining futures (if any)
+        client.cancel(metadata_distribution)
 
         # Shut down the cluster
         client.shutdown()

--- a/nemo_curator/scripts/separate_by_metadata.py
+++ b/nemo_curator/scripts/separate_by_metadata.py
@@ -52,13 +52,6 @@ def main(args):
             shutil.rmtree(args.input_data_dir)
             print(f"Finished removing all files in {args.input_data_dir}")
 
-        # Warn the user about possible Dask messages
-        print(
-            f"Finished separating {args.input_metadata_field} metadata\n"
-            "Dask messages from here may relate to cluster shutdown.",
-            flush=True,
-        )
-
         #  Cancel any remaining futures (if any)
         client.cancel(metadata_distribution)
 

--- a/nemo_curator/scripts/separate_by_metadata.py
+++ b/nemo_curator/scripts/separate_by_metadata.py
@@ -14,7 +14,10 @@
 
 import argparse
 import json
+import logging
 import shutil
+
+from dask.distributed.utils import silence_logging_cmgr
 
 from nemo_curator.utils.distributed_utils import get_client
 from nemo_curator.utils.file_utils import separate_by_metadata
@@ -24,36 +27,40 @@ from nemo_curator.utils.script_utils import ArgumentHelper
 def main(args):
     print(f"Beginning metadata separation for {args.input_metadata_field}")
 
-    # Initializes or connects to a Dask cluster.
-    client = get_client(**ArgumentHelper.parse_client_args(args))
+    with silence_logging_cmgr(logging.ERROR):
+        # Initializes a Dask cluster.
+        client = get_client(**ArgumentHelper.parse_client_args(args))
 
-    # Separete corpus by metadata
-    metadata_distribution = separate_by_metadata(
-        args.input_data_dir,
-        args.output_data_dir,
-        args.input_metadata_field,
-        remove_metadata=args.remove_metadata_field,
-        output_type=args.output_file_type,
-        value_selection_filter=args.value_selection_filter,
-        value_exclusion_filter=args.value_exclusion_filter,
-    ).compute()
+        # Separete corpus by metadata
+        metadata_distribution = separate_by_metadata(
+            args.input_data_dir,
+            args.output_data_dir,
+            args.input_metadata_field,
+            remove_metadata=args.remove_metadata_field,
+            output_type=args.output_file_type,
+            value_selection_filter=args.value_selection_filter,
+            value_exclusion_filter=args.value_exclusion_filter,
+        ).compute()
 
-    with open(args.output_metadata_distribution, "w") as fp:
-        json.dump(metadata_distribution, fp)
+        with open(args.output_metadata_distribution, "w") as fp:
+            json.dump(metadata_distribution, fp)
 
-    if args.remove_input_dir:
-        print(f"Removing all files in {args.input_data_dir}")
-        shutil.rmtree(args.input_data_dir)
-        print(f"Finished removing all files in {args.input_data_dir}")
+        if args.remove_input_dir:
+            print(f"Removing all files in {args.input_data_dir}")
+            shutil.rmtree(args.input_data_dir)
+            print(f"Finished removing all files in {args.input_data_dir}")
 
-    print(
-        f"Finished separating {args.input_metadata_field} metadata\n"
-        "Dask messages from here may relate to cluster shutdown.",
-        flush=True,
-    )
+        print(
+            f"Finished separating {args.input_metadata_field} metadata\n"
+            "Dask messages from here may relate to cluster shutdown.",
+            flush=True,
+        )
 
-    # Shut down the cluster
-    client.shutdown()
+        # Shut down the cluster
+        client.shutdown()
+
+        # Close the client
+        client.close()
 
 
 def attach_args(

--- a/nemo_curator/scripts/separate_by_metadata.py
+++ b/nemo_curator/scripts/separate_by_metadata.py
@@ -16,35 +16,25 @@ import argparse
 import json
 import shutil
 
-from nemo_curator.utils.distributed_utils import get_client, read_data
-from nemo_curator.utils.file_utils import (
-    expand_outdir_and_mkdir,
-    get_all_files_paths_under,
-    separate_by_metadata,
-)
+from nemo_curator.utils.distributed_utils import get_client
+from nemo_curator.utils.file_utils import separate_by_metadata
 from nemo_curator.utils.script_utils import ArgumentHelper
 
 
 def main(args):
     client = get_client(**ArgumentHelper.parse_client_args(args))
 
-    files = get_all_files_paths_under(args.input_data_dir)
-    input_data = read_data(
-        files, file_type=args.input_file_type, backend="pandas", add_filename=True
-    )
-
-    output_dir = expand_outdir_and_mkdir(args.output_data_dir)
-
-    metadata_field = args.input_metadata_field
-    print(f"Beginning metadata separation for {metadata_field}")
+    print(f"Beginning metadata separation for {args.input_metadata_field}")
     metadata_distribution = separate_by_metadata(
-        input_data,
-        output_dir,
-        metadata_field,
+        args.input_data_dir,
+        args.output_data_dir,
+        args.input_metadata_field,
         remove_metadata=args.remove_metadata_field,
         output_type=args.output_file_type,
+        value_selection_filter=args.value_selection_filter,
+        value_exclusion_filter=args.value_exclusion_filter,
     ).compute()
-    print(f"Finished metadata separation for {metadata_field}")
+    print(f"Finished metadata separation for {args.input_metadata_field}")
 
     with open(args.output_metadata_distribution, "w") as fp:
         json.dump(metadata_distribution, fp)
@@ -101,6 +91,22 @@ def attach_args(
         help="Option of whether to remove the metadata field "
         "after filtering. Useful only in the case in which one metadata "
         "is desired to be separated from the others",
+    )
+
+    exclusive_filters_group = parser.add_mutually_exclusive_group(required=False)
+    exclusive_filters_group.add_argument(
+        "--value-selection-filter",
+        nargs="+",
+        type=str,
+        help="A list of strings representing specific values to be selected or included. "
+        "If provided, only the items matching these values should be kept.",
+    )
+    exclusive_filters_group.add_argument(
+        "--value-exclusion-filter",
+        nargs="+",
+        type=str,
+        help="A list of strings representing specific values to be excluded or ignored. "
+        "If provided, any items matching these values should be skipped.",
     )
 
     return parser

--- a/nemo_curator/scripts/separate_by_metadata.py
+++ b/nemo_curator/scripts/separate_by_metadata.py
@@ -22,9 +22,12 @@ from nemo_curator.utils.script_utils import ArgumentHelper
 
 
 def main(args):
+    print(f"Beginning metadata separation for {args.input_metadata_field}")
+
+    # Initializes or connects to a Dask cluster.
     client = get_client(**ArgumentHelper.parse_client_args(args))
 
-    print(f"Beginning metadata separation for {args.input_metadata_field}")
+    # Separete corpus by metadata
     metadata_distribution = separate_by_metadata(
         args.input_data_dir,
         args.output_data_dir,
@@ -34,7 +37,6 @@ def main(args):
         value_selection_filter=args.value_selection_filter,
         value_exclusion_filter=args.value_exclusion_filter,
     ).compute()
-    print(f"Finished metadata separation for {args.input_metadata_field}")
 
     with open(args.output_metadata_distribution, "w") as fp:
         json.dump(metadata_distribution, fp)
@@ -43,6 +45,15 @@ def main(args):
         print(f"Removing all files in {args.input_data_dir}")
         shutil.rmtree(args.input_data_dir)
         print(f"Finished removing all files in {args.input_data_dir}")
+
+    print(
+        f"Finished separating {args.input_metadata_field} metadata\n"
+        "Dask messages from here may relate to cluster shutdown.",
+        flush=True,
+    )
+
+    # Shut down the cluster
+    client.shutdown()
 
 
 def attach_args(

--- a/nemo_curator/scripts/separate_by_metadata.py
+++ b/nemo_curator/scripts/separate_by_metadata.py
@@ -33,13 +33,14 @@ def main(args):
 
         # Separete corpus by metadata
         metadata_distribution = separate_by_metadata(
-            args.input_data_dir,
-            args.output_data_dir,
-            args.input_metadata_field,
+            input_data=args.input_data_dir,
+            output_dir=args.output_data_dir,
+            metadata_field=args.input_metadata_field,
             remove_metadata=args.remove_metadata_field,
             output_type=args.output_file_type,
-            value_selection_filter=args.value_selection_filter,
-            value_exclusion_filter=args.value_exclusion_filter,
+            input_type=args.input_file_type,
+            include_values=args.include_values,
+            exclude_values=args.exclude_values,
         )
 
         # Save metadata distribution to disk
@@ -112,14 +113,14 @@ def attach_args(
 
     exclusive_filters_group = parser.add_mutually_exclusive_group(required=False)
     exclusive_filters_group.add_argument(
-        "--value-selection-filter",
+        "--include-values",
         nargs="+",
         type=str,
         help="A list of strings representing specific values to be selected or included. "
         "If provided, only the items matching these values should be kept.",
     )
     exclusive_filters_group.add_argument(
-        "--value-exclusion-filter",
+        "--exclude-values",
         nargs="+",
         type=str,
         help="A list of strings representing specific values to be excluded or ignored. "

--- a/nemo_curator/utils/file_utils.py
+++ b/nemo_curator/utils/file_utils.py
@@ -24,7 +24,6 @@ import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 from dask import delayed
-from dask.distributed import wait
 
 from nemo_curator.utils.distributed_utils import (
     read_data,
@@ -286,9 +285,7 @@ def separate_by_metadata(
                     value_selection_filter=value_selection_filter,
                     value_exclusion_filter=value_exclusion_filter,
                 )
-            ).persist()
-            # Wait for completion
-            wait(bag)
+            )
 
             frequencies = dict(bag.frequencies().compute())
             frequencies.pop(None, None)  # Remove None when applying filters

--- a/tests/test_separate_by_metadata.py
+++ b/tests/test_separate_by_metadata.py
@@ -64,7 +64,7 @@ class TestMetadataSep:
             add_filename=True,
         ).df
         separate_by_metadata(
-            df=df,
+            input_data=df,
             output_dir=str(output_dir),
             metadata_field="metadata",
             output_type=file_ext,


### PR DESCRIPTION
Fix #255 - Improve separate_by_metadata performance when dealing with jsonl files

This PR improves separate_by_metadata performance a minimum of 3x, while reducing the memory needs from O(N) to O(1).

The above translates to less OOMs, better CPU utilization, and constant memory usage (around 11GB in a 500GB server).

I have also added a new functionality that allows to select which fields to keep, or which fields to exclude. This is interesting, for instance, after applying a quality classifier, where some user would like to keep only "High" quality documents.

Hope it helps!