### PR TITLE
Fix Jaccard Shuffle Error when Result is Empty + Overwrite using fuzzy_dedup cache

### DIFF
--- a/docs/user-guide/gpudeduplication.rst
+++ b/docs/user-guide/gpudeduplication.rst
@@ -251,7 +251,7 @@ Python API
   - The default values of ``num_buckets`` and ``hashes_per_bucket`` are set to find documents with an approximately Jaccard similarity of 0.8 or above.
   - Higher ``buckets_per_shuffle`` values can lead to better performance but might lead to out of memory errors.
   - Setting the ``false_positive_check`` flag to ``False`` is ideal for optimal performance.
-  - Clear the ``cache_dir`` between runs to avoid data from previous runs interfering with the current run's results.
+  - When setting the ``false_positive_check`` flag to ``True`` ensure ``cache_dir`` between runs is emptied to avoid data from previous runs interfering with the current run's results.
 
 """"""""""""
 CLI Utility

--- a/docs/user-guide/gpudeduplication.rst
+++ b/docs/user-guide/gpudeduplication.rst
@@ -184,7 +184,7 @@ Python API
     from nemo_curator import FuzzyDuplicatesConfig
 
     config = FuzzyDuplicatesConfig(
-        cache_dir="/path/to/dedup_outputs",
+        cache_dir="/path/to/dedup_outputs", # must be cleared between runs
         id_field="my_id",
         text_field="text",
         seed=42,

--- a/examples/fuzzy_deduplication.py
+++ b/examples/fuzzy_deduplication.py
@@ -31,7 +31,7 @@ def main(args):
 
     dataset_dir = "/path/to/dataset"
     log_dir = "./"
-    cache_dir = "./fuzzy_cache"
+    cache_dir = "./fuzzy_cache"  # must be cleared between runs
     output_dir = "./output"
     dataset_id_field = "id"
     dataset_text_field = "text"

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -1141,11 +1141,6 @@ class _Shuffle:
                     text_part_offset:end_text_offset
                 ]
 
-                print("==== HERE ====")
-                print(subset_text_df.compute().to_pandas().to_dict("records"))
-                print(subset_bucket_df.compute().to_pandas().to_dict("records"))
-                print("==== HERE OVER ====")
-
                 try:
                     # NOTE: If we have more text-df partitions than bucket-map
                     # partitions, we are more likely to see an OverflowError

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -33,7 +33,6 @@ import pyarrow as pa
 from cugraph import MultiGraph
 from dask import dataframe as dd
 from dask.utils import M
-from itsdangerous import NoneAlgorithm
 from tqdm import tqdm
 
 from nemo_curator.datasets import DocumentDataset

--- a/nemo_curator/modules/fuzzy_dedup.py
+++ b/nemo_curator/modules/fuzzy_dedup.py
@@ -1159,6 +1159,7 @@ class _Shuffle:
                         num_workers=num_workers,
                     )
                     if output_df is None:
+                        text_part_offset += parts_per_text_batch_use
                         continue
                 except OverflowError as err:
                     # We encountered an overflow error!

--- a/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
+++ b/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
@@ -173,8 +173,8 @@ def text_bytes_aware_shuffle(
     output_col = "_partitions"
 
     df = df.persist()
-    # if len(df) == 0:
-    #     return None
+    if len(df) == 0:
+        return None
     shuffle_part_ids = get_shuffle_partition_info(
         df=df,
         partition_on=partition_on,

--- a/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
+++ b/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
@@ -154,8 +154,11 @@ def get_shuffle_partition_info(
 
 
 def text_bytes_aware_shuffle(
-    df, partition_on: str, text_column: str, num_workers: Optional[int] = None
-) -> Optional[None]:
+    df: dask_cuda.DataFrame,
+    partition_on: str,
+    text_column: str,
+    num_workers: Optional[int] = None,
+):
     """
     This shuffle takes into account the text bytes of each partition
     and tries to make sure that the output partitions do not exceed
@@ -167,7 +170,7 @@ def text_bytes_aware_shuffle(
         text_column: column name for the text data
 
     Returns:
-        dask_cudf dataframe with _partitions columns
+        dask_cudf dataframe with _partitions columns or None if `df` is empty after the merge
     """
     print("Starting text bytes aware shuffle", flush=True)
     output_col = "_partitions"

--- a/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
+++ b/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
@@ -154,7 +154,7 @@ def get_shuffle_partition_info(
 
 
 def text_bytes_aware_shuffle(
-    df: dask_cuda.DataFrame,
+    df,
     partition_on: str,
     text_column: str,
     num_workers: Optional[int] = None,

--- a/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
+++ b/nemo_curator/utils/fuzzy_dedup_utils/shuffle_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 import cudf
 import dask_cuda
 import numpy as np
@@ -151,7 +153,9 @@ def get_shuffle_partition_info(
     return shuffle_part_ids
 
 
-def text_bytes_aware_shuffle(df, partition_on, text_column, num_workers=None):
+def text_bytes_aware_shuffle(
+    df, partition_on: str, text_column: str, num_workers: Optional[int] = None
+) -> Optional[None]:
     """
     This shuffle takes into account the text bytes of each partition
     and tries to make sure that the output partitions do not exceed
@@ -160,7 +164,7 @@ def text_bytes_aware_shuffle(df, partition_on, text_column, num_workers=None):
     Args:
         df: dask_cudf dataframe
         partition_on: column name to partition on
-
+        text_column: column name for the text data
 
     Returns:
         dask_cudf dataframe with _partitions columns
@@ -169,6 +173,8 @@ def text_bytes_aware_shuffle(df, partition_on, text_column, num_workers=None):
     output_col = "_partitions"
 
     df = df.persist()
+    if len(df) == 0:
+        return None
     shuffle_part_ids = get_shuffle_partition_info(
         df=df,
         partition_on=partition_on,

--- a/tests/test_fuzzy_dedup.py
+++ b/tests/test_fuzzy_dedup.py
@@ -71,6 +71,24 @@ def large_fuzzy_dedup_data():
     return DocumentDataset(df)
 
 
+@pytest.fixture
+def shuffle_fail_fuzzy_dedup_data():
+    df = cudf.DataFrame(
+        {
+            "id": [1, 2, 300, 4, -1],
+            "text": [
+                "A test string",
+                "A different test string",
+                "A different object",
+                "Something completely else that doesn't match",
+                "The quick black cat jumps over the lazy dog",
+            ],
+        }
+    )
+    df = dask_cudf.from_cudf(df, 2)
+    return DocumentDataset(df)
+
+
 def minhash_overlap(minhash1: np.array, minhash2: np.array):
     assert len(minhash1) == len(minhash2)
     overlap = sum(minhash1 == minhash2)
@@ -412,6 +430,54 @@ class TestFuzzyDuplicates:
         expected_df = expected_df.list.sort_values()
         expected_df = expected_df.sort_values()
         assert_eq(expected_df, result_df, check_index=False)
+
+        @pytest.mark.parametrize(
+            "num_buckets,jaccard_threshold,duplicate_docs",
+            # Duplcated docs estimated from true_jaccard values
+            [
+                (5, 0.5, [[4, -1]]),
+                (10, 0.39, [[4, -1], [1, 2]]),
+                (3, 0.3, [[4, -1], [1, 2, 300]]),
+            ],
+        )
+        def test_shuffle_fail_fuzzy_dedup_data(
+            self,
+            shuffle_fail_fuzzy_dedup_data,
+            tmpdir,
+        ):
+            print(self.client)
+            # Dedup might fail when indices per partition do not start from 0
+            shuffle_fail_fuzzy_dedup_data.df = (
+                shuffle_fail_fuzzy_dedup_data.df.reset_index(drop=True)
+            )
+            config = FuzzyDuplicatesConfig(
+                cache_dir=tmpdir,
+                id_field="id",
+                text_field="text",
+                seed=42,
+                char_ngrams=5,
+                num_buckets=10,
+                hashes_per_bucket=1,
+                use_64_bit_hash=False,
+                buckets_per_shuffle=5,
+                false_positive_check=True,
+                num_anchors=2,
+                jaccard_threshold=0.39,
+            )
+            fuzzy_duplicates = FuzzyDuplicates(config=config)
+            result = fuzzy_duplicates(shuffle_fail_fuzzy_dedup_data)
+            result_df = result.df.compute()
+            # Drop non duplicated docs
+            result_df = result_df[result_df.group.duplicated(keep=False)]
+            result_df = result_df.groupby("group").id.agg(list)
+            # Sort to maintain uniform ordering
+
+            result_df = result_df.list.sort_values()
+            result_df = result_df.sort_values()
+            expected_df = cudf.Series([[1, 2]], name="id")
+            expected_df = expected_df.list.sort_values()
+            expected_df = expected_df.sort_values()
+            assert_eq(expected_df, result_df, check_index=False)
 
 
 class TestFuzzyDuplicatesConfig:

--- a/tests/test_fuzzy_dedup.py
+++ b/tests/test_fuzzy_dedup.py
@@ -431,53 +431,43 @@ class TestFuzzyDuplicates:
         expected_df = expected_df.sort_values()
         assert_eq(expected_df, result_df, check_index=False)
 
-        @pytest.mark.parametrize(
-            "num_buckets,jaccard_threshold,duplicate_docs",
-            # Duplcated docs estimated from true_jaccard values
-            [
-                (5, 0.5, [[4, -1]]),
-                (10, 0.39, [[4, -1], [1, 2]]),
-                (3, 0.3, [[4, -1], [1, 2, 300]]),
-            ],
+    def test_shuffle_fail_fuzzy_dedup_data(
+        self,
+        shuffle_fail_fuzzy_dedup_data,
+        tmpdir,
+    ):
+        # Dedup might fail when indices per partition do not start from 0
+        shuffle_fail_fuzzy_dedup_data.df = shuffle_fail_fuzzy_dedup_data.df.reset_index(
+            drop=True
         )
-        def test_shuffle_fail_fuzzy_dedup_data(
-            self,
-            shuffle_fail_fuzzy_dedup_data,
-            tmpdir,
-        ):
-            print(self.client)
-            # Dedup might fail when indices per partition do not start from 0
-            shuffle_fail_fuzzy_dedup_data.df = (
-                shuffle_fail_fuzzy_dedup_data.df.reset_index(drop=True)
-            )
-            config = FuzzyDuplicatesConfig(
-                cache_dir=tmpdir,
-                id_field="id",
-                text_field="text",
-                seed=42,
-                char_ngrams=5,
-                num_buckets=10,
-                hashes_per_bucket=1,
-                use_64_bit_hash=False,
-                buckets_per_shuffle=5,
-                false_positive_check=True,
-                num_anchors=2,
-                jaccard_threshold=0.39,
-            )
-            fuzzy_duplicates = FuzzyDuplicates(config=config)
-            result = fuzzy_duplicates(shuffle_fail_fuzzy_dedup_data)
-            result_df = result.df.compute()
-            # Drop non duplicated docs
-            result_df = result_df[result_df.group.duplicated(keep=False)]
-            result_df = result_df.groupby("group").id.agg(list)
-            # Sort to maintain uniform ordering
+        config = FuzzyDuplicatesConfig(
+            cache_dir=tmpdir,
+            id_field="id",
+            text_field="text",
+            seed=42,
+            char_ngrams=5,
+            num_buckets=10,
+            hashes_per_bucket=1,
+            use_64_bit_hash=False,
+            buckets_per_shuffle=5,
+            false_positive_check=True,
+            num_anchors=2,
+            jaccard_threshold=0.39,
+        )
+        fuzzy_duplicates = FuzzyDuplicates(config=config)
+        result = fuzzy_duplicates(shuffle_fail_fuzzy_dedup_data)
+        result_df = result.df.compute()
+        # Drop non duplicated docs
+        result_df = result_df[result_df.group.duplicated(keep=False)]
+        result_df = result_df.groupby("group").id.agg(list)
+        # Sort to maintain uniform ordering
 
-            result_df = result_df.list.sort_values()
-            result_df = result_df.sort_values()
-            expected_df = cudf.Series([[1, 2]], name="id")
-            expected_df = expected_df.list.sort_values()
-            expected_df = expected_df.sort_values()
-            assert_eq(expected_df, result_df, check_index=False)
+        result_df = result_df.list.sort_values()
+        result_df = result_df.sort_values()
+        expected_df = cudf.Series([[1, 2]], name="id")
+        expected_df = expected_df.list.sort_values()
+        expected_df = expected_df.sort_values()
+        assert_eq(expected_df, result_df, check_index=False)
 
 
 class TestFuzzyDuplicatesConfig:


### PR DESCRIPTION
## Fix Jaccard Shuffle Error

Check `len(merged_df) == 0`, if so won't bother. 

## Overwrite cache
Vibhu in #302 added
1. connected_components.parquet
2. final_dedup_encoded_jaccard_pair.parquet

This PR adds
1. encoded_jaccard_pair
2. dedup_parsed_id
3. anchor_docs_with_bk
4. jaccard_similarity_results.parquet

These were already being overwritten 
1. _buckets.parquet
2. _minhashes.parquet
3. _edges.parquet

We are overwritten this
1. shuffled_docs.parquet
## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
