### PR TITLE
Fix `gpu_exact_dups` due to deprecated flag

### DIFF
--- a/nemo_curator/scripts/find_exact_duplicates.py
+++ b/nemo_curator/scripts/find_exact_duplicates.py
@@ -60,7 +60,7 @@ def main(args):
         df = read_data(
             files[:num_files] if num_files else files,
             file_type="jsonl",
-            backend="pandas" if args.no_gpu else "cudf",
+            backend="pandas" if args.device != "gpu" else "cudf",
             files_per_partition=args.files_per_partition,
             add_filename=False,
         )[[id_field, text_field]]


### PR DESCRIPTION
## Description
This PR is to fix `gpu_exact_dups` mention in this issue, https://github.com/NVIDIA/NeMo-Curator/issues/350

Referencing these 2 commits:
- https://github.com/NVIDIA/NeMo-Curator/commit/1c73adeedb20df33cebe45cf94c5a3109b10c3b5#diff-67ff83fb9bb047c0cc82578699f04307c242ecb4249937c971dbf644494b56edR43
- https://github.com/NVIDIA/NeMo-Curator/commit/5e46cd8df7bf16b5442e8614b3ce45421eba3ebf

I noticed the `args.no_gpu` is a deprecated argument, however during the refactoring process, one of this argument is being left out. This blocks `gpu_exact_dups` from executing correctly.

## Usage
Prereqs:

add_id is executed on the jsonl to add id for dedup
existing .jsonl files in file directory eg.books_dedup/

```
gpu_exact_dups \
 --input-json-id-field="nemo_id" \
 --input-data-dir=books_dedup/ \
 --output-dir=exact_dedup \
 --device=gpu \
> logs/exact_dedup2.log 2>&1
```
## Checklist
-

## Results

Notice that after this commit, we can run `gpu_exact_dups` to completion.
<img width="1031" alt="image" src="https://github.com/user-attachments/assets/45499a6e-c035-4c96-bcd8-56396a4b35b8">
