### PR TITLE
ci: Bump release workflow to allow of `devN` semver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   release:
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@v0.10.0
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@ko3n1g/feat/allow-dev-bump
     with:
       release-ref: ${{ inputs.release-ref }}
       image-name: nemo_curator_container

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         CURATOR_COMMIT=${{ github.sha }}
       prune-filter-timerange: 24h
       python-package: nemo_curator
-      container-workdir: /opt/NeMo_Curator
+      container-workdir: /opt/NeMo-Curator
       library-name: NeMo-Curator
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   release:
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@ko3n1g/feat/allow-dev-bump
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_release_library.yml@v0.12.0
     with:
       release-ref: ${{ inputs.release-ref }}
       image-name: nemo_curator_container

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN bash -exu <<EOF
   cd /opt/NeMo-Curator
   git init
   git remote add origin $REPO_URL
-  git fetch origin main
+  git fetch --all
   git fetch origin '+refs/pull/*/merge:refs/remotes/pull/*/merge'
   git checkout $CURATOR_COMMIT
 EOF


### PR DESCRIPTION
## Description

The release workflow was not yet able to handle the `devN` segment properly. A prerelease must reset it back to `dev0`. This is done with version `v0.12.0`.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
