### PR TITLE
Update fuzzy dedup test args to account for minhash algo changes.

### DIFF
--- a/tests/test_fuzzy_dedup.py
+++ b/tests/test_fuzzy_dedup.py
@@ -317,7 +317,7 @@ class TestFuzzyDuplicates:
         [
             (5, 0.5, [[4, -1]]),
             (10, 0.39, [[4, -1], [1, 2]]),
-            (3, 0.3, [[4, -1], [1, 2, 300]]),
+            (15, 0.3, [[4, -1], [1, 2, 300]]),
         ],
     )
     def test_fuzzy_dedup(
@@ -329,11 +329,6 @@ class TestFuzzyDuplicates:
         duplicate_docs,
         tmpdir,
     ):
-        if not use_64_bit_hash and jaccard_threshold == 0.3:
-            pytest.xfail(
-                "TODO: RAPIDS 24.12 fails with parameters 3-0.3-duplicate_docs2-False"
-            )
-
         print(self.client)
         # Dedup might fail when indices per partition do not start from 0
         fuzzy_dedup_data.df = fuzzy_dedup_data.df.reset_index(drop=True)
@@ -477,17 +472,12 @@ class TestFuzzyDuplicates:
         # Duplcated docs estimated from true_jaccard values
         [
             (10, [[4, -1], [1, 2, 300]]),
-            (3, [[4, -1], [1, 2, 300]]),
+            (5, [[4, -1], [1, 2, 300]]),
         ],
     )
     def test_no_fp_check(
         self, fuzzy_dedup_data, use_64_bit_hash, num_buckets, duplicate_docs, tmpdir
     ):
-        if not use_64_bit_hash and num_buckets == 3:
-            pytest.xfail(
-                "TODO: RAPIDS 24.12 fails with parameters 3-duplicate_docs1-False"
-            )
-
         config = FuzzyDuplicatesConfig(
             cache_dir=tmpdir,
             id_field="id",


### PR DESCRIPTION
## Description
24.12 moves to using the new minhash_permuted api which use different seed values and produce different minhash values. For tests with few minhashes `3` and strings
`"The quick brown fox jumps over the lazy dog."`
`"The quick black cat jumps over the lazy dog."`
Given 12 ngrams do not match each other there is a chance that a few hashes do not have any overlaps leading to failing tests.

Increased the number of minhashes to increase the probability of a collision in the tests.

## Usage

## Checklist

- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
