### PR TITLE
Remove flakey download tests

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -124,18 +124,6 @@ class TestDownload:
 
         assert result == expected
 
-    def test_incorrect_snapshot_order(self):
-        with pytest.raises(ValueError):
-            end_snapshot = "2021-04"
-            start_snapshot = "2021-10"
-            urls = get_common_crawl_urls(start_snapshot, end_snapshot)
-
-    def test_incorrect_snapshot_order_news(self):
-        with pytest.raises(ValueError):
-            end_snapshot = "2021-04"
-            start_snapshot = "2021-10"
-            urls = get_common_crawl_urls(start_snapshot, end_snapshot, news=True)
-
     def test_no_urls(self):
         with pytest.raises(ValueError):
             output_format = {

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -124,6 +124,24 @@ class TestDownload:
 
         assert result == expected
 
+    @pytest.mark.skip(
+        reason="This test is flaky due to calling out to an external service and should be fixed."
+    )
+    def test_incorrect_snapshot_order(self):
+        with pytest.raises(ValueError):
+            end_snapshot = "2021-04"
+            start_snapshot = "2021-10"
+            urls = get_common_crawl_urls(start_snapshot, end_snapshot)
+
+    @pytest.mark.skip(
+        reason="This test is flaky due to calling out to an external service and should be fixed."
+    )
+    def test_incorrect_snapshot_order_news(self):
+        with pytest.raises(ValueError):
+            end_snapshot = "2021-04"
+            start_snapshot = "2021-10"
+            urls = get_common_crawl_urls(start_snapshot, end_snapshot, news=True)
+
     def test_no_urls(self):
         with pytest.raises(ValueError):
             output_format = {


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Remove download tests that interact with external service and have been failing.

## Usage
<!-- Potentially add a usage example below -->
N/A
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
