### PR TITLE
Remove minhash conditional for 25.02

### DIFF
--- a/nemo_curator/_compat.py
+++ b/nemo_curator/_compat.py
@@ -44,7 +44,9 @@ except (ImportError, TypeError):
 DASK_SHUFFLE_METHOD_ARG = _dask_version > parse_version("2024.1.0")
 DASK_P2P_ERROR = _dask_version < parse_version("2023.10.0")
 DASK_SHUFFLE_CAST_DTYPE = _dask_version > parse_version("2023.12.0")
-DASK_CUDF_PARQUET_READ_INCONSISTENT_SCHEMA = _dask_cudf_version > parse_version("2025.02")
+DASK_CUDF_PARQUET_READ_INCONSISTENT_SCHEMA = _dask_cudf_version > parse_version(
+    "2025.02"
+)
 
 # Query-planning check (and cache)
 _DASK_QUERY_PLANNING_ENABLED = None

--- a/nemo_curator/_compat.py
+++ b/nemo_curator/_compat.py
@@ -39,22 +39,12 @@ try:
 except (ImportError, TypeError):
     CURRENT_CUDF_VERSION = parse_version("24.10.0")
 
-# TODO remove this once 25.02 becomes the base version of cudf in nemo-curator
-
-# minhash in < 24.12 used to have a minhash(txt) api which was deprecated in favor of
-# minhash(a, b) in 25.02 (in 24.12, minhash_permuted(a,b) was introduced)
-MINHASH_DEPRECATED_API = (
-    CURRENT_CUDF_VERSION.base_version < parse_version("24.12").base_version
-)
-MINHASH_PERMUTED_AVAILABLE = (CURRENT_CUDF_VERSION.major == 24) & (
-    CURRENT_CUDF_VERSION.minor == 12
-)
 
 # TODO: remove when dask min version gets bumped
 DASK_SHUFFLE_METHOD_ARG = _dask_version > parse_version("2024.1.0")
 DASK_P2P_ERROR = _dask_version < parse_version("2023.10.0")
 DASK_SHUFFLE_CAST_DTYPE = _dask_version > parse_version("2023.12.0")
-DASK_CUDF_PARQUET_READ_INCONSISTENT_SCHEMA = _dask_version > parse_version("2024.12")
+DASK_CUDF_PARQUET_READ_INCONSISTENT_SCHEMA = _dask_cudf_version > parse_version("2025.02")
 
 # Query-planning check (and cache)
 _DASK_QUERY_PLANNING_ENABLED = None

--- a/nemo_curator/_compat.py
+++ b/nemo_curator/_compat.py
@@ -45,7 +45,7 @@ DASK_SHUFFLE_METHOD_ARG = _dask_version > parse_version("2024.1.0")
 DASK_P2P_ERROR = _dask_version < parse_version("2023.10.0")
 DASK_SHUFFLE_CAST_DTYPE = _dask_version > parse_version("2023.12.0")
 DASK_CUDF_PARQUET_READ_INCONSISTENT_SCHEMA = _dask_cudf_version > parse_version(
-    "2025.02"
+    "25.2.0"
 )
 
 # Query-planning check (and cache)

--- a/nemo_curator/modules/fuzzy_dedup/minhash.py
+++ b/nemo_curator/modules/fuzzy_dedup/minhash.py
@@ -138,9 +138,7 @@ class MinHash:
         seeds_a = cudf.Series(seeds[:, 0], dtype="uint32")
         seeds_b = cudf.Series(seeds[:, 1], dtype="uint32")
 
-        return ser.str.minhash(
-            a=seeds_a, b=seeds_b, seed=seeds[0][0], width=char_ngram
-        )
+        return ser.str.minhash(a=seeds_a, b=seeds_b, seed=seeds[0][0], width=char_ngram)
 
     def minhash64(
         self, ser: cudf.Series, seeds: np.ndarray, char_ngram: int

--- a/tests/test_read_data.py
+++ b/tests/test_read_data.py
@@ -540,7 +540,6 @@ def test_read_data_different_columns_files_per_partition(
     assert len(df) == NUM_FILES * NUM_RECORDS
 
 
-# @pytest.mark.skip(reason="Parquet tests are failing after upgrading to RAPIDS 25.02")
 @pytest.mark.parametrize(
     "backend,file_type",
     [

--- a/tests/test_read_data.py
+++ b/tests/test_read_data.py
@@ -540,7 +540,7 @@ def test_read_data_different_columns_files_per_partition(
     assert len(df) == NUM_FILES * NUM_RECORDS
 
 
-@pytest.mark.skip(reason="Parquet tests are failing after upgrading to RAPIDS 25.02")
+# @pytest.mark.skip(reason="Parquet tests are failing after upgrading to RAPIDS 25.02")
 @pytest.mark.parametrize(
     "backend,file_type",
     [


### PR DESCRIPTION
## Description
Since now stable points to 25.02 we can remove the old conditionla logic we had to handle various minhash api's.

Also fixes an issue with dask_cudf.read_parquet inconssitent schema, we hope https://github.com/rapidsai/cudf/pull/17554 get's merged in 25.04

Closes https://github.com/NVIDIA/NeMo-Curator/issues/557.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
