### PR TITLE
Adding fuzzy and semantic dedupe

### DIFF
--- a/tutorials/dapt-curation/README.md
+++ b/tutorials/dapt-curation/README.md
@@ -37,6 +37,7 @@ The tutorial follows the steps below:<br>
     - Heuristic-based quality filtering (Number of lines, worc count, top N-grams, etc.)
     - Fix unicode errors via ftfy
     - PII redaction
+    - GPU accelerated fuzzy and semanctic deduplication
 - Step 6: Save the filtered and curated data <br>
 - Step 7: Blend datasets and shuffle
 
@@ -45,8 +46,10 @@ The tutorial follows the steps below:<br>
 
 After installing the NeMo Curator package, install the dependencies and run:
 
-`pip install -r code/requirements.txt`
-
-`python code/main.py`
+```bash
+pip install -r code/requirements.txt
+cd code
+python main.py
+```
 
 This will download chip-design related datasets and begin the data curation pipeline.

--- a/tutorials/dapt-curation/code/configs/text_semantic_dedupe_config.yaml
+++ b/tutorials/dapt-curation/code/configs/text_semantic_dedupe_config.yaml
@@ -1,0 +1,28 @@
+# Configuration file for semdantic dedup
+cache_dir: "workspace/semdedup_cache/text"
+num_files: 16
+
+# Embeddings configuration
+embeddings_save_loc: "embeddings"
+embedding_model_name_or_path: "sentence-transformers/all-MiniLM-L6-v2"
+embedding_batch_size: 128
+
+# Clustering configuration
+clustering_save_loc: "clustering_results"
+n_clusters: 20
+seed: 1234
+max_iter: 100
+kmeans_with_cos_dist: false
+
+# Semdedup configuration
+which_to_keep: "hard"
+largest_cluster_size_to_process: 100000
+sim_metric: "cosine"
+
+# Extract dedup configuration
+eps_thresholds:
+  - 0.1
+  - 0.01
+
+# Which threshold to use for extracting deduped data
+eps_to_extract: 0.1

--- a/tutorials/dapt-curation/code/requirements.txt
+++ b/tutorials/dapt-curation/code/requirements.txt
@@ -1,6 +1,7 @@
-arxiv
+arxiv==2.1.0
 arxiv-downloader
 cchardet
+nltk==3.8.1
 poppler-utils
 unstructured[all-docs]==0.14.5
 unstructured[pdf]

--- a/tutorials/dapt-curation/code/utils.py
+++ b/tutorials/dapt-curation/code/utils.py
@@ -13,12 +13,23 @@
 # limitations under the License.
 
 import json
+import os
 import re
 
 import dask.dataframe as dd
 import pandas as pd
+import yaml
 
-from nemo_curator import ExactDuplicates, Modify, ScoreFilter, Sequential
+from nemo_curator import (
+    ExactDuplicates,
+    FuzzyDuplicates,
+    FuzzyDuplicatesConfig,
+    Modify,
+    ScoreFilter,
+    SemDedup,
+    SemDedupConfig,
+    Sequential,
+)
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.filters import (
     DocumentFilter,
@@ -37,7 +48,10 @@ from nemo_curator.modifiers.pii_modifier import PiiModifier
 from nemo_curator.modifiers.unicode_reformatter import UnicodeReformatter
 from nemo_curator.pii.constants import DEFAULT_LANGUAGE, DEFAULT_MAX_DOC_SIZE
 from nemo_curator.utils.distributed_utils import get_client
-from nemo_curator.utils.file_utils import get_all_files_paths_under
+from nemo_curator.utils.file_utils import (
+    expand_outdir_and_mkdir,
+    get_all_files_paths_under,
+)
 
 
 class QuotationUnifier(DocumentModifier):
@@ -259,7 +273,7 @@ def redact_code(dataset: DocumentDataset) -> DocumentDataset:
     return redacted_dataset
 
 
-def dedupe(dataset: DocumentDataset) -> DocumentDataset:
+def exact_dedupe(dataset: DocumentDataset) -> DocumentDataset:
     """
     Remove exact duplicates from the given DocumentDataset.
 
@@ -280,6 +294,71 @@ def dedupe(dataset: DocumentDataset) -> DocumentDataset:
     dataset_df = dataset.df
     deduped = dataset_df[~dataset_df.id.isin(duplicate_ids)]
     return DocumentDataset(deduped)
+
+
+def fuzzy_dedupe(dataset: DocumentDataset, cache: str) -> DocumentDataset:
+    """
+    Removes near-duplicate documents and code lines
+
+    Args:
+        dataset (DocumentDataset): The dataset containing documents.
+        type (str): Document type to process.
+
+    Returns:
+        DocumentDataset: The deduplicated dataset.
+    """
+    fuzzy_dedup_config = FuzzyDuplicatesConfig(
+        cache_dir=cache,
+        id_field="id",
+        text_field="text",
+        seed=42,
+        char_ngrams=20,
+        num_buckets=20,
+        hashes_per_bucket=13,
+        use_64_bit_hash=False,
+        buckets_per_shuffle=5,
+        false_positive_check=False,
+        num_anchors=2,
+        jaccard_threshold=0.8,
+    )
+    fuzzy_dup = FuzzyDuplicates(config=fuzzy_dedup_config)
+    duplicates = fuzzy_dup(dataset)
+
+    docs_to_remove = duplicates.df.map_partitions(
+        lambda x: x[x.group.duplicated(keep="first")]
+    )
+
+    # When there are few duplicates we can compute the results to a list and use `isin`.
+    duplicate_ids = docs_to_remove.compute().id.to_arrow().to_pylist()
+    dataset_df = dataset.df
+    deduped = dataset_df[~dataset_df.id.isin(duplicate_ids)]
+    return DocumentDataset(deduped)
+
+
+def semantic_dedupe(
+    dataset: DocumentDataset, sem_dedupe_config_yaml_path: str, cache_dir: str
+):
+    """
+    Perform semantic deduplication on the given dataset.
+
+    Args:
+        dataset (DocumentDataset): The dataset containing documents.
+        type (str): Document type to process.
+
+    Returns:
+        The deduplicated DocumentDataset.
+    """
+    partition_lengths = dataset.df.map_partitions(len).compute()
+    non_empty_partitions = [
+        i for i, length in enumerate(partition_lengths) if length > 0
+    ]
+    dataset.df = dataset.df.partitions[non_empty_partitions]
+
+    semdedup_config = SemDedupConfig.from_yaml(sem_dedupe_config_yaml_path)
+    expand_outdir_and_mkdir(semdedup_config.cache_dir)
+    semdup = SemDedup(config=semdedup_config, id_column_type="str")
+    duplicates = semdup(dataset)
+    return duplicates
 
 
 class TextLineCountFilter(DocumentFilter):
@@ -323,3 +402,8 @@ class CodeLineCountFilter(DocumentFilter):
 
     def keep_document(self, score) -> bool:
         return score
+
+
+def rm_dir(cache_dir):
+    if os.path.isdir(cache_dir):
+        os.system(f"rm -rf {cache_dir}")


### PR DESCRIPTION
## Description
The PR adds 
- Versions for installations edits in requirements.txt for pip packages
- `fuzzy_dedupe` module implementation to DAPT data curator tutorial for chipNeMo. It performs Fuzzy Deduplication on code as well as text documents from Wikipedia and Arxiv sources.
- `semantic_dedupe` module implementation to DAPT data curator tutorial for chipNeMo. It performs Semantic Deduplication on text documents from Wikipedia and Arxiv sources.
## Usage
```
cd NeMo-Curator/tutorials/dapt-curation/code/
python main.py
```
## Checklist
- [ X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ X] New or Existing tests cover these changes.
- [ X] The documentation is up to date with these changes.
