### PR TITLE
Respect file order in `DocumentDataset.read_`

### DIFF
--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -485,7 +485,6 @@ def read_data_files_per_partition(
     columns: Optional[List[str]] = None,
     **kwargs,
 ) -> dd.DataFrame:
-    input_files = sorted(input_files)
     if files_per_partition > 1:
         input_files = [
             input_files[i : i + files_per_partition]


### PR DESCRIPTION
## Description

By removing the `sorted(..)` in `read_data_files_per_partition` we can be sure that the input order provided by user is respected. And in case a directory is provided as an input then we are ls-ing and then sorting before reading.

Solves https://github.com/NVIDIA/NeMo-Curator/issues/486

## Current Code Flow

Current flow is
1. `DocumentDataset.read_json/parquet` calls `_read_json_or_parquet`
2. `_read_json_or_parquet` which calls `read_data`
   - `_read_json_or_parquet` accepts `input_files` that could be `list[files]`, `list[dir]` or `file` or `dir`
   - if it's a `dir` or `list[dir]` it calls `get_all_files_paths_under` which has an implicit `sort`
3. `read_data` accepts `list[files]` and calls `read_data_blocksize` or read_data_files_per_partition`
4. 
    1. `read_data_files_per_partition` performs a sort
    2. `read_data_blocksize` doesn't perform a sort
## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
