### PR TITLE
Bug fix in dockerfile ARG vs ENV var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,11 @@ FROM rapidsai/ci-conda:cuda${CUDA_VER}-${LINUX_VER}-py${PYTHON_VER}
 LABEL "nemo.library"=${IMAGE_LABEL}
 WORKDIR /opt
 
+# Re-declare ARGs after new FROM to make them available in this stage
+ARG CUDA_VER
+
 # Install the minimal libcu* libraries needed by NeMo Curator
-ENV _CUDA_VER=${CUDA_VER}
-RUN conda create -y --name curator -c nvidia/label/cuda-${_CUDA_VER} -c conda-forge \
+RUN conda create -y --name curator -c nvidia/label/cuda-${CUDA_VER} -c conda-forge \
   python=3.10 \
   cuda-cudart \
   libcufft \


### PR DESCRIPTION
## Description
Since we have two `FROM`s in our Dockerfile, to reference the first build arg (CUDA_VER) we need to redeclare it as an arg again.

 <!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
