### PR TITLE
Dockerfile should use the correct nvidia channel to install libcu*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ LABEL "nemo.library"=${IMAGE_LABEL}
 WORKDIR /opt
 
 # Install the minimal libcu* libraries needed by NeMo Curator
-RUN conda create -y --name curator -c nvidia/label/cuda-${CUDA_VER} -c conda-forge
+RUN conda create -y --name curator -c nvidia/label/cuda-${CUDA_VER} -c conda-forge \
   python=3.10 \
   cuda-cudart \
   libcufft \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,15 @@ LABEL "nemo.library"=${IMAGE_LABEL}
 WORKDIR /opt
 
 # Install the minimal libcu* libraries needed by NeMo Curator
-RUN conda create -y --name curator -c conda-forge -c nvidia \
+RUN conda create -y --name curator -c -c nvidia/label/cuda-${CUDA_VER} -c conda-forge
   python=3.10 \
   cuda-cudart \
   libcufft \
   libcublas \
   libcurand \
   libcusparse \
-  libcusolver && \
+  libcusolver \
+  cuda-nvvm && \
   source activate curator && \
   pip install --upgrade pytest pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ LABEL "nemo.library"=${IMAGE_LABEL}
 WORKDIR /opt
 
 # Install the minimal libcu* libraries needed by NeMo Curator
-RUN conda create -y --name curator -c -c nvidia/label/cuda-${CUDA_VER} -c conda-forge
+RUN conda create -y --name curator -c nvidia/label/cuda-${CUDA_VER} -c conda-forge
   python=3.10 \
   cuda-cudart \
   libcufft \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ LABEL "nemo.library"=${IMAGE_LABEL}
 WORKDIR /opt
 
 # Install the minimal libcu* libraries needed by NeMo Curator
-RUN conda create -y --name curator -c nvidia/label/cuda-${CUDA_VER} -c conda-forge \
+ENV _CUDA_VER=${CUDA_VER}
+RUN conda create -y --name curator -c nvidia/label/cuda-${_CUDA_VER} -c conda-forge \
   python=3.10 \
   cuda-cudart \
   libcufft \


### PR DESCRIPTION
## Description
Realised that while we're installing cuda-12.5.1 in the CI image, the conda installations are all over the place and some of them are being picked up from conda-forge rather than nvidia. (IIUC -c A -c B, A takes precedence over B, and in our case conda-forge might have older versions of packages)

Secondly if we wish to use UDFs on `dask_cudf` we need `NVVM`. The place where I needed it was hack for #417

## Checklist
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
