### PR TITLE
Reorder imports to work around cugraph bug for comet

### DIFF
--- a/nemo_curator/modules/__init__.py
+++ b/nemo_curator/modules/__init__.py
@@ -25,7 +25,6 @@ from .add_id import AddId
 from .config import FuzzyDuplicatesConfig, SemDedupConfig
 from .dataset_ops import blend_datasets, Shuffle
 from .exact_dedup import ExactDuplicates
-from .filter import Filter, Score, ScoreFilter, ParallelScoreFilter
 from .meta import Sequential
 from .modify import Modify
 from .task import TaskDecontamination
@@ -39,9 +38,7 @@ FuzzyDuplicates = gpu_only_import_from(
 BucketsToEdges = gpu_only_import_from(
     "nemo_curator.modules.fuzzy_dedup", "BucketsToEdges"
 )
-# Pytorch related imports must come after all imports that require cugraph,
-# because of context cleanup issues b/w pytorch and cugraph
-# See this issue: https://github.com/rapidsai/cugraph/issues/2718
+
 SemDedup = gpu_only_import_from("nemo_curator.modules.semantic_dedup", "SemDedup")
 EmbeddingCreator = gpu_only_import_from(
     "nemo_curator.modules.semantic_dedup", "EmbeddingCreator"
@@ -52,6 +49,10 @@ ClusteringModel = gpu_only_import_from(
 SemanticClusterLevelDedup = gpu_only_import_from(
     "nemo_curator.modules.semantic_dedup", "SemanticClusterLevelDedup"
 )
+# Pytorch related imports must come after all imports that require cugraph,
+# because of context cleanup issues b/w pytorch and cugraph
+# See this issue: https://github.com/rapidsai/cugraph/issues/2718
+from .filter import Filter, Score, ScoreFilter, ParallelScoreFilter
 
 __all__ = [
     "ExactDuplicates",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Reorders import to move filter import after all cugraph imports due to this issue: https://github.com/rapidsai/cugraph/issues/2718.

The PyTorch import comes from `nemo_curator/__init__.py` -> `nemo_curator/modules/__init__.py` -> `nemo_curator/modules/filter.py` -> `from nemo_curator.filters import DocumentFilter` -> `nemo_curator/filters/__init__.py` -> `nemo_curator/filters/classifier_filter` -> `nemo_curator/filters/models/qe_models/py` -> `comet = safe_import("comet", msg=COMET_IMPORT_MSG)`.

This error only occurs when using the optional `comet` package.

## Usage
<!-- Potentially add a usage example below -->
N/A
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
