### PR TITLE
Removal logic for Exact / Fuzzy Dedup

### DIFF
--- a/nemo_curator/_deduplicator.py
+++ b/nemo_curator/_deduplicator.py
@@ -87,6 +87,7 @@ class Deduplicator(ABC):
         left = dataset.df
         right = duplicates.df
 
+        print(f"{left.npartitions=}, {right.npartitions=}")
         if left.npartitions < right.npartitions:
             msg = (
                 "The number of partitions in the dataset to remove duplicates from is less than the number of partitions in the duplicates dataset. "

--- a/nemo_curator/_deduplicator.py
+++ b/nemo_curator/_deduplicator.py
@@ -1,0 +1,111 @@
+import warnings
+from abc import ABC
+from typing import Optional
+
+import dask.dataframe as dd
+
+from nemo_curator.datasets.doc_dataset import DocumentDataset
+
+
+def _perform_removal(
+    left: dd.DataFrame,
+    duplicates: dd.DataFrame,
+    id_field: str,
+    group_field: str,
+) -> dd.DataFrame:
+    new_id_field = f"{id_field}_new"
+
+    duplicates_to_remove = (
+        duplicates.map_partitions(lambda x: x[x[group_field].duplicated(keep="first")])
+        .drop(columns=group_field)
+        .rename(columns={id_field: new_id_field})[[new_id_field]]
+    )
+    merge = left.merge(
+        right=duplicates_to_remove,
+        how="left",
+        broadcast=True,
+        left_on=id_field,
+        right_on=new_id_field,
+    )
+    removed_result = merge[merge[new_id_field].isna()].drop(columns=[new_id_field])
+    return removed_result
+
+
+class Deduplicator(ABC):
+    def __init__(
+        self,
+        id_field: str,
+        text_field: str,
+        grouped_field: str,
+        cache_dir: Optional[str] = None,
+        **kwargs,
+    ):
+        self.id_field = id_field
+        self.text_field = text_field
+        self.grouped_field = grouped_field
+        self.cache_dir = cache_dir
+
+    def identify(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def remove(
+        self, dataset: DocumentDataset, duplicates: DocumentDataset
+    ) -> DocumentDataset:
+        """
+        Parameters
+        ----------
+        dataset: DocumentDataset
+            The input datset to remove duplicates from.
+
+        duplicates: DocumentDataset
+            The dataset containing IDs of all documents and the corresponding duplicate group
+            they belong to. Documents in the same group are considered duplicates.
+            Only the first document in each group is retained.
+
+        Returns
+        -------
+        DocumentDataset of all documents with duplicates removed.
+        """
+        if self.cache_dir is None:
+            msg = "Cache directory should be specified for improved performance for removal step."
+            warnings.warn(msg)
+
+        left = dataset.df
+        right = duplicates.df
+
+        if left.npartitions < right.npartitions:
+            msg = (
+                "The number of partitions in the dataset to remove duplicates from is less than the number of partitions in the duplicates dataset. "
+                "This may lead to a shuffle join. Please re-read the datasets and call nemo_curator._deduplicat.perform_merge explicitly."
+            )
+            raise ValueError(msg)
+
+        removed_result = _perform_removal(
+            left=left,
+            duplicates=right,
+            id_field=self.id_field,
+            group_field=self.grouped_field,
+        )
+        return DocumentDataset(removed_result)
+
+    def __call__(
+        self, dataset: DocumentDataset, perform_removal: bool = False
+    ) -> DocumentDataset:
+        """
+        Parameters
+        ----------
+        dataset: DocumentDataset
+            The input datset to remove duplicates from.
+        perform_removal: bool
+            If True, duplicates are removed from the dataset. If False, only the duplicates are identified.
+
+        Returns
+        -------
+        DocumentDataset of all duplicates (id field, group field) if if perform_removal is False.
+        DocumentDataset of all documents with duplicates removed if perform_removal is True.
+
+        """
+        duplicates = self.identify(dataset)
+        if perform_removal:
+            return self.remove(dataset, duplicates)
+        return duplicates

--- a/nemo_curator/modules/fuzzy_dedup/connectedcomponents.py
+++ b/nemo_curator/modules/fuzzy_dedup/connectedcomponents.py
@@ -125,8 +125,6 @@ class ConnectedComponents:
                 f"# rows in labels_df = {len(labels_df)}"
             )
             assert num_nodes == len(labels_df)
-            # Ensure all docs in the same group are in the same partition
-            labels_df = labels_df.shuffle(on=["group"], ignore_index=True)
             labels_df.to_parquet(output_path, write_index=False, overwrite=True)
             Comms.destroy()
         self._logger.info(

--- a/tests/test_deduplicator.py
+++ b/tests/test_deduplicator.py
@@ -3,9 +3,27 @@ import random
 import pandas as pd
 import pytest
 from dask import dataframe as dd
-from dask.dataframe.utils import assert_eq
 
-from nemo_curator._deduplicator import _perform_removal
+from nemo_curator._deduplicator import Deduplicator, _perform_removal
+from nemo_curator.datasets import DocumentDataset
+
+@pytest.fixture()
+def dummy_deduplicator():
+    class TestDeduplicator(Deduplicator):
+        def __init__(self):
+            super().__init__(
+                id_field="id",
+                text_field="text",
+                grouped_field="group",
+                cache_dir=None,
+            )
+        def identify(self, ds: DocumentDataset):
+            """ Dummy identify which marks all documents as duplicate """
+            df = ds.df.drop(columns=[self.text_field])
+            df[self.grouped_field] = 0
+            return DocumentDataset(df[[self.id_field, self.grouped_field]])
+            
+    return TestDeduplicator()
 
 
 @pytest.fixture()
@@ -92,3 +110,35 @@ def test_not_remove_unique(ids: list[str], sample_data: dd.DataFrame):
     assert len(result) == 1 + 9 + 1
     # The last 10 ids should be in the result, there would be one more from the first 30
     assert set(ids[30:]).issubset(set(result["id"].tolist()))
+
+
+def test_deduplicator_class(dummy_deduplicator : Deduplicator):
+    # Create sample dataframes with specific partition counts
+    df1 = dd.from_pandas(pd.DataFrame({
+        'id': ['a1', 'a2', 'a3'],
+        'text': ['text1', 'text2', 'text3']
+    }), npartitions=2)  # dataset with 2 partitions
+    
+    dataset = DocumentDataset(df1)
+    duplicates = dummy_deduplicator.identify(dataset)
+    assert isinstance(duplicates, DocumentDataset)
+
+    # We are able to perform deduplication successfully
+    result = dummy_deduplicator.remove(dataset, duplicates)
+    assert isinstance(result, DocumentDataset)
+    result = result.df.compute()
+    assert len(result) == 1
+    assert list(result.columns) == ['id', 'text']
+
+    # Test that it raises ValueError when right npartitions are greater than left npartitions
+    with pytest.raises(ValueError) as exc_info:
+        dummy_deduplicator.remove(dataset, duplicates.repartition(npartitions=3))
+    
+    expected_msg = (
+        "The number of partitions in the dataset to remove duplicates from is less than "
+        "the number of partitions in the duplicates dataset. This may lead to a shuffle "
+        "join. Please re-read the datasets and call nemo_curator._deduplicat.perform_merge explicitly."
+    )
+    assert str(exc_info.value) == expected_msg
+
+

--- a/tests/test_deduplicator.py
+++ b/tests/test_deduplicator.py
@@ -1,0 +1,94 @@
+import random
+
+import pandas as pd
+import pytest
+from dask import dataframe as dd
+from dask.dataframe.utils import assert_eq
+
+from nemo_curator._deduplicator import _perform_removal
+
+
+@pytest.fixture()
+def ids():
+    # Dataset has id a0...a9, b0...b9, c0...c9, d0...d9
+    l = [f"{group}{i}" for group in ["a", "b", "c", "d"] for i in range(10)]
+    # We shuffle it to make sure all duplicates are not in the same partition
+    random.shuffle(l)
+    return l
+
+
+@pytest.fixture
+def sample_data(ids):
+    df = pd.DataFrame(
+        {
+            "id": ids,
+            "text": [f"text for {_id}" for _id in ids],
+        }
+    )
+    return dd.from_pandas(df, npartitions=4)
+
+
+@pytest.fixture
+def duplicate_data(ids):
+    # In each group we want to keep only the first occurrence (e.g. a1, b1, c1, d1)
+    df = pd.DataFrame([{"id": _id, "group": _id[0]} for _id in ids])
+    # Shuffle to make sure all duplicates are not in the same partition
+    return dd.from_pandas(df, npartitions=2)
+
+
+def test_perform_removal_basic(sample_data: dd.DataFrame, duplicate_data: dd.DataFrame):
+    # Test basic duplicate removal functionality
+    result = _perform_removal(
+        left=sample_data, duplicates=duplicate_data, id_field="id", group_field="group"
+    )
+
+    result = result.compute()
+
+    assert list(result.columns) == ["id", "text"]
+    assert len(result) == 4
+    # It's not guaranteed that we'll have a0, b0, c0, d0 in the result
+    # So we should check the first character
+    assert set(result["id"].apply(lambda x: x[0]).tolist()) == set(["a", "b", "c", "d"])
+
+
+def test_perform_removal_all_duplicates(ids: list[str], sample_data: dd.DataFrame):
+    duplicates = dd.from_pandas(
+        pd.DataFrame({"id": ids, "group": [1] * len(ids)}), npartitions=2
+    )
+
+    result = _perform_removal(
+        left=sample_data, duplicates=duplicates, id_field="id", group_field="group"
+    )
+
+    result = result.compute()
+    assert list(result.columns) == ["id", "text"]
+    # Should keep only one of the occurrences
+    assert len(result) == 1
+
+
+def test_not_remove_unique(ids: list[str], sample_data: dd.DataFrame):
+    # We create a dataset where first 30 ids are in one group
+    # Next 9 ids are in distinct groups
+    # And last id is not mentioned in duplicates
+
+    duplicates = dd.from_pandas(
+        pd.DataFrame(
+            {
+                "id": ids[:30] + ids[30:39],
+                "group": ["group0"] * 30 + [f"group{i}" for i in range(1, 10)],
+            }
+        ),
+        npartitions=2,
+    )
+    result = _perform_removal(
+        left=sample_data, duplicates=duplicates, id_field="id", group_field="group"
+    )
+
+    result = result.compute()
+    assert list(result.columns) == ["id", "text"]
+    # It has 1 row from the first group of 30
+    # 9 rows from the 9 distinct groups
+    # And 1 row from the last group which is not included in set of duplicates
+    assert len(result) == 1 + 9 + 1
+    # The last 10 ids should be in the result, there would be one more from the first 30
+    assert set(ids[30:]).issubset(set(result["id"].tolist()))


### PR DESCRIPTION
## Description

### Removal Description
1. We implement ~left-anti join using a broadcast merge. This allows us to scale even when right is greater than memory per node.
2. We observe that the performance varies as num partitions (or partition sizes vary). 
    - The fastest being where right is exactly one partition, in which case we broadcast all of right to all the workers, and perform a merge (resulting in least transfer).
3.  One downside of this approach is when right is bigger than system memory per node, then the merge operation will have to spill, and that won't be possible, hence resulting in a stuck state where [dask pauses workers once it reaches 80% capacity](https://distributed.dask.org/en/latest/worker-memory.html#pause-worker) in which case user will have to implement a different merge logic.
 
### Class Description
1. Implements an abstract class called `Deduplicator` (name suggestions welcome)
        1. Lives in `nemo_curator._deduplicator.py`
        7. Implements identify / remove / __call__
        8. __call__ now accepts a boolean called `perform_removal` (alternative API's also accepted)  
2. Fuzzy / Exact Duplicates extend this class and the `__call__` is now renamed as `identify` since the `__call__` is implemented in base class 
## Usage
<!-- Potentially add a usage example below -->
```python
dataset = DocumentDataset.read_parquet(...)
exact_dedup = ExactDeduplicator(..)
duplicates = exact_dedup(dataset) # or exact_dedup.identify(exact_dedup)

exact_dedup.remove(dataset)
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
