### PR TITLE
ci: Add code-freeze workflow

### DIFF
--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -1,0 +1,22 @@
+name: 'Code freeze'
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        type: choice
+        description: Type of release
+        options:
+          - major
+          - minor
+
+jobs:
+  code-freeze:
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_code_freeze.yml@v0.12.0
+    with:
+      library-name: NeMo Curator
+      python-package: nemo_curator
+      release-type: ${{ inputs.release-type }}
+
+    secrets:
+      SLACK_RELEASE_ENDPOINT: ${{ secrets.SLACK_RELEASE_ENDPOINT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: "Release NeMo Curator"
+name: 'Release NeMo Curator'
 
 on:
   workflow_dispatch:
@@ -36,7 +36,7 @@ jobs:
       prune-filter-timerange: 24h
       python-package: nemo_curator
       container-workdir: /opt/NeMo-Curator
-      library-name: NeMo-Curator
+      library-name: NeMo Curator
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
## Description

This workflow is triggered manually. It branches `main` into a new branch of `rX.Y.Z.` based on the semver of its cut-off commit. Then, it attempts a version bump in `main based on the workflow input (major/minor) via a PR into `main`. Finally, it shoots a notification into the main Slack channel


## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
