### PR TITLE
ci: Bump `_build_container` workflow

### DIFF
--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -23,7 +23,7 @@ jobs:
   build-container:
     # "build-container" job is run if the "gpuci" label is added to the PR
     if: ${{ github.event.label.name == 'gpuci' || github.ref == 'refs/heads/main' }}
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_build_container.yml@v0.11.0
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_build_container.yml@v0.18.0
     with:
       image-name: nemo_curator_container
       dockerfile: Dockerfile


### PR DESCRIPTION
## Description

This provides a new input `use_cache: [boolean]` which we can use to create nightly builds from scratch 

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
