### PR TITLE
[REVIEW] Speedup Connected Components

### DIFF
--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -1569,14 +1569,6 @@ class ConnectedComponents:
         )
         return output_path
 
-    def _convert_str_id_pair_to_int(self, df):
-        for id, tag in zip([self.left_id, self.right_id], ["x", "y"]):
-            dx = df[id].str.rsplit("-", n=1, expand=True)
-            df[f"dataset_id_{tag}"] = dx[0].astype("uint32").values
-            df[f"doc_id_{tag}"] = dx[1].astype("int64").values
-            df = df.drop(columns=[id])
-        return df
-
     def _write_dedup_parsed_id(self):
         dedup_parsed_id_path = f"{self.cache_dir}/dedup_parsed_id.parquet"
         t0 = time.time()

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -1493,7 +1493,7 @@ class ConnectedComponents:
             assert num_nodes == len(labels_df)
             # Ensure all docs in the same group are in the same partition
             labels_df = labels_df.shuffle(on=["group"], ignore_index=True)
-            labels_df.to_parquet(output_path, write_index=False)
+            labels_df.to_parquet(output_path, write_index=False, overwrite=True)
             Comms.destroy()
         self._logger.info(
             f"Time taken for Connected Components Run = {time.time() - t0}s and output written at {output_path}"
@@ -1561,7 +1561,7 @@ class ConnectedComponents:
                 transform_divisions=False,
                 align_dataframes=False,
             )
-            ddf.to_parquet(output_path, write_index=False)
+            ddf.to_parquet(output_path, write_index=False, overwrite=True)
         self._logger.info(
             f"Time taken for Dedup Encoding Jaccard Pairs = {time.time() - t0}s and output written at {output_path}"
         )
@@ -1590,7 +1590,9 @@ class ConnectedComponents:
             unique_docs["uid"] = np.uint64(1)
             unique_docs["uid"] = unique_docs["uid"].cumsum()
             unique_docs["uid"] = unique_docs["uid"] - 1
-            unique_docs.to_parquet(dedup_parsed_id_path, write_index=False)
+            unique_docs.to_parquet(
+                dedup_parsed_id_path, write_index=False, overwrite=True
+            )
         self._logger.info(
             f"Time taken for Dedup Parsed Id = {time.time() - t0}s and output written at {dedup_parsed_id_path}"
         )
@@ -1644,7 +1646,7 @@ class ConnectedComponents:
             ddf = ddf.drop(columns=pair_id)
             ddf = ddf.rename(columns={"uid": f"{self.id_column}_{tag}"})
         ddf = ddf[[self.left_id, self.right_id, "jaccard"]]
-        ddf.to_parquet(output_path, write_index=False)
+        ddf.to_parquet(output_path, write_index=False, overwrite=True)
 
         et = time.time()
         self._logger.info(

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -1428,7 +1428,6 @@ class ConnectedComponents:
             self._logger = logger
 
     def cc_workflow(self, output_path):
-        print("Writing deduped parsed id")
         deduped_parsed_id_path = self._write_dedup_parsed_id()
         encoded_jaccard_pair_path = self._write_encoded_jaccard_pair(
             deduped_parsed_id_path

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -1448,7 +1448,7 @@ class ConnectedComponents:
             self.profile_dir, "connected-components-run"
         ):
 
-            Comms.initialize(p2p=True)
+            Comms.initialize(p2p=False)
             df = dask_cudf.read_parquet(
                 deduped_encoded_jaccard_path, blocksize="1GB", aggregate_files=True
             )
@@ -1476,9 +1476,7 @@ class ConnectedComponents:
             labels_df = labels_df.merge(
                 result, left_on=["uid"], right_on=["vertex"], how="inner"
             )
-            id_columns = (
-                ["dataset_id", "doc_id"] if self.convert_str_ids else [self.id_column]
-            )
+            id_columns = [self.id_column]
             labels_df = labels_df[id_columns + ["labels"]]
             labels_df = labels_df.rename(columns={"labels": "group"})
             labels_df = labels_df.persist()
@@ -1578,7 +1576,7 @@ class ConnectedComponents:
             ddf = dask_cudf.read_parquet(
                 self.jaccard_pairs_path,
                 columns=[self.left_id, self.right_id],
-                blocksize="1GB",
+                blocksize="512MB",
                 aggregate_files=True,
             )
             id_columns = [self.id_column]

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -1714,3 +1714,4 @@ class ConnectedComponents:
         unique_df = cudf.concat(unique_df_ls, ignore_index=True)
         unique_df = unique_df.drop_duplicates(ignore_index=True)
         return unique_df
+

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -1668,7 +1668,7 @@ class ConnectedComponents:
         ddf: dask_cudf.DataFrame,
         ddf_id: dask_cudf.DataFrame,
         output_path: str,
-        id_columns: Union[str, List[str]]
+        id_columns: Union[str, List[str]],
     ) -> None:
         st = time.time()
         # Ensure 'id_columns' is a list
@@ -1696,7 +1696,9 @@ class ConnectedComponents:
         ddf.to_parquet(output_path, write_index=False)
 
         et = time.time()
-        self._logger.info(f"Time taken for merge and write = {time.time() - t0}s and output written at {output_path}")
+        self._logger.info(
+            f"Time taken for merge and write = {time.time() - t0}s and output written at {output_path}"
+        )
 
     @staticmethod
     def _get_unique_ids_per_partition(df, id_columns):
@@ -1714,4 +1716,3 @@ class ConnectedComponents:
         unique_df = cudf.concat(unique_df_ls, ignore_index=True)
         unique_df = unique_df.drop_duplicates(ignore_index=True)
         return unique_df
-

--- a/nemo_curator/scripts/fuzzy_deduplication/connected_components.py
+++ b/nemo_curator/scripts/fuzzy_deduplication/connected_components.py
@@ -40,6 +40,7 @@ def main(args):
         id_column=args.input_json_id_field,
         jaccard_threshold=args.jaccard_threshold,
         logger=args.log_dir,
+        profile_dir=args.profile_path,
     )
     components_stage.cc_workflow(output_path=output_path)
     print(f"All done in {time.time()-st:.1f} seconds")

--- a/nemo_curator/scripts/fuzzy_deduplication/connected_components.py
+++ b/nemo_curator/scripts/fuzzy_deduplication/connected_components.py
@@ -32,15 +32,15 @@ def main(args):
     st = time.time()
     output_path = os.path.join(args.output_dir, "connected_components.parquet")
     args.enable_spilling = True
-
     client = get_client(**ArgumentHelper.parse_client_args(args))
 
     components_stage = ConnectedComponents(
         cache_dir=args.cache_dir,
         jaccard_pairs_path=args.jaccard_pairs_path,
         id_column=args.input_json_id_field,
-        convert_str_ids=True,
+        convert_str_ids=False,
         jaccard_threshold=args.jaccard_threshold,
+        logger=args.log_dir,
     )
     components_stage.cc_workflow(output_path=output_path)
     print(f"All done in {time.time()-st:.1f} seconds")

--- a/nemo_curator/scripts/fuzzy_deduplication/connected_components.py
+++ b/nemo_curator/scripts/fuzzy_deduplication/connected_components.py
@@ -38,7 +38,6 @@ def main(args):
         cache_dir=args.cache_dir,
         jaccard_pairs_path=args.jaccard_pairs_path,
         id_column=args.input_json_id_field,
-        convert_str_ids=False,
         jaccard_threshold=args.jaccard_threshold,
         logger=args.log_dir,
     )


### PR DESCRIPTION
This pull request includes several changes to the `nemo_curator/modules/fuzzy_dedup.py` file, focusing on removing the `convert_str_ids` functionality, optimizing performance, and improving logging. 

The most important changes are:

#### Removal of `convert_str_ids` functionality:

* Removed the `convert_str_ids` parameter and its associated logic from the `__init__` method and other methods in `nemo_curator/modules/fuzzy_dedup.py`. [[1]](diffhunk://#diff-b836d89c298548dd47480ece278782f030d04e2beb421c59c0e546718aede6c3L472) [[2]](diffhunk://#diff-b836d89c298548dd47480ece278782f030d04e2beb421c59c0e546718aede6c3L1408) [[3]](diffhunk://#diff-b836d89c298548dd47480ece278782f030d04e2beb421c59c0e546718aede6c3L1418) [[4]](diffhunk://#diff-b836d89c298548dd47480ece278782f030d04e2beb421c59c0e546718aede6c3L1482-R1483) [[5]](diffhunk://#diff-b836d89c298548dd47480ece278782f030d04e2beb421c59c0e546718aede6c3L1592-L1607) [[6]](diffhunk://#diff-b836d89c298548dd47480ece278782f030d04e2beb421c59c0e546718aede6c3L1633-R1650)

This is done because now we have longstrings support in `cuDF` so we no longer need to convert string to int ids

#### Performance optimizations:

* Decreased the block size for reading parquet files in `_write_dedup_parsed_id`  [[1]](diffhunk://#diff-b836d89c298548dd47480ece278782f030d04e2beb421c59c0e546718aede6c3L1592-L1607) to a lesser value to allow scaling of drop_duplicates (which has a big memory overhead 16x+ ) to prevent OOMs, this will allow us to run CC at larger scales without requiring more hardware.

* Increased the   chuck size in `_write_encoded_jaccard_pair` methods to improve merge performance, as with large base chunks, we have bigger transfers so the throughput of transfer is better on TCP  [[2]](diffhunk://#diff-b836d89c298548dd47480ece278782f030d04e2beb421c59c0e546718aede6c3L1633-R1650) 


* Updated the `_run_connected_components` method to initialize `Comms` with `p2p=False` 

Merge Improvements: 
  - This PR optimizes the merge process by using an index-based approach instead of the previous batched method, while maintaining the broadcast merge.
  - The new method reduces shuffles to 2*num_batches - 1 through indexing. 
  - The only additional operation is setting the index on the `ddf_id` column.

Main: 22m 10s 
PR: 444.85 s 

![image](https://github.com/user-attachments/assets/b793c004-0896-4992-bb2f-a0675defce97)

Dask Profiles:
[cc_profiles.zip](https://github.com/user-attachments/files/17374101/cc_profiles.zip)



#### Logging improvements:

* Added start time logging in the `cc_workflow` method and end-to-end time logging for the workflow. [[1]](diffhunk://#diff-b836d89c298548dd47480ece278782f030d04e2beb421c59c0e546718aede6c3R1428) [[2]](diffhunk://#diff-b836d89c298548dd47480ece278782f030d04e2beb421c59c0e546718aede6c3R1439)




**Verify Equal Results:**

```python3
ddf_1 = dask_cudf.read_parquet("/raid/vjawa/rpv2_debug_cache_pull_302/connected_components.parquet")
ddf_1 = ddf_1.repartition(npartitions=4).sort_values(by=['id', 'group'])
len(ddf_1)
```
376321911

```python3
ddf_2 = dask_cudf.read_parquet("/raid/vjawa/rpv2_debug_cache/connected_components.parquet")
ddf_2 = ddf_2.repartition(npartitions=4).sort_values(by=['id', 'group'])

len(ddf_2)
```
376321911

#### Check same ids
```python3
merged_df = ddf_1[['id']].merge(ddf_2[['id']], on='id', how='inner')
len(merged_df)
```
376321911


CC: @ayushdg 

## Checklist

- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
