### PR TITLE
Add read_custom_data to DocumentDataset

### DIFF
--- a/nemo_curator/datasets/doc_dataset.py
+++ b/nemo_curator/datasets/doc_dataset.py
@@ -156,7 +156,7 @@ class DocumentDataset:
         )
 
     @classmethod
-    def read_custom_data(
+    def read_custom(
         cls,
         input_files: Union[str, List[str]],
         file_type: str,

--- a/nemo_curator/download/doc_builder.py
+++ b/nemo_curator/download/doc_builder.py
@@ -139,7 +139,7 @@ def _download_and_extract_single_partition(
         partition = read_single_partition(
             [output_path],
             backend="pandas",
-            filetype=output_type,
+            file_type=output_type,
             add_filename=filename_col,
         )
         return partition

--- a/nemo_curator/scripts/semdedup/clustering.py
+++ b/nemo_curator/scripts/semdedup/clustering.py
@@ -18,9 +18,9 @@ from datetime import datetime
 
 import dask_cudf
 
-from nemo_curator import ClusteringModel
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.log import create_logger
+from nemo_curator.modules import ClusteringModel
 from nemo_curator.modules.config import SemDedupConfig
 from nemo_curator.utils.distributed_utils import get_client
 from nemo_curator.utils.file_utils import expand_outdir_and_mkdir

--- a/nemo_curator/scripts/semdedup/compute_embeddings.py
+++ b/nemo_curator/scripts/semdedup/compute_embeddings.py
@@ -16,9 +16,9 @@ import logging
 import os
 import time
 
-from nemo_curator import EmbeddingCreator
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.log import create_logger
+from nemo_curator.modules import EmbeddingCreator
 from nemo_curator.modules.config import SemDedupConfig
 from nemo_curator.utils.distributed_utils import get_client, read_data
 from nemo_curator.utils.file_utils import expand_outdir_and_mkdir, get_remaining_files

--- a/nemo_curator/scripts/semdedup/extract_dedup_data.py
+++ b/nemo_curator/scripts/semdedup/extract_dedup_data.py
@@ -2,8 +2,8 @@ import logging
 import os
 from datetime import datetime
 
-from nemo_curator import SemanticClusterLevelDedup
 from nemo_curator.log import create_logger
+from nemo_curator.modules import SemanticClusterLevelDedup
 from nemo_curator.modules.config import SemDedupConfig
 from nemo_curator.utils.distributed_utils import get_client
 from nemo_curator.utils.script_utils import ArgumentHelper

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -28,7 +28,7 @@ import warnings
 from contextlib import nullcontext
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Union
+from typing import Callable, Dict, List, Literal, Optional, Union
 
 import dask.dataframe as dd
 import numpy as np
@@ -288,11 +288,11 @@ def _resolve_filename_col(filename: Union[bool, str]) -> Union[str, bool]:
 def select_columns(
     df: Union[dd.DataFrame, pd.DataFrame, "cudf.DataFrame"],
     columns: List[str],
-    filetype: Literal["jsonl", "json", "parquet"],
+    file_type: Literal["jsonl", "json", "parquet"],
     add_filename: Union[bool, str],
 ) -> Union[dd.DataFrame, pd.DataFrame, "cudf.DataFrame"]:
     # We exclude parquet because the parquet readers already support column selection
-    if filetype in ["jsonl", "json"] and columns is not None:
+    if file_type in ["jsonl", "json"] and columns is not None:
         if add_filename:
             filename_str = _resolve_filename_col(add_filename)
             if filename_str not in columns:
@@ -305,7 +305,7 @@ def select_columns(
 def read_single_partition(
     files: List[str],
     backend: Literal["cudf", "pandas"] = "cudf",
-    filetype: str = "jsonl",
+    file_type: str = "jsonl",
     add_filename: Union[bool, str] = False,
     input_meta: Union[str, dict] = None,
     io_columns: Optional[List[str]] = None,
@@ -321,6 +321,7 @@ def read_single_partition(
         add_filename: Whether to add a filename column to the DataFrame.
                 If True, a new column is added to the DataFrame called `file_name`.
                 If str, sets new column name. Default is False.
+        file_type: The type of the file to read.
         input_meta: A dictionary or a string formatted as a dictionary, which outlines
             the field names and their respective data types within the JSONL input file.
         columns: If not None, only these columns will be read from the file.
@@ -330,14 +331,14 @@ def read_single_partition(
         A cudf DataFrame or a pandas DataFrame.
 
     """
-    if input_meta is not None and filetype != "jsonl":
+    if input_meta is not None and file_type != "jsonl":
         warnings.warn(
             "input_meta is only valid for JSONL files and will be ignored for other "
             " file formats.."
         )
 
-    if filetype in ["jsonl", "json"]:
-        read_kwargs = {"lines": filetype == "jsonl"}
+    if file_type in ["jsonl", "json"]:
+        read_kwargs = {"lines": file_type == "jsonl"}
         if backend == "cudf":
             read_f = cudf.read_json
             if input_meta is not None:
@@ -348,14 +349,16 @@ def read_single_partition(
 
         if input_meta is not None:
             read_kwargs["dtype"] = (
-                ast.literal_eval(input_meta) if type(input_meta) == str else input_meta
+                ast.literal_eval(input_meta)
+                if isinstance(input_meta, str)
+                else input_meta
             )
             # because pandas doesn't support `prune_columns`, it'll always return all columns even when input_meta is specified
             # to maintain consistency we explicitly set `io_columns` here
             if backend == "pandas" and not io_columns:
                 io_columns = list(read_kwargs["dtype"].keys())
 
-    elif filetype == "parquet":
+    elif file_type == "parquet":
         read_kwargs = {"columns": io_columns}
         if backend == "cudf":
             read_f = cudf.read_parquet
@@ -385,13 +388,13 @@ def read_single_partition(
             df = read_f(file, **read_kwargs, **kwargs)
             if add_filename:
                 df[_resolve_filename_col(add_filename)] = os.path.basename(file)
-            df = select_columns(df, io_columns, filetype, add_filename)
+            df = select_columns(df, io_columns, file_type, add_filename)
             df_ls.append(df)
 
         df = concat_f(df_ls, ignore_index=True)
     else:
         df = read_f(files, **read_kwargs, **kwargs)
-        df = select_columns(df, io_columns, filetype, add_filename)
+        df = select_columns(df, io_columns, file_type, add_filename)
     return df
 
 
@@ -405,7 +408,6 @@ def read_data_blocksize(
     columns: Optional[List[str]] = None,
     **kwargs,
 ) -> dd.DataFrame:
-
     read_kwargs = dict()
 
     if file_type == "jsonl":
@@ -482,10 +484,26 @@ def read_data_files_per_partition(
     backend: Literal["cudf", "pandas"] = "cudf",
     add_filename: Union[bool, str] = False,
     files_per_partition: Optional[int] = None,
-    input_meta: Union[str, dict] = None,
+    input_meta: Optional[Union[str, dict]] = None,
     columns: Optional[List[str]] = None,
+    read_func_single_partition: Optional[
+        Callable[
+            [List[str], str, bool, Union[str, dict], dict],  # Input type
+            Union[dd.DataFrame, pd.DataFrame],  # Return type
+        ]
+    ] = None,
     **kwargs,
 ) -> dd.DataFrame:
+    if read_func_single_partition is None:
+        read_func_single_partition = read_single_partition
+        read_func_single_partition_kwargs = dict(
+            enforce_metadata=False,
+            io_columns=columns,
+            **kwargs,
+        )
+    else:
+        read_func_single_partition_kwargs = kwargs
+
     if files_per_partition > 1:
         input_files = [
             input_files[i : i + files_per_partition]
@@ -495,15 +513,13 @@ def read_data_files_per_partition(
         input_files = [[file] for file in input_files]
 
     output = dd.from_map(
-        read_single_partition,
+        read_func_single_partition,
         input_files,
-        filetype=file_type,
+        file_type=file_type,
         backend=backend,
         add_filename=add_filename,
         input_meta=input_meta,
-        enforce_metadata=False,
-        io_columns=columns,
-        **kwargs,
+        **read_func_single_partition_kwargs,
     )
     output = output[sorted(output.columns)]
     return output
@@ -544,6 +560,12 @@ def read_data(
     add_filename: Union[bool, str] = False,
     input_meta: Union[str, dict] = None,
     columns: Optional[List[str]] = None,
+    read_func_single_partition: Optional[
+        Callable[
+            [List[str], str, bool, Union[str, dict], dict],  # Input type
+            Union[dd.DataFrame, pd.DataFrame],  # Return type
+        ]
+    ] = None,
     **kwargs,
 ) -> dd.DataFrame:
     """
@@ -553,12 +575,22 @@ def read_data(
         input_files: The path of the input file(s).
         file_type: The type of the input file(s).
         backend: The backend to use for reading the data.
-        files_per_partition: The number of files to read per partition.
+        blocksize: The size of desired indidivudal partition to be read from files. Either blocksize or files_per_partition must be set.
+        files_per_partition: The number of files to read per partition. Either blocksize or files_per_partition must be set.
         add_filename: Whether to add a "file_name" column to the DataFrame.
         input_meta: A dictionary or a string formatted as a dictionary, which outlines
             the field names and their respective data types within the JSONL input file.
         columns: If not None, only these columns will be read from the file.
             There is a significant performance gain when specifying columns for Parquet files.
+        read_func_single_partition: A function that reads a single partition of data.
+            This can only be used in conjunction with files_per_partition.
+            The function should take the following arguments:
+                - files: A list of file paths that will be read in a single partition.
+                - file_type: The type of the file to read (in case you want to handle different file types differently).
+                - backend: The backend to use for reading the data. (cudf or pandas)
+                - add_filename: Read below
+                - columns: Read below
+                - input_meta: Read below
 
     Returns:
         A Dask-cuDF or a Dask-pandas DataFrame.
@@ -569,7 +601,19 @@ def read_data(
 
     check_dask_cwd(input_files)
 
-    if file_type == "pickle":
+    if read_func_single_partition is not None and files_per_partition is not None:
+        return read_data_files_per_partition(
+            input_files,
+            file_type=file_type,
+            backend=backend,
+            add_filename=add_filename,
+            files_per_partition=files_per_partition,
+            input_meta=input_meta,
+            columns=columns,
+            read_func_single_partition=read_func_single_partition,
+            **kwargs,
+        )
+    elif file_type == "pickle":
         df = read_pandas_pickle(
             input_files[0], add_filename=add_filename, columns=columns, **kwargs
         )
@@ -626,6 +670,7 @@ def read_data(
                 files_per_partition=files_per_partition,
                 input_meta=input_meta,
                 columns=columns,
+                read_func_single_partition=read_func_single_partition,
                 **kwargs,
             )
     else:
@@ -899,7 +944,6 @@ def write_to_disk(
 
     # output_path is a directory
     if write_to_filename and output_type != "bitext":
-
         os.makedirs(output_path, exist_ok=True)
         output = df.map_partitions(
             single_partition_write_with_filename,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,25 +1,10 @@
-import dask.dataframe as dd
 import pandas as pd
 
-import nemo_curator as nc
 from nemo_curator.datasets import DocumentDataset
 
 
-def all_equal(left_result: pd.DataFrame, right_result: pd.DataFrame):
-    l_cols = set(left_result.columns)
-    r_cols = set(right_result.columns)
-    assert l_cols == r_cols
-    for col in left_result.columns:
-        left = left_result[col].reset_index(drop=True)
-        right = right_result[col].reset_index(drop=True)
-        assert all(left == right), f"Mismatch in {col} column.\n{left}\n{right}\n"
-
-
-class TestDocumentDataset:
-    def test_to_from_pandas(self):
-        original_df = pd.DataFrame(
-            {"first_col": [1, 2, 3], "second_col": ["a", "b", "c"]}
-        )
-        dataset = DocumentDataset.from_pandas(original_df)
-        converted_df = dataset.to_pandas()
-        all_equal(original_df, converted_df)
+def test_to_from_pandas():
+    original_df = pd.DataFrame({"first_col": [1, 2, 3], "second_col": ["a", "b", "c"]})
+    dataset = DocumentDataset.from_pandas(original_df)
+    converted_df = dataset.to_pandas()
+    pd.testing.assert_frame_equal(original_df, converted_df)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -150,7 +150,7 @@ class TestIO:
     @pytest.mark.parametrize(
         "backend", ["pandas", pytest.param("cudf", marks=pytest.mark.gpu)]
     )
-    def test_read_custom_data(
+    def test_read_custom(
         self, jsonl_dataset: str, backend: Literal["pandas", "cudf"]
     ):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -172,7 +172,7 @@ class TestIO:
                 )
                 return df
 
-            dataset = DocumentDataset.read_custom_data(
+            dataset = DocumentDataset.read_custom(
                 input_files=tmp_dir,
                 file_type="pkl",
                 read_func_single_partition=read_npy_file,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import json
+import math
 import os
+import pickle
 import random
 import string
 import tempfile
 from datetime import datetime, timedelta
+from typing import List, Literal
 
 import pandas as pd
 import pytest
@@ -144,6 +147,48 @@ class TestIO:
             output_meta == expected_meta
         ), f"Expected: {expected_meta}, got: {output_meta}"
 
+    @pytest.mark.parametrize(
+        "backend", ["pandas", pytest.param("cudf", marks=pytest.mark.gpu)]
+    )
+    def test_read_custom_data(
+        self, jsonl_dataset: str, backend: Literal["pandas", "cudf"]
+    ):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            num_lines = jsonl_dataset.count("\n")
+            for i, line in enumerate(jsonl_dataset.split("\n")):
+                with open(os.path.join(tmp_dir, f"test_{i}.pkl"), "wb") as f:
+                    pickle.dump(line, f)
+
+            def read_npy_file(
+                files: List[str], backend: Literal["cudf", "pandas"], **kwargs
+            ):
+                if backend == "cudf":
+                    import cudf as df_backend
+                else:
+                    import pandas as df_backend
+
+                df = df_backend.DataFrame(
+                    [{**json.loads(pickle.load(open(file, "rb")))} for file in files],
+                )
+                return df
+
+            dataset = DocumentDataset.read_custom_data(
+                input_files=tmp_dir,
+                file_type="pkl",
+                read_func_single_partition=read_npy_file,
+                files_per_partition=2,
+            )
+            assert dataset.df.npartitions == math.ceil(num_lines / 2)
+            expected_df = pd.DataFrame(map(json.loads, jsonl_dataset.split("\n")))
+            pd.testing.assert_frame_equal(
+                dataset.df.to_backend("pandas")
+                .compute()
+                .sort_values(by="id", ignore_index=True),
+                expected_df[["date", "id", "text"]].sort_values(
+                    by="id", ignore_index=True
+                ),  # because we sort columns by name
+            )
+
 
 class TestWriteWithFilename:
     @pytest.mark.parametrize("keep_filename_column", [True, False])
@@ -168,12 +213,12 @@ class TestWriteWithFilename:
             df = df.drop(filename_col, axis=1)
 
         df1 = read_single_partition(
-            files=[tmp_path / f"file0.{file_ext}"], backend="pandas", filetype=file_ext
+            files=[tmp_path / f"file0.{file_ext}"], backend="pandas", file_type=file_ext
         )
         assert_eq(df1, df.iloc[0:1], check_index=False)
 
         df2 = read_single_partition(
-            files=[tmp_path / f"file1.{file_ext}"], backend="pandas", filetype=file_ext
+            files=[tmp_path / f"file1.{file_ext}"], backend="pandas", file_type=file_ext
         )
         assert_eq(df2, df.iloc[1:3], check_index=False)
 
@@ -199,7 +244,7 @@ class TestWriteWithFilename:
         if not keep_filename_column:
             df = df.drop("file_name", axis=1)
         got = read_single_partition(
-            files=[tmp_path / f"file2.{file_ext}"], backend="pandas", filetype=file_ext
+            files=[tmp_path / f"file2.{file_ext}"], backend="pandas", file_type=file_ext
         )
         assert_eq(got, df)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -150,9 +150,7 @@ class TestIO:
     @pytest.mark.parametrize(
         "backend", ["pandas", pytest.param("cudf", marks=pytest.mark.gpu)]
     )
-    def test_read_custom(
-        self, jsonl_dataset: str, backend: Literal["pandas", "cudf"]
-    ):
+    def test_read_custom(self, jsonl_dataset: str, backend: Literal["pandas", "cudf"]):
         with tempfile.TemporaryDirectory() as tmp_dir:
             num_lines = jsonl_dataset.count("\n")
             for i, line in enumerate(jsonl_dataset.split("\n")):

--- a/tests/test_read_data.py
+++ b/tests/test_read_data.py
@@ -565,7 +565,6 @@ def test_read_data_custom_read_function(mock_npy_files, backend):
     )
 
 
-
 """ Tests below this test for inconsistent schema """
 
 

--- a/tests/test_read_data.py
+++ b/tests/test_read_data.py
@@ -12,6 +12,10 @@ from nemo_curator.utils.distributed_utils import (
 
 NUM_FILES = 5
 NUM_RECORDS = 100
+import os
+from typing import Dict, List, Literal, Optional
+
+import numpy as np
 
 
 # Fixture to create multiple small JSONL files
@@ -49,6 +53,17 @@ def mock_multiple_parquet_files(tmp_path):
         # We specify row_group_size so that we can test splitting a single big file into smaller chunks
         df.to_parquet(parquet_file, compression=None, row_group_size=10)
         file_paths.append(str(parquet_file))
+    return file_paths
+
+
+# Fixture to create arbitrary npy files to test custom read functions
+@pytest.fixture
+def mock_npy_files(tmp_path):
+    file_paths = []
+    for file_id in range(NUM_FILES):
+        npy_file = tmp_path / f"test_{file_id}.npy"
+        np.save(npy_file, np.asarray([file_id], dtype=np.float32))
+        file_paths.append(str(npy_file))
     return file_paths
 
 
@@ -489,6 +504,70 @@ def test_read_data_input_meta(
     )
 
     assert list(df.columns) == list(input_meta.keys())
+
+
+""" Tests below this test for custom read functions """
+
+
+@pytest.mark.parametrize(
+    "backend", ["pandas", pytest.param("cudf", marks=pytest.mark.gpu)]
+)
+def test_read_data_custom_read_function(mock_npy_files, backend):
+    # This function ignores file_type, add_filename, columns, and input_meta
+    def read_npy_file(files: List[str], backend: Literal["cudf", "pandas"], **kwargs):
+        if backend == "cudf":
+            import cudf as df_backend
+            import cupy as arr_backend
+        else:
+            import numpy as arr_backend
+            import pandas as df_backend
+
+        df = df_backend.DataFrame(
+            [(os.path.basename(file), arr_backend.load(file)) for file in files],
+            columns=["id", "embedding"],
+        )
+        return df
+
+    expected_df = pd.DataFrame(
+        [
+            {"id": f"test_{file_id}.npy", "embedding": np.asarray([file_id])}
+            for file_id in range(NUM_FILES)
+        ],
+    )
+
+    # Test that we can read the file without specifying columns
+    df_no_columns = read_data(
+        input_files=mock_npy_files,
+        backend=backend,
+        file_type="npy",
+        read_func_single_partition=read_npy_file,
+    )
+    assert df_no_columns.optimize().npartitions == NUM_FILES
+    df_no_columns_computed = df_no_columns.to_backend("pandas").compute()
+    pd.testing.assert_frame_equal(
+        df_no_columns_computed.sort_values("id").reset_index(drop=True),
+        expected_df[["embedding", "id"]],  # because we sort columns by name
+    )
+
+    # Test that we can read the file with a custom column
+    df_fpp_2 = read_data(
+        input_files=mock_npy_files,
+        backend=backend,
+        file_type="npy",
+        read_func_single_partition=read_npy_file,
+        files_per_partition=2,
+    )
+    assert df_fpp_2.optimize().npartitions == int(np.ceil(NUM_FILES / 2))
+    df_fpp_2_computed = df_fpp_2.to_backend("pandas").compute()
+    pd.testing.assert_frame_equal(
+        df_fpp_2_computed.sort_values("id").reset_index(drop=True),
+        expected_df[["embedding", "id"]],  # because we sort columns by name,
+    )
+
+    # Test multiple files per partition
+
+
+""" Tests below this test for inconsistent schema """
 
 
 def xfail_inconsistent_schema_jsonl():

--- a/tests/test_read_data.py
+++ b/tests/test_read_data.py
@@ -549,7 +549,7 @@ def test_read_data_custom_read_function(mock_npy_files, backend):
         expected_df[["embedding", "id"]],  # because we sort columns by name
     )
 
-    # Test that we can read the file with a custom column
+    # Test multiple files per partition
     df_fpp_2 = read_data(
         input_files=mock_npy_files,
         backend=backend,
@@ -564,7 +564,6 @@ def test_read_data_custom_read_function(mock_npy_files, backend):
         expected_df[["embedding", "id"]],  # because we sort columns by name,
     )
 
-    # Test multiple files per partition
 
 
 """ Tests below this test for inconsistent schema """


### PR DESCRIPTION
## Description
We need an ability to read arbitrary datasets using a user defined function. 
The UDF should accept
                - files: A list of file paths.
                - file_type: The type of the file to read (in case you want to handle different file types differently).
                - backend: pd / cudf 
                - add_filename: True / False / str in which case they can use `from nemo_curator.utils.distributed_utils import _resolve_filename_col`
                - columns: Can use this to define set of cols to return (output is always sorted columns)
                - input_meta: Can use this for typecasting if eneded

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
