### PR TITLE
Added LookUp error handling during encoding detection.

### DIFF
--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -359,7 +359,7 @@ def read_single_partition(
             df = df[columns]
         except Exception as ex:
             print(f"For {os.path.basename(file)}, columns {columns} not in df... Skipping")
-            return None
+            return []
 
     df = df[sorted(df.columns)]
     return df

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -579,12 +579,19 @@ def single_partition_write_with_filename(
                 output_file_path = output_file_path + ".jsonl"
 
                 if isinstance(df, pd.DataFrame):
-                    out_df.to_json(
-                        output_file_path,
-                        orient="records",
-                        lines=True,
-                        force_ascii=False,
-                    )
+                    # Experimenting memory leak when calling to_json
+                    # Workaround: use .to_dict and dump it
+                    records = out_df.to_dict(orient="records")
+                    with open(output_file_path, 'w') as fd:
+                        for record in records:
+                            json.dump(record, fd, ensure_ascii=False)
+                            fd.write('\n')
+                    # out_df.to_json(
+                    #     output_file_path,
+                    #     orient="records",
+                    #     lines=True,
+                    #     force_ascii=False,
+                    # )
                 else:
                     # See open issue here: https://github.com/rapidsai/cudf/issues/15211
                     # df.to_json(

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -581,7 +581,7 @@ def single_partition_write_with_filename(
         If the DataFrame is empty, return a Series containing a single element, False.
 
     """
-    if len(df) > 0:
+    if len(df) > 0 and "filename" in df.columns:
         empty_partition = False
     else:
         warnings.warn(f"Empty partition found")

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -546,8 +546,6 @@ def single_partition_write_with_filename(
         If the DataFrame is empty, return a Series containing a single element, False.
 
     """
-    assert "filename" in df.columns
-
     if len(df) > 0:
         empty_partition = False
     else:

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -358,6 +358,7 @@ def read_single_partition(
         try:
             df = df[columns]
         except Exception as ex:
+            # In the case of a bad write, where the columns are not present in the record, avoid stopping the programme and simply skip the present file.
             print(f"For {os.path.basename(file)}, columns {columns} not in df... Skipping")
             return []
 

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -344,12 +344,13 @@ def read_single_partition(
             concat_f = pd.concat
         df_ls = []
         for file in files:
-            print(os.path.basename(file))
+            # print(os.path.basename(file))
             df = read_f(file, **read_kwargs, **kwargs)
-            print(df.columns)
+            # print(df.columns)
             if add_filename:
                 df["filename"] = os.path.basename(file)
-            df_ls.append(df)
+            if columns in df.columns and type(df["text"]) == str:
+                df_ls.append(df)
         df = concat_f(df_ls, ignore_index=True)
     else:
         df = read_f(files, **read_kwargs, **kwargs)

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -360,7 +360,7 @@ def read_single_partition(
         except Exception as ex:
             # In the case of a bad write, where the columns are not present in the record, avoid stopping the programme and simply skip the present file.
             print(f"For {os.path.basename(file)}, columns {columns} not in df... Skipping")
-            return []
+            df = pd.DataFrame(columns=columns)
 
     df = df[sorted(df.columns)]
     return df

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -296,7 +296,6 @@ def read_single_partition(
         A cudf DataFrame or a pandas DataFrame.
 
     """
-    print(os.path.basename(file))
     if input_meta is not None and filetype != "jsonl":
         warnings.warn(
             "input_meta is only valid for JSONL files and will be ignored for other "
@@ -345,7 +344,9 @@ def read_single_partition(
             concat_f = pd.concat
         df_ls = []
         for file in files:
+            print(os.path.basename(file))
             df = read_f(file, **read_kwargs, **kwargs)
+            print(df.columns)
             if add_filename:
                 df["filename"] = os.path.basename(file)
             df_ls.append(df)

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -356,6 +356,8 @@ def read_single_partition(
         if add_filename and "filename" not in columns:
             columns.append("filename")
         try:
+            if "text" not in columns:
+                columns.append("text")
             df = df[columns]
         except Exception as ex:
             # In the case of a bad write, where the columns are not present in the record, avoid stopping the programme and simply skip the present file.

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -355,7 +355,11 @@ def read_single_partition(
     if filetype in ["jsonl", "json"] and columns is not None:
         if add_filename and "filename" not in columns:
             columns.append("filename")
-        df = df[columns]
+        try:
+            df = df[columns]
+        except Exception as ex:
+            print(f"For {os.path.basename(file)}, columns {columns} not in df... Skipping")
+            return None
 
     df = df[sorted(df.columns)]
     return df

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import ast
 import os
+import json
 import shutil
 
 os.environ["RAPIDS_NO_INITIALIZE"] = "1"

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -296,6 +296,7 @@ def read_single_partition(
         A cudf DataFrame or a pandas DataFrame.
 
     """
+    print(os.path.basename(file))
     if input_meta is not None and filetype != "jsonl":
         warnings.warn(
             "input_meta is only valid for JSONL files and will be ignored for other "

--- a/tutorials/dapt-curation/code/docbuilder.py
+++ b/tutorials/dapt-curation/code/docbuilder.py
@@ -283,7 +283,7 @@ class GitHubIterator(DocumentIterator):
 
             try:
                 content = content.decode(encoding)
-            except UnicodeDecodeError:
+            except (UnicodeDecodeError, LookupError):
                 # If the file cannot be decoded, return None
                 return None
 

--- a/tutorials/dapt-curation/code/requirements.txt
+++ b/tutorials/dapt-curation/code/requirements.txt
@@ -1,3 +1,6 @@
 arxiv
 arxiv-downloader
 cchardet
+poppler-utils
+unstructured[all-docs]==0.14.5
+unstructured[pdf]

--- a/tutorials/dapt-curation/code/requirements.txt
+++ b/tutorials/dapt-curation/code/requirements.txt
@@ -4,3 +4,4 @@ cchardet
 poppler-utils
 unstructured[all-docs]==0.14.5
 unstructured[pdf]
+datasets

--- a/tutorials/dapt-curation/code/requirements.txt
+++ b/tutorials/dapt-curation/code/requirements.txt
@@ -1,6 +1,3 @@
 arxiv
 arxiv-downloader
 cchardet
-poppler-utils
-unstructured[all-docs]==0.14.5
-unstructured[pdf]


### PR DESCRIPTION
Please check Issue #411 

I go into details on how to reproduce and the reasoning behind my simple fix.

---

In the current implementation of parse_file, the exception handling only catches `UnicodeDecodeError`. 

https://github.com/NVIDIA/NeMo-Curator/blob/7272ca04c2ec2255203c430412798071444e8bb4/tutorials/dapt-curation/code/docbuilder.py#L275-L288

This can be updated to also catch `LookupError`. 
```python
except (UnicodeDecodeError, LookupError):
    return None
```

While this works, it will still trigger an error when prompted with an encoding not available in the runtime system. Would be very nice to parse line by line instead, this way we would only skip the line and not ditch the whole github repo from the curation process. However, parsing the file line by line might introduce a lot of overhead for big repos.
