### PR TITLE
Add Partition On Logic 

### DIFF
--- a/nemo_curator/datasets/doc_dataset.py
+++ b/nemo_curator/datasets/doc_dataset.py
@@ -160,6 +160,7 @@ class DocumentDataset:
         output_path: str,
         write_to_filename: Union[bool, str] = False,
         keep_filename_column: bool = False,
+        partition_on: Optional[str] = None,
     ):
         """
         See nemo_curator.utils.distributed_utils.write_to_disk docstring for parameters.
@@ -170,6 +171,7 @@ class DocumentDataset:
             output_path=output_path,
             write_to_filename=write_to_filename,
             keep_filename_column=keep_filename_column,
+            partition_on=partition_on,
             output_type="jsonl",
         )
 
@@ -178,6 +180,7 @@ class DocumentDataset:
         output_path: str,
         write_to_filename: Union[bool, str] = False,
         keep_filename_column: bool = False,
+        partition_on: Optional[str] = None,
     ):
         """
         See nemo_curator.utils.distributed_utils.write_to_disk docstring for parameters.
@@ -188,6 +191,7 @@ class DocumentDataset:
             output_path=output_path,
             write_to_filename=write_to_filename,
             keep_filename_column=keep_filename_column,
+            partition_on=partition_on,
             output_type="parquet",
         )
 

--- a/nemo_curator/datasets/doc_dataset.py
+++ b/nemo_curator/datasets/doc_dataset.py
@@ -163,8 +163,26 @@ class DocumentDataset:
         partition_on: Optional[str] = None,
     ):
         """
-        See nemo_curator.utils.distributed_utils.write_to_disk docstring for parameters.
+        Writes the dataset to the specified path in JSONL format.
 
+        If `write_to_filename` is True, the DataFrame is expected to have a column
+        that specifies the filename for each document. This column can be named
+        `file_name` by default, or a custom name if `write_to_filename` is a string.
+
+        Args:
+            output_path (str): The directory or file path where the dataset will be written.
+            write_to_filename (Union[bool, str]): Determines how filenames are handled.
+                - If True, uses the `file_name` column in the DataFrame to determine filenames.
+                - If a string, uses that string as the column name for filenames.
+                - If False, writes all data to the specified `output_path`.
+            keep_filename_column (bool): If True, retains the filename column in the output.
+                If False, the filename column is dropped from the output.
+            partition_on (Optional[str]): The column name used to partition the data.
+                If specified, data is partitioned based on unique values in this column,
+                with each partition written to a separate directory.
+
+        For more details, refer to the `write_to_disk` function in
+        `nemo_curator.utils.distributed_utils`.
         """
         write_to_disk(
             df=self.df,
@@ -183,8 +201,26 @@ class DocumentDataset:
         partition_on: Optional[str] = None,
     ):
         """
-        See nemo_curator.utils.distributed_utils.write_to_disk docstring for parameters.
+        Writes the dataset to the specified path in Parquet format.
 
+        If `write_to_filename` is True, the DataFrame is expected to have a column
+        that specifies the filename for each document. This column can be named
+        `file_name` by default, or a custom name if `write_to_filename` is a string.
+
+        Args:
+            output_path (str): The directory or file path where the dataset will be written.
+            write_to_filename (Union[bool, str]): Determines how filenames are handled.
+                - If True, uses the `file_name` column in the DataFrame to determine filenames.
+                - If a string, uses that string as the column name for filenames.
+                - If False, writes all data to the specified `output_path`.
+            keep_filename_column (bool): If True, retains the filename column in the output.
+                If False, the filename column is dropped from the output.
+            partition_on (Optional[str]): The column name used to partition the data.
+                If specified, data is partitioned based on unique values in this column,
+                with each partition written to a separate directory.
+
+        For more details, refer to the `write_to_disk` function in
+        `nemo_curator.utils.distributed_utils`.
         """
         write_to_disk(
             df=self.df,

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -748,6 +748,7 @@ def single_partition_write_with_filename(
                         orient="records",
                         lines=True,
                         force_ascii=False,
+                        index=False,  # Only index=False is supported for orient="records"
                     )
                 else:
                     # See open issue here: https://github.com/rapidsai/cudf/issues/15211
@@ -759,6 +760,7 @@ def single_partition_write_with_filename(
                         orient="records",
                         lines=True,
                         force_ascii=False,
+                        index=False,  # Only index=False is supported for orient="records"
                     )
 
             elif output_type == "parquet":
@@ -973,14 +975,27 @@ def _write_to_jsonl_or_parquet(
                     orient="records",
                     lines=True,
                     force_ascii=False,
+                    index=False,  # Only index=False is supported for orient="records"
                 )
         else:
             if is_cudf_type(df):
                 # See open issue here: https://github.com/rapidsai/cudf/issues/15211
                 # df.to_json(output_path, orient="records", lines=True, engine="cudf", force_ascii=False)
-                df.to_json(output_path, orient="records", lines=True, force_ascii=False)
+                df.to_json(
+                    output_path,
+                    orient="records",
+                    lines=True,
+                    force_ascii=False,
+                    index=False,
+                )  # Only index=False is supported for orient="records"
             else:
-                df.to_json(output_path, orient="records", lines=True, force_ascii=False)
+                df.to_json(
+                    output_path,
+                    orient="records",
+                    lines=True,
+                    force_ascii=False,
+                    index=False,
+                )  # Only index=False is supported for orient="records"
     elif output_type == "parquet":
         df.to_parquet(output_path, write_index=False, partition_on=partition_on)
     else:

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -858,6 +858,9 @@ def write_to_disk(
                 If str, uses that as the filename column to write to.
         keep_filename_column: Boolean representing whether to keep or drop the filename column, if it exists.
         output_type: The type of output file to write. Can be "jsonl" or "parquet".
+        partition_on: The column name to partition the data on.
+                      If specified, the data will be partitioned based on the unique values in this column,
+                      and each partition will be written to a separate directory
     """
 
     filename_col = _resolve_filename_col(write_to_filename)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
This pull request introduces the ability to partition datasets when writing to JSONL or Parquet formats. It includes updates to the `DocumentDataset` and `write_to_disk` functions

## Usage

Writing a Partitioned Dataset to Disk

This example demonstrates how to partition your output files by a specific column (here, `category`). The output directory will contain subdirectories for each unique value in the partition column.

```python

import os
import json
import pandas as pd
import dask.dataframe as dd
from nemo_curator.datasets import DocumentDataset

# Create a sample dataset
data = {
    "id": [1, 2, 3, 4],
    "category": ["A", "B", "A", "B"],
    "value": [10, 20, 30, 40],
    "text": [
        "This is document 1",
        "This is document 2",
        "This is document 3",
        "This is document 4"
    ]
}
df = pd.DataFrame(data)
ddf = dd.from_pandas(df, npartitions=2)
dataset = DocumentDataset(ddf)

output_path = "output_partitioned"
# Write out the dataset in JSONL format, partitioning by the 'category' column.
# This will create subdirectories named like 'category=A' and 'category=B'
dataset.to_json(
    output_path=output_path,
    partition_on="category"
)

# (Optional) Print out the directory structure to verify the partitioning
for root, dirs, files in os.walk(output_path):
    print("Directory:", root)
    for d in dirs:
        print("  Subdirectory:", d)
    for f in files:
        print("  File:", f)

# Example output directory structure:
# output_partitioned/
# ├── category=A
# │   ├── part-0.part
# │   └── part-1.part
# └── category=B
#     ├── part-0.part
#     └── part-1.part

```
