### PR TITLE
Add `enable_cudf_spill` to LocalCudaCluster

### DIFF
--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -65,7 +65,6 @@ def start_dask_gpu_local_cluster(
         if nvlink_only and protocol == "ucx"
         else {}
     )
-    LocalCUDACluster()
 
     cluster = LocalCUDACluster(
         rmm_pool_size=rmm_pool_size,

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -38,8 +38,6 @@ get_device_total_memory = gpu_only_import_from(
     "dask_cuda.utils", "get_device_total_memory"
 )
 
-LocalCUDACluster()
-
 
 class NoWorkerError(Exception):
     pass

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -38,6 +38,8 @@ get_device_total_memory = gpu_only_import_from(
     "dask_cuda.utils", "get_device_total_memory"
 )
 
+LocalCUDACluster()
+
 
 class NoWorkerError(Exception):
     pass
@@ -65,6 +67,7 @@ def start_dask_gpu_local_cluster(
         if nvlink_only and protocol == "ucx"
         else {}
     )
+    LocalCUDACluster()
 
     cluster = LocalCUDACluster(
         rmm_pool_size=rmm_pool_size,
@@ -188,18 +191,6 @@ def _set_torch_to_use_rmm():
         return
 
     torch.cuda.memory.change_current_allocator(rmm_torch_allocator)
-
-
-def _enable_spilling():
-    """
-    Setting this environment variable enables automatic spilling (and "unspilling")
-    of buffers from device to host to enable out-of-memory computation,
-    i.e., computing on objects that occupy more memory than is available on the GPU.
-
-    """
-    import cudf
-
-    cudf.set_option("spill", True)
 
 
 def read_single_partition(

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -21,7 +21,7 @@ import random
 import warnings
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import TYPE_CHECKING, Dict, List, Union
 
 import dask.dataframe as dd
 import numpy as np
@@ -33,7 +33,13 @@ from nemo_curator.utils.gpu_utils import GPU_INSTALL_STRING, is_cudf_type
 from nemo_curator.utils.import_utils import gpu_only_import, gpu_only_import_from
 
 cudf = gpu_only_import("cudf")
-LocalCUDACluster = gpu_only_import_from("dask_cuda", "LocalCUDACluster")
+
+
+if TYPE_CHECKING:
+    from dask_cuda import LocalCUDACluster
+else:
+    LocalCUDACluster = gpu_only_import_from("dask_cuda", "LocalCUDACluster")
+
 get_device_total_memory = gpu_only_import_from(
     "dask_cuda.utils", "get_device_total_memory"
 )
@@ -70,13 +76,10 @@ def start_dask_gpu_local_cluster(
         rmm_pool_size=rmm_pool_size,
         protocol=protocol,
         rmm_async=True,
+        enable_cudf_spill=True,
         **extra_kwargs,
     )
     client = Client(cluster)
-
-    if enable_spilling:
-        _enable_spilling()
-        client.run(_enable_spilling)
 
     if set_torch_to_use_rmm:
         _set_torch_to_use_rmm()

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -33,13 +33,7 @@ from nemo_curator.utils.gpu_utils import GPU_INSTALL_STRING, is_cudf_type
 from nemo_curator.utils.import_utils import gpu_only_import, gpu_only_import_from
 
 cudf = gpu_only_import("cudf")
-
-
-if TYPE_CHECKING:
-    from dask_cuda import LocalCUDACluster
-else:
-    LocalCUDACluster = gpu_only_import_from("dask_cuda", "LocalCUDACluster")
-
+LocalCUDACluster = gpu_only_import_from("dask_cuda", "LocalCUDACluster")
 get_device_total_memory = gpu_only_import_from(
     "dask_cuda.utils", "get_device_total_memory"
 )
@@ -76,7 +70,7 @@ def start_dask_gpu_local_cluster(
         rmm_pool_size=rmm_pool_size,
         protocol=protocol,
         rmm_async=True,
-        enable_cudf_spill=True,
+        enable_cudf_spill=enable_spilling,
         **extra_kwargs,
     )
     client = Client(cluster)

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -21,7 +21,7 @@ import random
 import warnings
 from contextlib import nullcontext
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import Dict, List, Union
 
 import dask.dataframe as dd
 import numpy as np
@@ -29,7 +29,7 @@ import pandas as pd
 import psutil
 from dask.distributed import Client, LocalCluster, get_worker, performance_report
 
-from nemo_curator.utils.gpu_utils import GPU_INSTALL_STRING, is_cudf_type
+from nemo_curator.utils.gpu_utils import is_cudf_type
 from nemo_curator.utils.import_utils import gpu_only_import, gpu_only_import_from
 
 cudf = gpu_only_import("cudf")


### PR DESCRIPTION
## Description

Since https://github.com/rapidsai/dask-cuda/pull/1362 is merged we don't need to rely on `client.run(_enable_spilling)` and can just pass that arg to `LocalCUDACluster`
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
