### PR TITLE
Lower nworkers for tinystories tutorial to avoid OOM

### DIFF
--- a/tutorials/tinystories/main.py
+++ b/tutorials/tinystories/main.py
@@ -215,7 +215,7 @@ def main():
     parser = argparse.ArgumentParser()
     args = ArgumentHelper(parser).add_distributed_args().parse_args()
     # Limit the total number of workers to ensure we don't run out of memory.
-    args.n_workers = min(args.n_workers, 8)
+    args.n_workers = min(args.n_workers, 4)
 
     # Prepare the download and JSONL directories.
     if not os.path.isdir(DATA_DIR):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Lowers the default number of workers in the tinystories tutorial so it is less likely to OOM.

## Usage
<!-- Potentially add a usage example below -->
N/A
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
