### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: "Release NeMo Curator"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-ref: 
+        description: Ref (SHA or branch name) to release
+        required: true
+        type: string
+    
+jobs:
+  release:
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@v0.10.0
+    with:
+      release-ref: ${{ inputs.release-ref }}
+      image-name: nemo_curator_container
+      dockerfile: Dockerfile
+      image-label: nemo-curator
+      build-args: |
+        IMAGE_LABEL=nemo-curator
+        REPO_URL=https://github.com/${{ github.repository }}.git
+        CURATOR_COMMIT=${{ github.sha }}
+      prune-filter-timerange: 24h
+      python-package: nemo_curator
+      container-workdir: /opt/NeMo_Curator
+      library-name: NeMo-Curator
+    secrets:
+      TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+      TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+      SLACK_RELEASE_ENDPOINT: ${{ secrets.SLACK_RELEASE_ENDPOINT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ name: "Release NeMo Curator"
 on:
   workflow_dispatch:
     inputs:
-      release-ref: 
+      release-ref:
         description: Ref (SHA or branch name) to release
         required: true
         type: string
-    
+
 jobs:
   release:
     uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@v0.10.0


### PR DESCRIPTION
To be merged after https://github.com/NVIDIA/NeMo-Curator/pull/356.

Reference: https://github.com/NVIDIA/NeMo-Aligner/blob/ko3n1g/ci/add-prerelease-tagging-workflow/.github/workflows/release.yaml