### PR TITLE
ci: Run on main

### DIFF
--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -1,6 +1,9 @@
 name: "GPU CI/CD"
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       # We can run gpuCI on any PR targeting these branches
@@ -19,7 +22,7 @@ jobs:
   # First, we build and push a NeMo-Curator container
   build-container:
     # "build-container" job is run if the "gpuci" label is added to the PR
-    if: ${{ github.event.label.name == 'gpuci' }}
+    if: ${{ github.event.label.name == 'gpuci' || github.ref == 'refs/heads/main' }}
     uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_build_container.yml@v0.11.0
     with:
       image-name: nemo_curator_container
@@ -38,7 +41,7 @@ jobs:
     # It has 2 A100 GPUs
     runs-on: self-hosted-azure
     # "run-gpu-tests" job is run if the "gpuci" label is added to the PR
-    if: ${{ github.event.label.name == 'gpuci' }}
+    if: ${{ github.event.label.name == 'gpuci' || github.ref == 'refs/heads/main' }}
 
     steps:
       # If something went wrong during the last cleanup, this step ensures any existing container is removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN bash -exu <<EOF
   cd /opt/NeMo-Curator
   git init
   git remote add origin $FORKED_REPO_URL
-  git fetch origin $CURATOR_COMMIT --depth=1
+  git fetch origin '+refs/pull/*/merge:refs/remotes/pull/*/merge'
   git checkout $CURATOR_COMMIT
 EOF
 


### PR DESCRIPTION
## Description

This will build a `buildcache` image on `main` that PRs then can benefit from.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
