### PR TITLE
chore: Bump to `0.6.0rc1`

### DIFF
--- a/nemo_curator/package_info.py
+++ b/nemo_curator/package_info.py
@@ -16,7 +16,7 @@
 MAJOR = 0
 MINOR = 6
 PATCH = 0
-PRE_RELEASE = "rc0"
+PRE_RELEASE = "rc1"
 DEV = "dev1"
 
 # Use the following formatting: (major, minor, patch, pre-release)


### PR DESCRIPTION
We need to move package version as  `0.6.0rc0` already got released

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
