### PR TITLE
Enforce Dataframe Backend Checks

### DIFF
--- a/docs/user-guide/api/dask.rst
+++ b/docs/user-guide/api/dask.rst
@@ -5,3 +5,6 @@ Dask Cluster Functions
 .. autofunction:: nemo_curator.get_client
 
 .. autofunction:: nemo_curator.get_network_interfaces
+
+.. autoclass:: nemo_curator.ToBackend
+    :members:

--- a/docs/user-guide/cpuvsgpu.rst
+++ b/docs/user-guide/cpuvsgpu.rst
@@ -117,6 +117,7 @@ To see how it works, take a look at this example.
       main()
 
 Let's highlight some of the important parts of this example.
+
 * ``client = get_client(cluster_type="gpu")``: Creates a local Dask cluster with access to the GPUs. In order to use/swap to a cuDF dataframe backend, you need to make sure you are running on a GPU Dask cluster.
 * ``dataset = DocumentDataset.read_json("books.jsonl")``: Reads in the dataset to a pandas (CPU) backend.
 * ``curation_pipeline = ...``: Defines a curation pipeline consisting of a CPU filtering step and a GPU classifier step. The ``ToBackend("cudf")`` in between moves the dataset from CPU to GPU for the classifier.

--- a/docs/user-guide/cpuvsgpu.rst
+++ b/docs/user-guide/cpuvsgpu.rst
@@ -119,7 +119,7 @@ To see how it works, take a look at this example.
 Let's highlight some of the important parts of this example.
 
 * ``client = get_client(cluster_type="gpu")``: Creates a local Dask cluster with access to the GPUs. In order to use/swap to a cuDF dataframe backend, you need to make sure you are running on a GPU Dask cluster.
-* ``dataset = DocumentDataset.read_json("books.jsonl")``: Reads in the dataset to a pandas (CPU) backend.
+* ``dataset = DocumentDataset.read_json("books.jsonl")``: Reads in the dataset to a pandas (CPU) backend by default.
 * ``curation_pipeline = ...``: Defines a curation pipeline consisting of a CPU filtering step and a GPU classifier step. The ``ToBackend("cudf")`` in between moves the dataset from CPU to GPU for the classifier.
 * ``curated_dataset.to_json("curated_books.jsonl")``: Writes the dataset directly to disk from the GPU. There is no need to transfer back to the CPU before writing to disk.
 

--- a/docs/user-guide/cpuvsgpu.rst
+++ b/docs/user-guide/cpuvsgpu.rst
@@ -97,7 +97,7 @@ To see how it works, take a look at this example.
   from nemo_curator import Sequential, ToBackend, ScoreFilter, get_client
   from nemo_curator.datasets import DocumentDataset
   from nemo_curator.classifiers import DomainClassifier
-  from nemo_curator.filters import RepeatingTopNGramsFilter
+  from nemo_curator.filters import RepeatingTopNGramsFilter, NonAlphaNumericFilter
 
   def main():
       client = get_client(cluster_type="gpu")
@@ -107,6 +107,8 @@ To see how it works, take a look at this example.
           ScoreFilter(RepeatingTopNGramsFilter(n=5)),
           ToBackend("cudf"),
           DomainClassifier(),
+          ToBackend("pandas"),
+          ScoreFilter(NonAlphaNumericFilter()),
       ])
 
       curated_dataset = curation_pipeline(dataset)
@@ -120,7 +122,7 @@ Let's highlight some of the important parts of this example.
 
 * ``client = get_client(cluster_type="gpu")``: Creates a local Dask cluster with access to the GPUs. In order to use/swap to a cuDF dataframe backend, you need to make sure you are running on a GPU Dask cluster.
 * ``dataset = DocumentDataset.read_json("books.jsonl")``: Reads in the dataset to a pandas (CPU) backend by default.
-* ``curation_pipeline = ...``: Defines a curation pipeline consisting of a CPU filtering step and a GPU classifier step. The ``ToBackend("cudf")`` in between moves the dataset from CPU to GPU for the classifier.
+* ``curation_pipeline = ...``: Defines a curation pipeline consisting of a CPU filtering step, a GPU classifier step, and another CPU filtering step. The ``ToBackend("cudf")`` moves the dataset from CPU to GPU for the classifier, and the ``ToBackend("pandas")`` moves the dataset back to the CPU from the GPU for the last filter.
 * ``curated_dataset.to_json("curated_books.jsonl")``: Writes the dataset directly to disk from the GPU. There is no need to transfer back to the CPU before writing to disk.
 
 -----------------------------------------

--- a/nemo_curator/classifiers/base.py
+++ b/nemo_curator/classifiers/base.py
@@ -25,10 +25,11 @@ from huggingface_hub import PyTorchModelHubMixin
 from transformers import AutoModel
 
 from nemo_curator.datasets import DocumentDataset
+from nemo_curator.modules.base import Module
 from nemo_curator.utils.distributed_utils import get_gpu_memory_info
 
 
-class DistributedDataClassifier(ABC):
+class DistributedDataClassifier(ABC, Module):
     """Abstract class for running multi-node multi-GPU data classification"""
 
     def __init__(
@@ -43,6 +44,7 @@ class DistributedDataClassifier(ABC):
         device_type: str,
         autocast: bool,
     ):
+        super().__init__(input_backend="cudf")
         self.model = model
         self.labels = labels
         self.filter_by = filter_by

--- a/nemo_curator/classifiers/base.py
+++ b/nemo_curator/classifiers/base.py
@@ -15,7 +15,7 @@ import os
 from dataclasses import dataclass
 
 os.environ["RAPIDS_NO_INITIALIZE"] = "1"
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import List, Optional, Union
 
 import torch
@@ -29,7 +29,7 @@ from nemo_curator.modules.base import Module
 from nemo_curator.utils.distributed_utils import get_gpu_memory_info
 
 
-class DistributedDataClassifier(ABC, Module):
+class DistributedDataClassifier(Module):
     """Abstract class for running multi-node multi-GPU data classification"""
 
     def __init__(
@@ -44,7 +44,7 @@ class DistributedDataClassifier(ABC, Module):
         device_type: str,
         autocast: bool,
     ):
-        Module.__init__(input_backend="cudf")
+        super().__init__(input_backend="cudf")
         self.model = model
         self.labels = labels
         self.filter_by = filter_by
@@ -55,7 +55,7 @@ class DistributedDataClassifier(ABC, Module):
         self.device_type = device_type
         self.autocast = autocast
 
-    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
         result_doc_dataset = self._run_classifier(dataset)
         if self.filter_by is not None:
             return self._filter_documents(result_doc_dataset)

--- a/nemo_curator/classifiers/base.py
+++ b/nemo_curator/classifiers/base.py
@@ -25,11 +25,11 @@ from huggingface_hub import PyTorchModelHubMixin
 from transformers import AutoModel
 
 from nemo_curator.datasets import DocumentDataset
-from nemo_curator.modules.base import Module
+from nemo_curator.modules.base import BaseModule
 from nemo_curator.utils.distributed_utils import get_gpu_memory_info
 
 
-class DistributedDataClassifier(Module):
+class DistributedDataClassifier(BaseModule):
     """Abstract class for running multi-node multi-GPU data classification"""
 
     def __init__(

--- a/nemo_curator/classifiers/base.py
+++ b/nemo_curator/classifiers/base.py
@@ -44,7 +44,7 @@ class DistributedDataClassifier(ABC, Module):
         device_type: str,
         autocast: bool,
     ):
-        super().__init__(input_backend="cudf")
+        Module.__init__(input_backend="cudf")
         self.model = model
         self.labels = labels
         self.filter_by = filter_by

--- a/nemo_curator/filters/doc_filter.py
+++ b/nemo_curator/filters/doc_filter.py
@@ -14,7 +14,7 @@
 
 import importlib
 from abc import ABC, abstractmethod
-from typing import Any, Union
+from typing import Any, Literal, Union
 
 from nemo_curator.filters.bitext_filter import BitextFilter
 
@@ -81,7 +81,8 @@ class DocumentFilter(ABC):
             "keep_document method must be implemented by subclasses"
         )
 
-    def get_backend(self) -> str:
+    @property
+    def backend(self) -> Literal["pandas", "cudf", "any"]:
         """
         The dataframe backend the filter operates on.
         Can be 'pandas', 'cudf', or 'any'. Defaults to 'pandas'.

--- a/nemo_curator/filters/doc_filter.py
+++ b/nemo_curator/filters/doc_filter.py
@@ -81,6 +81,15 @@ class DocumentFilter(ABC):
             "keep_document method must be implemented by subclasses"
         )
 
+    def get_backend(self) -> str:
+        """
+        The dataframe backend the filter operates on.
+        Can be 'pandas', 'cudf', or 'any'. Defaults to 'pandas'.
+        Returns:
+            str: A string representing the dataframe backend the filter needs as input
+        """
+        return "pandas"
+
     @property
     def name(self):
         return self._name

--- a/nemo_curator/modifiers/doc_modifier.py
+++ b/nemo_curator/modifiers/doc_modifier.py
@@ -26,3 +26,12 @@ class DocumentModifier(ABC):
     @abstractmethod
     def modify_document(self, text):
         pass
+
+    def get_backend(self) -> str:
+        """
+        The dataframe backend the filter operates on.
+        Can be 'pandas', 'cudf', or 'any'. Defaults to 'pandas'.
+        Returns:
+            str: A string representing the dataframe backend the filter needs as input
+        """
+        return "pandas"

--- a/nemo_curator/modifiers/doc_modifier.py
+++ b/nemo_curator/modifiers/doc_modifier.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
+from typing import Literal
 
 
 class DocumentModifier(ABC):
@@ -27,11 +28,12 @@ class DocumentModifier(ABC):
     def modify_document(self, text):
         pass
 
-    def get_backend(self) -> str:
+    @property
+    def backend(self) -> Literal["pandas", "cudf", "any"]:
         """
-        The dataframe backend the filter operates on.
+        The dataframe backend the modifier operates on.
         Can be 'pandas', 'cudf', or 'any'. Defaults to 'pandas'.
         Returns:
-            str: A string representing the dataframe backend the filter needs as input
+            str: A string representing the dataframe backend the modifier needs as input
         """
         return "pandas"

--- a/nemo_curator/modules/__init__.py
+++ b/nemo_curator/modules/__init__.py
@@ -22,7 +22,7 @@ os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
 from nemo_curator.utils.import_utils import gpu_only_import_from
 
 from .add_id import AddId
-from .base import Module
+from .base import BaseModule
 from .config import FuzzyDuplicatesConfig, SemDedupConfig
 from .dataset_ops import blend_datasets, Shuffle
 from .exact_dedup import ExactDuplicates
@@ -90,6 +90,6 @@ __all__ = [
     "ClusteringModel",
     "SemanticClusterLevelDedup",
     "SemDedup",
-    "Module",
+    "BaseModule",
     "ToBackend",
 ]

--- a/nemo_curator/modules/__init__.py
+++ b/nemo_curator/modules/__init__.py
@@ -22,6 +22,7 @@ os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
 from nemo_curator.utils.import_utils import gpu_only_import_from
 
 from .add_id import AddId
+from .base import Module
 from .config import FuzzyDuplicatesConfig, SemDedupConfig
 from .dataset_ops import blend_datasets, Shuffle
 from .exact_dedup import ExactDuplicates
@@ -88,4 +89,5 @@ __all__ = [
     "ClusteringModel",
     "SemanticClusterLevelDedup",
     "SemDedup",
+    "Module",
 ]

--- a/nemo_curator/modules/__init__.py
+++ b/nemo_curator/modules/__init__.py
@@ -29,6 +29,7 @@ from .exact_dedup import ExactDuplicates
 from .meta import Sequential
 from .modify import Modify
 from .task import TaskDecontamination
+from .to_backend import ToBackend
 
 # GPU packages
 MinHash = gpu_only_import_from("nemo_curator.modules.fuzzy_dedup.minhash", "MinHash")
@@ -90,4 +91,5 @@ __all__ = [
     "SemanticClusterLevelDedup",
     "SemDedup",
     "Module",
+    "ToBackend",
 ]

--- a/nemo_curator/modules/add_id.py
+++ b/nemo_curator/modules/add_id.py
@@ -19,11 +19,11 @@ import numpy as np
 from dask import delayed
 
 from nemo_curator.datasets import DocumentDataset
-from nemo_curator.modules.base import Module
+from nemo_curator.modules.base import BaseModule
 from nemo_curator.utils.module_utils import count_digits
 
 
-class AddId(Module):
+class AddId(BaseModule):
     def __init__(
         self, id_field, id_prefix: str = "doc_id", start_index: Optional[int] = None
     ) -> None:

--- a/nemo_curator/modules/add_id.py
+++ b/nemo_curator/modules/add_id.py
@@ -32,7 +32,7 @@ class AddId(Module):
         self.id_prefix = id_prefix
         self.start_index = start_index
 
-    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
         if self.start_index is None:
             return self._add_id_fast(dataset)
         else:

--- a/nemo_curator/modules/add_id.py
+++ b/nemo_curator/modules/add_id.py
@@ -19,13 +19,15 @@ import numpy as np
 from dask import delayed
 
 from nemo_curator.datasets import DocumentDataset
+from nemo_curator.modules.base import Module
 from nemo_curator.utils.module_utils import count_digits
 
 
-class AddId:
+class AddId(Module):
     def __init__(
         self, id_field, id_prefix: str = "doc_id", start_index: Optional[int] = None
     ) -> None:
+        super().__init__(input_backend="pandas")
         self.id_field = id_field
         self.id_prefix = id_prefix
         self.start_index = start_index

--- a/nemo_curator/modules/base.py
+++ b/nemo_curator/modules/base.py
@@ -13,14 +13,34 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
+from typing import Literal, Optional
+
+import dask.dataframe as dd
 
 from nemo_curator.datasets import DocumentDataset
 
 
-class Module(ABC):
+class BaseModule(ABC):
+    """
+    Base class for all NeMo Curator modules.
+
+    Handles validating that data lives on the correct device for each module
+    """
+
     SUPPORTED_BACKENDS = ["pandas", "cudf", "any"]
 
-    def __init__(self, input_backend: str, name=None) -> None:
+    def __init__(
+        self,
+        input_backend: Literal["pandas", "cudf", "any"],
+        name: Optional[str] = None,
+    ) -> None:
+        """
+        Constructs a Module
+
+        Args:
+            input_backend (Literal["pandas", "cudf", "any"]): The backend the input dataframe must be on for the module to work
+            name (str, Optional): The name of the module. If None, defaults to self.__class__.__name__
+        """
         super().__init__()
         self.name = name or self.__class__.__name__
 
@@ -31,10 +51,16 @@ class Module(ABC):
         self.input_backend = input_backend
 
     @abstractmethod
-    def call(self, dataset: DocumentDataset) -> DocumentDataset:
+    def call(self, dataset: DocumentDataset):
+        """
+        Performs an arbitrary operation on a dataset
+
+        Args:
+            dataset (DocumentDataset): The dataset to operate on
+        """
         raise NotImplementedError("call method must be implemented by subclasses")
 
-    def _check_backend(self, ddf):
+    def _validate_correct_backend(self, ddf: dd.DataFrame):
         if self.input_backend == "any":
             return
 
@@ -44,7 +70,13 @@ class Module(ABC):
                 f"Module {self.name} requires dataset to have backend {self.input_backend} but got backend {backend}"
             )
 
-    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
-        self._check_backend(dataset.df)
+    def __call__(self, dataset: DocumentDataset):
+        """
+        Validates the dataset is on the right backend, and performs an arbitrary operation on it
+
+        Args:
+            dataset (DocumentDataset): The dataset to operate on
+        """
+        self._validate_correct_backend(dataset.df)
 
         return self.call(dataset)

--- a/nemo_curator/modules/base.py
+++ b/nemo_curator/modules/base.py
@@ -18,6 +18,7 @@ from typing import Literal, Optional
 import dask.dataframe as dd
 
 from nemo_curator.datasets import DocumentDataset
+from nemo_curator.utils.gpu_utils import is_cudf_type
 
 
 class BaseModule(ABC):
@@ -64,10 +65,11 @@ class BaseModule(ABC):
         if self.input_backend == "any":
             return
 
-        backend = type(ddf._meta).__module__.split(".")[0]
+        backend = "cudf" if is_cudf_type(ddf) else "pandas"
         if backend != self.input_backend:
             raise ValueError(
-                f"Module {self.name} requires dataset to have backend {self.input_backend} but got backend {backend}"
+                f"Module {self.name} requires dataset to have backend {self.input_backend} but got backend {backend}."
+                "Try using nemo_curator.ToBackend to swap dataframe backends before running this module."
             )
 
     def __call__(self, dataset: DocumentDataset):

--- a/nemo_curator/modules/base.py
+++ b/nemo_curator/modules/base.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+
+from nemo_curator.datasets import DocumentDataset
+
+
+class Module(ABC):
+    SUPPORTED_BACKENDS = ["pandas", "cudf", "any"]
+
+    def __init__(self, input_backend: str, name=None) -> None:
+        super().__init__()
+        self.name = name or self.__class__.__name__
+
+        if input_backend not in self.SUPPORTED_BACKENDS:
+            raise ValueError(
+                f"{input_backend} not one of the supported backends {self.SUPPORTED_BACKENDS}"
+            )
+        self.input_backend = input_backend
+
+    @abstractmethod
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
+        raise NotImplementedError("call method must be implemented by subclasses")
+
+    def _check_backend(self, ddf):
+        if self.input_backend == "any":
+            return
+
+        backend = type(ddf._meta).__module__.split(".")[0]
+        if backend != self.input_backend:
+            raise ValueError(
+                f"Module {self.name} requires dataset to have backend {self.input_backend} but got backend {backend}"
+            )
+
+    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
+        self._check_backend(dataset.df)
+
+        return self.call(dataset)

--- a/nemo_curator/modules/dataset_ops.py
+++ b/nemo_curator/modules/dataset_ops.py
@@ -5,13 +5,14 @@ import dask.dataframe as dd
 import numpy as np
 
 from nemo_curator.datasets.doc_dataset import DocumentDataset
+from nemo_curator.modules.base import Module
 
 
 def default_filename(partition_num: int) -> str:
     return f"file_{partition_num:010d}.jsonl"
 
 
-class Shuffle:
+class Shuffle(Module):
     def __init__(
         self,
         seed: Optional[int] = None,
@@ -32,6 +33,7 @@ class Shuffle:
                 will look like given the partition number. The default method names the partition
                 f'file_{partition_num:010d}.jsonl' and should be changed if the user is not using a .jsonl format.
         """
+        super().__init__(input_backend="pandas")
         self.seed = seed
         self.npartitions = npartitions
         self.partition_to_filename = partition_to_filename

--- a/nemo_curator/modules/dataset_ops.py
+++ b/nemo_curator/modules/dataset_ops.py
@@ -40,7 +40,7 @@ class Shuffle(Module):
         self.rand_col = "_shuffle_rand"
         self.filename_col = filename_col
 
-    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
         if self.seed is None:
             return self.shuffle_nondeterministic(dataset)
         else:

--- a/nemo_curator/modules/dataset_ops.py
+++ b/nemo_curator/modules/dataset_ops.py
@@ -5,14 +5,14 @@ import dask.dataframe as dd
 import numpy as np
 
 from nemo_curator.datasets.doc_dataset import DocumentDataset
-from nemo_curator.modules.base import Module
+from nemo_curator.modules.base import BaseModule
 
 
 def default_filename(partition_num: int) -> str:
     return f"file_{partition_num:010d}.jsonl"
 
 
-class Shuffle(Module):
+class Shuffle(BaseModule):
     def __init__(
         self,
         seed: Optional[int] = None,

--- a/nemo_curator/modules/exact_dedup.py
+++ b/nemo_curator/modules/exact_dedup.py
@@ -137,7 +137,7 @@ class ExactDuplicates(Module):
             # TODO: Generalize ty using self.hash_method
             return df.apply(lambda x: md5(x.encode()).hexdigest())
 
-    def __call__(self, dataset: DocumentDataset) -> Union[DocumentDataset, str]:
+    def call(self, dataset: DocumentDataset) -> Union[DocumentDataset, str]:
         """
         Find document ID's for exact duplicates in a given DocumentDataset
         Parameters

--- a/nemo_curator/modules/exact_dedup.py
+++ b/nemo_curator/modules/exact_dedup.py
@@ -29,12 +29,12 @@ from dask import dataframe as dd
 from nemo_curator._compat import DASK_P2P_ERROR
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.log import create_logger
-from nemo_curator.modules.base import Module
+from nemo_curator.modules.base import BaseModule
 from nemo_curator.utils.distributed_utils import performance_report_if_with_ts_suffix
 from nemo_curator.utils.gpu_utils import is_cudf_type
 
 
-class ExactDuplicates(Module):
+class ExactDuplicates(BaseModule):
     """Find exact duplicates in a document corpus"""
 
     SUPPORTED_HASHES = {"md5"}

--- a/nemo_curator/modules/exact_dedup.py
+++ b/nemo_curator/modules/exact_dedup.py
@@ -29,11 +29,12 @@ from dask import dataframe as dd
 from nemo_curator._compat import DASK_P2P_ERROR
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.log import create_logger
+from nemo_curator.modules.base import Module
 from nemo_curator.utils.distributed_utils import performance_report_if_with_ts_suffix
 from nemo_curator.utils.gpu_utils import is_cudf_type
 
 
-class ExactDuplicates:
+class ExactDuplicates(Module):
     """Find exact duplicates in a document corpus"""
 
     SUPPORTED_HASHES = {"md5"}
@@ -59,6 +60,7 @@ class ExactDuplicates:
         cache_dir: str, Default None
           If specified, will compute & write duplicate id's to cache directory.
         """
+        super().__init__(input_backend="any")
 
         if hash_method not in self.SUPPORTED_HASHES:
             raise ValueError(

--- a/nemo_curator/modules/filter.py
+++ b/nemo_curator/modules/filter.py
@@ -63,7 +63,7 @@ class Score(Module):
         self.text_field = text_field
         self.score_type = score_type
 
-    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
         """
         Applies the scoring to a dataset
 
@@ -137,7 +137,7 @@ class Filter(Module):
 
         return bool_mask
 
-    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
         """
         Applies the filtering to a dataset
 
@@ -223,7 +223,7 @@ class ScoreFilter(Module):
 
         return bool_mask
 
-    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
         """
         Scores and filters all records in the dataset
 
@@ -275,7 +275,7 @@ class ParallelScoreFilter(Module):
             tgt_filter_obj, tgt_field, tgt_score, score_type, invert
         )
 
-    def __call__(self, dataset: ParallelDataset):
+    def call(self, dataset: ParallelDataset):
         src_bool_mask = self.source_score_filter.compute_filter_mask(dataset)
         tgt_bool_mask = self.target_score_filter.compute_filter_mask(dataset)
 

--- a/nemo_curator/modules/filter.py
+++ b/nemo_curator/modules/filter.py
@@ -22,7 +22,7 @@ from dask.typing import no_default
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.datasets.parallel_dataset import ParallelDataset
 from nemo_curator.filters import DocumentFilter
-from nemo_curator.modules.base import Module
+from nemo_curator.modules.base import BaseModule
 from nemo_curator.utils.module_utils import is_batched
 
 # Override so that pd.NA is not passed during the metadata inference
@@ -32,7 +32,7 @@ make_array_nonempty.register(
 )
 
 
-class Score(Module):
+class Score(BaseModule):
     """
     The module responsible for adding metadata to records based on statistics about the text.
     It accepts an arbitrary scoring function that accepts a text field and returns a score.
@@ -91,7 +91,7 @@ class Score(Module):
         return dataset
 
 
-class Filter(Module):
+class Filter(BaseModule):
     """
     The module responsible for filtering records based on a metadata field.
     It accepts an arbitrary filter function that accepts a metadata field and returns True if the field should be kept.
@@ -151,7 +151,7 @@ class Filter(Module):
         return DocumentDataset(dataset.df[bool_mask])
 
 
-class ScoreFilter(Module):
+class ScoreFilter(BaseModule):
     """
     The module responsible for applying a filter to all documents in a DocumentDataset.
     It accepts an arbitrary DocumentFilter and first computes the score for a document.
@@ -179,7 +179,7 @@ class ScoreFilter(Module):
           score_type (Union[type, str]): The datatype of the score that will be made for each document.
           invert (bool): If True, will keep all documents that are normally discarded.
         """
-        super().__init__(input_backend=filter_obj.get_backend())
+        super().__init__(input_backend=filter_obj.backend)
         self.filter_obj = filter_obj
         self.text_field = text_field
         self.score_field = score_field
@@ -237,7 +237,7 @@ class ScoreFilter(Module):
         return DocumentDataset(dataset.df[bool_mask])
 
 
-class ParallelScoreFilter(Module):
+class ParallelScoreFilter(BaseModule):
     def __init__(
         self,
         src_filter_obj,
@@ -267,7 +267,7 @@ class ParallelScoreFilter(Module):
             score_type (Optional[str]): The datatype of the score that will be made for each document. Defaults to None.
             invert (bool, optional): If True, will keep all documents that are normally discarded. Defaults to False.
         """
-        super().__init__(input_backend=src_filter_obj.get_backend())
+        super().__init__(input_backend=src_filter_obj.backend)
         self.source_score_filter = ScoreFilter(
             src_filter_obj, src_field, src_score, score_type, invert
         )

--- a/nemo_curator/modules/filter.py
+++ b/nemo_curator/modules/filter.py
@@ -22,6 +22,7 @@ from dask.typing import no_default
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.datasets.parallel_dataset import ParallelDataset
 from nemo_curator.filters import DocumentFilter
+from nemo_curator.modules.base import Module
 from nemo_curator.utils.module_utils import is_batched
 
 # Override so that pd.NA is not passed during the metadata inference
@@ -31,7 +32,7 @@ make_array_nonempty.register(
 )
 
 
-class Score:
+class Score(Module):
     """
     The module responsible for adding metadata to records based on statistics about the text.
     It accepts an arbitrary scoring function that accepts a text field and returns a score.
@@ -56,6 +57,7 @@ class Score:
           text_field (str): The field the documents will be read from.
           score_type (Union[type, str]): The datatype of the score that will be made for each document.
         """
+        super().__init__(input_backend="pandas")
         self.score_fn = score_fn
         self.score_field = score_field
         self.text_field = text_field
@@ -89,7 +91,7 @@ class Score:
         return dataset
 
 
-class Filter:
+class Filter(Module):
     """
     The module responsible for filtering records based on a metadata field.
     It accepts an arbitrary filter function that accepts a metadata field and returns True if the field should be kept.
@@ -107,6 +109,7 @@ class Filter:
           filter_field (str): The field(s) to be passed into the filter function.
           invert (bool): Whether to invert the filter condition.
         """
+        super().__init__(input_backend="pandas")
         self.filter_fn = filter_fn
         self.filter_field = filter_field
         self.invert = invert
@@ -148,7 +151,7 @@ class Filter:
         return DocumentDataset(dataset.df[bool_mask])
 
 
-class ScoreFilter:
+class ScoreFilter(Module):
     """
     The module responsible for applying a filter to all documents in a DocumentDataset.
     It accepts an arbitrary DocumentFilter and first computes the score for a document.
@@ -176,6 +179,7 @@ class ScoreFilter:
           score_type (Union[type, str]): The datatype of the score that will be made for each document.
           invert (bool): If True, will keep all documents that are normally discarded.
         """
+        super().__init__(input_backend=filter_obj.get_backend())
         self.filter_obj = filter_obj
         self.text_field = text_field
         self.score_field = score_field
@@ -233,7 +237,7 @@ class ScoreFilter:
         return DocumentDataset(dataset.df[bool_mask])
 
 
-class ParallelScoreFilter:
+class ParallelScoreFilter(Module):
     def __init__(
         self,
         src_filter_obj,
@@ -263,7 +267,7 @@ class ParallelScoreFilter:
             score_type (Optional[str]): The datatype of the score that will be made for each document. Defaults to None.
             invert (bool, optional): If True, will keep all documents that are normally discarded. Defaults to False.
         """
-
+        super().__init__(input_backend=src_filter_obj.get_backend())
         self.source_score_filter = ScoreFilter(
             src_filter_obj, src_field, src_score, score_type, invert
         )

--- a/nemo_curator/modules/fuzzy_dedup/fuzzyduplicates.py
+++ b/nemo_curator/modules/fuzzy_dedup/fuzzyduplicates.py
@@ -23,6 +23,7 @@ import dask_cudf
 
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.log import create_logger
+from nemo_curator.modules.base import Module
 from nemo_curator.modules.config import FuzzyDuplicatesConfig
 from nemo_curator.modules.fuzzy_dedup._mapbuckets import _MapBuckets
 from nemo_curator.modules.fuzzy_dedup._shuffle import _Shuffle
@@ -35,7 +36,7 @@ from nemo_curator.modules.meta import Sequential
 from nemo_curator.utils.distributed_utils import performance_report_if_with_ts_suffix
 
 
-class FuzzyDuplicates:
+class FuzzyDuplicates(Module):
     def __init__(
         self,
         config: FuzzyDuplicatesConfig,
@@ -53,6 +54,7 @@ class FuzzyDuplicates:
         DocumentDataset containing IDs of all documents and the corresponding duplicate group
         they belong to. Documents in the same group are near duplicates.
         """
+        super().__init__(input_backend="cudf")
         if isinstance(logger, str):
             self._logger = create_logger(
                 rank=0,

--- a/nemo_curator/modules/fuzzy_dedup/fuzzyduplicates.py
+++ b/nemo_curator/modules/fuzzy_dedup/fuzzyduplicates.py
@@ -23,7 +23,7 @@ import dask_cudf
 
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.log import create_logger
-from nemo_curator.modules.base import Module
+from nemo_curator.modules.base import BaseModule
 from nemo_curator.modules.config import FuzzyDuplicatesConfig
 from nemo_curator.modules.fuzzy_dedup._mapbuckets import _MapBuckets
 from nemo_curator.modules.fuzzy_dedup._shuffle import _Shuffle
@@ -36,7 +36,7 @@ from nemo_curator.modules.meta import Sequential
 from nemo_curator.utils.distributed_utils import performance_report_if_with_ts_suffix
 
 
-class FuzzyDuplicates(Module):
+class FuzzyDuplicates(BaseModule):
     def __init__(
         self,
         config: FuzzyDuplicatesConfig,

--- a/nemo_curator/modules/fuzzy_dedup/fuzzyduplicates.py
+++ b/nemo_curator/modules/fuzzy_dedup/fuzzyduplicates.py
@@ -131,7 +131,7 @@ class FuzzyDuplicates(Module):
             profile_dir=self.config.profile_dir,
         )
 
-    def __call__(self, dataset: DocumentDataset):
+    def call(self, dataset: DocumentDataset):
         """
         Parameters
         ----------

--- a/nemo_curator/modules/modify.py
+++ b/nemo_curator/modules/modify.py
@@ -19,7 +19,7 @@ from nemo_curator.utils.module_utils import is_batched
 
 class Modify(BaseModule):
     def __init__(self, modifier: DocumentModifier, text_field="text"):
-        super().__init__(input_backend=modifier.get_backend())
+        super().__init__(input_backend=modifier.backend)
         self.modifier = modifier
         self.text_field = text_field
 

--- a/nemo_curator/modules/modify.py
+++ b/nemo_curator/modules/modify.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.modifiers import DocumentModifier
-from nemo_curator.modules.base import Module
+from nemo_curator.modules.base import BaseModule
 from nemo_curator.utils.module_utils import is_batched
 
 
-class Modify(Module):
+class Modify(BaseModule):
     def __init__(self, modifier: DocumentModifier, text_field="text"):
         super().__init__(input_backend=modifier.get_backend())
         self.modifier = modifier

--- a/nemo_curator/modules/modify.py
+++ b/nemo_curator/modules/modify.py
@@ -23,7 +23,7 @@ class Modify(Module):
         self.modifier = modifier
         self.text_field = text_field
 
-    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
         if is_batched(self.modifier.modify_document):
             dataset.df[self.text_field] = dataset.df[self.text_field].map_partitions(
                 self.modifier.modify_document, meta=(None, str)

--- a/nemo_curator/modules/modify.py
+++ b/nemo_curator/modules/modify.py
@@ -11,14 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.modifiers import DocumentModifier
+from nemo_curator.modules.base import Module
 from nemo_curator.utils.module_utils import is_batched
 
 
-class Modify:
+class Modify(Module):
     def __init__(self, modifier: DocumentModifier, text_field="text"):
+        super().__init__(input_backend=modifier.get_backend())
         self.modifier = modifier
         self.text_field = text_field
 

--- a/nemo_curator/modules/semantic_dedup/semdedup.py
+++ b/nemo_curator/modules/semantic_dedup/semdedup.py
@@ -82,7 +82,7 @@ class SemDedup(Module):
         self.eps_thresholds = config.eps_thresholds
         self.eps_to_extract = config.eps_to_extract
 
-    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
         """
         Execute the SemDedup process.
 

--- a/nemo_curator/modules/semantic_dedup/semdedup.py
+++ b/nemo_curator/modules/semantic_dedup/semdedup.py
@@ -18,6 +18,7 @@ import os
 from typing import Union
 
 from nemo_curator.datasets import DocumentDataset
+from nemo_curator.modules.base import Module
 from nemo_curator.modules.config import SemDedupConfig
 from nemo_curator.modules.semantic_dedup.clusteringmodel import ClusteringModel
 from nemo_curator.modules.semantic_dedup.embeddings import EmbeddingCreator
@@ -26,7 +27,7 @@ from nemo_curator.modules.semantic_dedup.semanticclusterleveldedup import (
 )
 
 
-class SemDedup:
+class SemDedup(Module):
     def __init__(
         self,
         config: SemDedupConfig,
@@ -42,6 +43,7 @@ class SemDedup:
             config (SemDedupConfig): Configuration for SemDedup.
             logger (Union[logging.Logger, str]): Logger instance or path to the log file directory.
         """
+        super().__init__(input_backend="cudf")
         self.config = config
         self.logger = logger
         cache_dir = config.cache_dir

--- a/nemo_curator/modules/semantic_dedup/semdedup.py
+++ b/nemo_curator/modules/semantic_dedup/semdedup.py
@@ -18,7 +18,7 @@ import os
 from typing import Union
 
 from nemo_curator.datasets import DocumentDataset
-from nemo_curator.modules.base import Module
+from nemo_curator.modules.base import BaseModule
 from nemo_curator.modules.config import SemDedupConfig
 from nemo_curator.modules.semantic_dedup.clusteringmodel import ClusteringModel
 from nemo_curator.modules.semantic_dedup.embeddings import EmbeddingCreator
@@ -27,7 +27,7 @@ from nemo_curator.modules.semantic_dedup.semanticclusterleveldedup import (
 )
 
 
-class SemDedup(Module):
+class SemDedup(BaseModule):
     def __init__(
         self,
         config: SemDedupConfig,

--- a/nemo_curator/modules/task.py
+++ b/nemo_curator/modules/task.py
@@ -20,13 +20,13 @@ import dask.dataframe as dd
 from dask import delayed
 
 from nemo_curator.datasets import DocumentDataset
-from nemo_curator.modules.base import Module
+from nemo_curator.modules.base import BaseModule
 from nemo_curator.tasks.downstream_task import DownstreamTask
 from nemo_curator.utils.distributed_utils import single_partition_write_with_filename
 from nemo_curator.utils.text_utils import get_words
 
 
-class TaskDecontamination(Module):
+class TaskDecontamination(BaseModule):
     def __init__(
         self,
         tasks: Union[DownstreamTask, Iterable[DownstreamTask]],

--- a/nemo_curator/modules/task.py
+++ b/nemo_curator/modules/task.py
@@ -20,12 +20,13 @@ import dask.dataframe as dd
 from dask import delayed
 
 from nemo_curator.datasets import DocumentDataset
+from nemo_curator.modules.base import Module
 from nemo_curator.tasks.downstream_task import DownstreamTask
 from nemo_curator.utils.distributed_utils import single_partition_write_with_filename
 from nemo_curator.utils.text_utils import get_words
 
 
-class TaskDecontamination:
+class TaskDecontamination(Module):
     def __init__(
         self,
         tasks: Union[DownstreamTask, Iterable[DownstreamTask]],
@@ -47,6 +48,7 @@ class TaskDecontamination:
             max_splits: The maximum number of times a document may be split before being entirely discarded.
             removed_dir: If not None, the documents split too many times will be written to this directory using the filename in the dataset.
         """
+        super().__init__(input_backend="pandas")
         if isinstance(tasks, DownstreamTask):
             tasks = [tasks]
         self.tasks = tasks

--- a/nemo_curator/modules/task.py
+++ b/nemo_curator/modules/task.py
@@ -60,7 +60,7 @@ class TaskDecontamination(Module):
         self.max_splits = max_splits
         self.removed_dir = removed_dir
 
-    def __call__(self, dataset: DocumentDataset) -> DocumentDataset:
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
 
         # Convert the dataframe to delayed objects for complex operations
         original_meta = dataset.df.dtypes.to_dict()

--- a/nemo_curator/modules/to_backend.py
+++ b/nemo_curator/modules/to_backend.py
@@ -11,13 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Literal
 
 from nemo_curator.datasets.doc_dataset import DocumentDataset
-from nemo_curator.modules.base import Module
+from nemo_curator.modules.base import BaseModule
 
 
-class ToBackend(Module):
-    def __init__(self, backend: str) -> None:
+class ToBackend(BaseModule):
+    """
+    A module for moving dataframes between backends.
+    """
+
+    def __init__(self, backend: Literal["pandas", "cudf"]) -> None:
+        """
+        Constructs a ToBackend module
+
+        Args:
+            backend (str): The backend to transfer the dataset to. Can be "pandas" or "cudf"
+        """
         super().__init__(input_backend="any")
         self.backend = backend
 

--- a/nemo_curator/modules/to_backend.py
+++ b/nemo_curator/modules/to_backend.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo_curator.datasets.doc_dataset import DocumentDataset
+from nemo_curator.modules.base import Module
+
+
+class ToBackend(Module):
+    def __init__(self, backend: str) -> None:
+        super().__init__(input_backend="any")
+        self.backend = backend
+
+    def call(self, dataset: DocumentDataset) -> DocumentDataset:
+        return DocumentDataset(dataset.df.to_backend(self.backend))

--- a/nemo_curator/modules/to_backend.py
+++ b/nemo_curator/modules/to_backend.py
@@ -30,6 +30,10 @@ class ToBackend(BaseModule):
             backend (str): The backend to transfer the dataset to. Can be "pandas" or "cudf"
         """
         super().__init__(input_backend="any")
+        if backend not in BaseModule.SUPPORTED_BACKENDS:
+            raise ValueError(
+                f"Backend must be either 'pandas' or 'cudf', but got {backend}"
+            )
         self.backend = backend
 
     def call(self, dataset: DocumentDataset) -> DocumentDataset:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -212,3 +212,11 @@ class TestBackendSupport:
         result_df = result.df.compute()
         assert_eq(result_df["cpu_lengths"], gt_cpu_lengths)
         assert_eq(result_df["gpu_lengths"], gt_gpu_lengths)
+
+    def test_wrong_backend(self, cpu_data):
+        with pytest.raises(ValueError):
+            print("client", self.client)
+            dataset, _ = cpu_data
+            pipeline = GPUModule()
+            result = pipeline(dataset)
+            _ = result.df.compute()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import pandas as pd
+import pytest
+from dask.dataframe.utils import assert_eq
+from distributed import Client
+
+from nemo_curator import Module
+from nemo_curator.datasets import DocumentDataset
+from nemo_curator.utils.import_utils import gpu_only_import, gpu_only_import_from
+
+cudf = gpu_only_import("cudf")
+dask_cudf = gpu_only_import("dask_cudf")
+LocalCUDACluster = gpu_only_import_from("dask_cuda", "LocalCUDACluster")
+
+
+class CPUModule(Module):
+    def __init__(self):
+        super().__init__(input_backend="pandas")
+
+    def call(dataset: DocumentDataset):
+        dataset.df["cpu_length"] = dataset.df["text"].str.len()
+        return dataset
+
+
+class GPUModule(Module):
+    def __init__(self):
+        super().__init__(input_backend="cudf")
+
+    def call(dataset: DocumentDataset):
+        dataset.df["gpu_length"] = dataset.df["text"].str.len()
+        return dataset
+
+
+@pytest.fixture
+def cpu_data():
+    df = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 100, 200, 300],
+            "text": [
+                "The quick brown fox jumps over the lazy dog",
+                "The quick brown foxes jumps over the lazy dog",
+                "The quick brown wolf jumps over the lazy dog",
+                "The quick black cat jumps over the lazy dog",
+                "A test string",
+                "Another test string",
+                "A different object",
+            ],
+        }
+    )
+    gt_lengths = pd.Series([43, 45, 44, 43, 13, 19, 18], name="cpu_lengths")
+    return DocumentDataset.from_pandas(df), gt_lengths
+
+
+@pytest.fixture
+def gpu_data():
+    df = cudf.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 100, 200, 300],
+            "text": [
+                "The quick brown fox jumps over the lazy dog",
+                "The quick brown foxes jumps over the lazy dog",
+                "The quick brown wolf jumps over the lazy dog",
+                "The quick black cat jumps over the lazy dog",
+                "A test string",
+                "Another test string",
+                "A different object",
+            ],
+        }
+    )
+    df = dask_cudf.from_cudf(df, 2)
+    gt_lengths = cudf.Series([43, 45, 44, 43, 13, 19, 18], name="gpu_lengths")
+    return DocumentDataset(df), gt_lengths
+
+
+@pytest.mark.gpu
+class TestBackendSupport:
+    @pytest.fixture(autouse=True, scope="class")
+    def gpu_client(self, request):
+        with LocalCUDACluster(n_workers=1) as cluster, Client(cluster) as client:
+            request.cls.client = client
+            request.cls.cluster = cluster
+            yield
+
+    def test_pandas_backend(
+        self,
+        cpu_data,
+    ):
+        print("client", self.client)
+        dataset, gt_lengths = cpu_data
+        pipeline = CPUModule()
+        result = pipeline(dataset)
+        result_df = result.df.compute()
+        assert_eq(result_df["cpu_lengths"], gt_lengths)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Refactors all modules to inherit from `nemo_curator.modules.base.Module`. With this change, the base class now checks to see if the dataframe backend for the `Module` matches what is passed in, and will throw an error prior to computation if there is a mismatch. We also prove a new module `ToBackend()` that allows easy chaining of CPU and GPU modules.


## Usage
<!-- Potentially add a usage example below -->
```python
from nemo_curator import Module, Sequential, ToBackend
from nemo_curator.datasets import DocumentDataset

class CPUModule(Module):
    def __init__(self):
        super().__init__(input_backend="pandas")

    def call(self, dataset: DocumentDataset):
        dataset.df["cpu_lengths"] = dataset.df["text"].str.len()
        return dataset


class GPUModule(Module):
    def __init__(self):
        super().__init__(input_backend="cudf")

    def call(self, dataset: DocumentDataset):
        dataset.df["gpu_lengths"] = dataset.df["text"].str.len()
        return dataset

def main():
  client = get_client(cluster_type="gpu")
  # Load a dataset with a pandas CPU backend
  dataset = DocumentDataset.from_pandas(...)
  pipeline = Sequential([
    CPUModule(),
    ToBackend("cudf"),
    GPUModule(),
  ])

  curated_dataset = pipeline(dataset)
  curated_dataset.to_json(...)

if __name__ == "__main__":
  main()
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
