### PR TITLE
ci: Add cherry pick workflow

### DIFF
--- a/.github/workflows/cherry-pick-release-commit.yml
+++ b/.github/workflows/cherry-pick-release-commit.yml
@@ -1,6 +1,6 @@
 name: Create PR to main with cherry-pick from release
 
-on: 
+on:
   push:
     branches:
       - main

--- a/.github/workflows/cherry-pick-release-commit.yml
+++ b/.github/workflows/cherry-pick-release-commit.yml
@@ -1,0 +1,14 @@
+name: Create PR to main with cherry-pick from release
+
+on: 
+  push:
+    branches:
+      - main
+
+jobs:
+  cherry-pick:
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_cherry_pick.yml@v0.12.0
+    secrets:
+      PAT: ${{ secrets.PAT }}
+      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Description

Once we have cut-off the release branch, we can automatically cherry pick fixes into it by assigning a label `$RELEASE_BRANCH_NAME` to the PR that goes into `main`. Once it hits `main`, the automation will attempt a cherry pick via PR into the release branch. If it fails due to an impossible 3-way merge, it sends a Slack alert into the CI channel with our user-group mention so that we can notify the original PR author

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
