### PR TITLE
Update to support Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Optionally free up space on Ubuntu

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # See https://github.com/rapidsai/ci-imgs for ARG options
-# NeMo Curator requires Python 3.10, Ubuntu 22.04/20.04, and CUDA 12 (or above)
+# NeMo Curator requires Python 3.12, Ubuntu 22.04/20.04, and CUDA 12 (or above)
 ARG CUDA_VER=12.5.1
 ARG LINUX_VER=ubuntu22.04
-ARG PYTHON_VER=3.10
+ARG PYTHON_VER=3.12
 ARG IMAGE_LABEL
 ARG REPO_URL
 ARG CURATOR_COMMIT
@@ -33,7 +33,7 @@ ARG CUDA_VER
 
 # Install the minimal libcu* libraries needed by NeMo Curator
 RUN conda create -y --name curator -c nvidia/label/cuda-${CUDA_VER} -c conda-forge \
-  python=3.10 \
+  python=3.12 \
   cuda-cudart \
   libcufft \
   libcublas \

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This section explains how to install NeMo Curator and use the Python library, Py
 
 Before installing NeMo Curator, ensure that the following requirements are met:
 
-- Python 3.10
+- Python 3.10 or higher
 - Ubuntu 22.04/20.04
 - NVIDIA GPU (optional)
   - Volta™ or higher ([compute capability 7.0+](https://developer.nvidia.com/cuda-gpus))

--- a/docs/user-guide/image/gettingstarted.rst
+++ b/docs/user-guide/image/gettingstarted.rst
@@ -12,7 +12,7 @@ Install NeMo Curator
 ---------------------
 To install the image curation modules of NeMo Curator, ensure you meet the following requirements:
 
-* Python 3.10
+* Python 3.10 or higher
 * Ubuntu 22.04/20.04
 * NVIDIA GPU
   * Volta™ or higher (compute capability 7.0+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ name = "nemo_curator"
 description = "Scalable Data Preprocessing Tool for Training Large Language Models"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
+    { name = "Ryan Wolf", email = "rywolf@nvidia.com" },
     { name = "Joseph Jennings", email = "jjennings@nvidia.com" },
     { name = "Mostofa Patwary", email = "mpatwary@nvidia.com" },
     { name = "Sandeep Subramanian", email = "sasubramania@nvidia.com" },
@@ -28,15 +29,15 @@ authors = [
     { name = "Ayush Dattagupta", email = "adattagupta@nvidia.com" },
     { name = "Vibhu Jawa", email = "vjawa@nvidia.com" },
     { name = "Jiwei Liu", email = "jiweil@nvidia.com" },
-    { name = "Ryan Wolf", email = "rywolf@nvidia.com" },
     { name = "Sarah Yurick", email = "syurick@nvidia.com" },
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.10, <3.11"
+requires-python = ">=3.10"
 dependencies = [
     "awscli>=1.22.55",
     "beautifulsoup4",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Updates NeMo Curator to remove the upper bound on the Python version. Eventually, we can raise the lower bound, but in the meantime while the CI is still transitioning I've left it at 3.10. All docs should be updated, please let me know if I missed something.

Another minor change I did was a request from @ericharper to reorder the author list. He noticed that the first author appears as the point of contact on the pypi page (https://pypi.org/project/nemo-curator/) and he prefers that I be the point of contact over Joseph since he is no longer involved in the project.

## Usage
<!-- Potentially add a usage example below -->
N/A
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
