### PR TITLE
Add a way to pass expected language to FastTextLangId filter

### DIFF
--- a/tutorials/bitext_cleaning/main.py
+++ b/tutorials/bitext_cleaning/main.py
@@ -23,6 +23,7 @@ from docbuilder import TedTalksDownloader
 from nemo_curator import ParallelScoreFilter, Sequential
 from nemo_curator.datasets.parallel_dataset import ParallelDataset
 from nemo_curator.filters import (
+    FastTextLangId,
     HistogramFilter,
     LengthRatioFilter,
     QualityEstimationFilter,
@@ -37,6 +38,10 @@ TGT_LANG = "de"
 
 SCRIPT_DIR_PATH = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(SCRIPT_DIR_PATH, "data")
+
+# If you want to test FastText language ID,
+# download the model from here first then update this with your local model path (https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.ftz)
+FAST_TEXT_MODEL_DIR = ""
 
 
 def download_files() -> str:
@@ -66,6 +71,15 @@ def filter_dataset(dataset: ParallelDataset, gpu: bool = False) -> ParallelDatas
             ),
         ]
     )
+
+    if FAST_TEXT_MODEL_DIR:
+        filters.modules.append(
+            ParallelScoreFilter(
+                FastTextLangId(model_path=FAST_TEXT_MODEL_DIR, lang=SRC_LANG),
+                FastTextLangId(model_path=FAST_TEXT_MODEL_DIR, lang=TGT_LANG),
+                score_type=str,
+            )
+        )
 
     if gpu:
         filters.modules.append(


### PR DESCRIPTION
## Description

Currently, FastTextLangId filter only supports filtering by a language ID filter, but sometimes, we know what the language the data is supposed to be, and it would be a useful addition to keep only the data that matches with the expected language.

We use two-letter ISO-639 code to denote languages.

## Usage

Passing an extra argument when initializing the filter will make it check against expected language, for example:

```
FastTextLangId(model_path=FAST_TEXT_MODEL_DIR, lang=SRC_LANG)
```

If `lang` argument is not passed, it falls back to the old behavior of filtering by minimum language ID score.

`bitext_filtering` tutorial is updated to demonstrate how this is used in a pipeline.

## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.

(FastTextLangId filter is currently only tested with a fake emulator class. Not sure how to best cover this change with test.)
