### PR TITLE
[REVIEW] Add pre-commit hook for DCO and pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,8 @@ ci:
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit suggestions'
   autoupdate_schedule: quarterly
 
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -47,3 +49,21 @@ repos:
       - id: isort
         name: Format imports
         exclude: docs/|nemo_curator/modules/__init__.py
+
+  - repo: local
+    hooks:
+      - id: check-signoff
+        name: Check Signed-off-by
+        entry: bash -c 'if ! grep -q "Signed-off-by:" "$1"; then echo "❌ Commit message must be signed off. Use git commit -s to add it automatically."; exit 1; fi' --
+        language: system
+        always_run: true
+        stages: [commit-msg]
+        types: [text]
+
+      - id: pre-commit-reminder
+        name: Pre-commit Installation Reminder
+        entry: echo "⚠️  Remember to install pre-commit and hooks (pip install pre-commit && pre-commit install --install-hooks)"
+        language: system
+        always_run: true
+        pass_filenames: false
+        stages: [pre-commit]


### PR DESCRIPTION
This pull request introduces improvements to the `.pre-commit-config.yaml` file, focusing on enhancing the pre-commit hook configuration. This PR closes: https://github.com/NVIDIA/NeMo-Curator/issues/290

Key updates:
   - Ensure commits are signed-off, enforcing commit message compliance.
   - Remind developers to install pre-commit hooks if missing, reducing setup errors.

### Example Usage:

```bash
(nemo_curator_dev) vjawa@dgx11:~/NeMo-Curator$ git add .pre-commit-config.yaml
(nemo_curator_dev) vjawa@dgx11:~/NeMo-Curator$ git commit -m 'check if signoff warning is raised'
```

```bash
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check yaml...............................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
Pre-commit Installation Reminder.........................................Passed
Check Signed-off-by......................................................Failed
- hook id: check-signoff
- exit code: 1

❌ Commit message must be signed off. Use git commit -s to add it automatically.
```

Additional example of running pre-commits 

```bash
(base) vjawa@dgx11:~/NeMo-Curator$ git commit -m 'check if signoff warning is raised'
`pre-commit` not found. Did you forget to activate your virtualenv?
```