### PR TITLE
Add batched pairwise similarity method for Semantic Dedup

### DIFF
--- a/config/sem_dedup_config.yaml
+++ b/config/sem_dedup_config.yaml
@@ -19,6 +19,7 @@ clustering_save_loc: "clustering_results"
 random_state: 1234
 sim_metric: "cosine"
 which_to_keep: "hard"
+batched_cosine_similarity: 1024
 sort_clusters: true
 kmeans_with_cos_dist: false
 clustering_input_partition_size: "2gb"

--- a/docs/user-guide/semdedup.rst
+++ b/docs/user-guide/semdedup.rst
@@ -57,6 +57,7 @@ Semantic deduplication in NeMo Curator can be configured using a YAML file. Here
     random_state: 1234
     sim_metric: "cosine"
     which_to_keep: "hard"
+    batched_cosine_similarity: 1024
     sort_clusters: true
     kmeans_with_cos_dist: false
     clustering_input_partition_size: "2gb"
@@ -209,6 +210,7 @@ Use Individual Components
         id_column="doc_id",
         id_column_type="str",
         which_to_keep="hard",
+        batched_cosine_similarity=1024,
         output_dir="path/to/output/deduped",
         logger="path/to/log/dir"
     )
@@ -257,7 +259,7 @@ Key parameters in the configuration file include:
 - ``n_clusters``: Number of clusters for k-means clustering.
 - ``eps_to_extract``: Deduplication threshold. Higher values result in more aggressive deduplication.
 - ``which_to_keep``: Strategy for choosing which duplicate to keep ("hard" or "soft").
-
+- ``batched_cosine_similarity``: Whether to use batched cosine similarity (has less memory usage, O(N*B) where B is the batch size) or vanilla cosine similarity (O(N^2) memory usage).
 -----------------------------------------
 Output
 -----------------------------------------

--- a/nemo_curator/modules/semantic_dedup/semanticclusterleveldedup.py
+++ b/nemo_curator/modules/semantic_dedup/semanticclusterleveldedup.py
@@ -65,8 +65,8 @@ class SemanticClusterLevelDedup:
             embedding_column (str): The column name that stores the embeddings.
                 Default is "embeddings".
             batched_cosine_similarity (int): Whether to use batched cosine similarity (has less memory usage).
-                Default is 1024. When >0, batching is used and memory requirements are O(N*B) where N is the number of items in the cluster and B is the batch size.
-                When <=0, no batching is used and memory requirements are O(N^2) where N is the number of items in the cluster.
+                Default is 1024. When greater than 0, batching is used and memory requirements are O(N*B) where N is the number of items in the cluster and B is the batch size.
+                When less than or equal to 0, no batching is used and memory requirements are O(N^2) where N is the number of items in the cluster.
             logger (Union[logging.Logger, str]): Existing logger to log to, or a path to a log directory.
                 Default is "./".
             profile_dir (Optional[str]): If specified, directory to write Dask profile.

--- a/nemo_curator/modules/semantic_dedup/semanticclusterleveldedup.py
+++ b/nemo_curator/modules/semantic_dedup/semanticclusterleveldedup.py
@@ -23,7 +23,6 @@ import dask.bag as db
 
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.log import create_logger
-from nemo_curator.modules.config import SemDedupConfig
 from nemo_curator.utils.distributed_utils import performance_report_if_with_ts_suffix
 from nemo_curator.utils.file_utils import expand_outdir_and_mkdir
 from nemo_curator.utils.semdedup_utils import (
@@ -43,6 +42,7 @@ class SemanticClusterLevelDedup:
         which_to_keep: str = "hard",
         output_dir: str = "./clustering_results",
         embedding_column: str = "embeddings",
+        batched_cosine_similarity: int = 1024,
         logger: Union[logging.Logger, str] = "./",
         profile_dir: Optional[str] = None,
     ) -> None:
@@ -64,6 +64,9 @@ class SemanticClusterLevelDedup:
                 Default is "./clustering_results".
             embedding_column (str): The column name that stores the embeddings.
                 Default is "embeddings".
+            batched_cosine_similarity (int): Whether to use batched cosine similarity (has less memory usage).
+                Default is 1024. When >0, batching is used and memory requirements are O(N*B) where N is the number of items in the cluster and B is the batch size.
+                When <=0, no batching is used and memory requirements are O(N^2) where N is the number of items in the cluster.
             logger (Union[logging.Logger, str]): Existing logger to log to, or a path to a log directory.
                 Default is "./".
             profile_dir (Optional[str]): If specified, directory to write Dask profile.
@@ -82,6 +85,7 @@ class SemanticClusterLevelDedup:
         )
         self.computed_semantic_match_dfs = False
         self.embedding_column = embedding_column
+        self.batched_cosine_similarity = batched_cosine_similarity
         self.logger = self._setup_logger(logger)
         self.profile_dir = profile_dir
 
@@ -144,6 +148,7 @@ class SemanticClusterLevelDedup:
                     output_dir=self.semdedup_pruning_tables_dir,
                     embedding_col=self.embedding_column,
                     which_to_keep=self.which_to_keep,
+                    batched_cosine_similarity=self.batched_cosine_similarity,
                 )
             )
             tasks.compute()

--- a/nemo_curator/modules/semantic_dedup/semdedup.py
+++ b/nemo_curator/modules/semantic_dedup/semdedup.py
@@ -91,6 +91,7 @@ class SemDedup(BaseModule):
             id_column=id_column,
             id_column_type=id_column_type,
             which_to_keep=config.which_to_keep,
+            batched_cosine_similarity=config.batched_cosine_similarity,
             output_dir=os.path.join(cache_dir, config.clustering_save_loc),
             embedding_column=config.embedding_column,
             logger=logger,

--- a/nemo_curator/scripts/semdedup/extract_dedup_data.py
+++ b/nemo_curator/scripts/semdedup/extract_dedup_data.py
@@ -54,6 +54,7 @@ def main(args):
         id_column=args.id_column,
         id_column_type=args.id_column_type,
         which_to_keep=semdedup_config.which_to_keep,
+        batched_cosine_similarity=semdedup_config.batched_cosine_similarity,
         output_dir=os.path.join(
             semdedup_config.cache_dir, semdedup_config.clustering_save_loc
         ),

--- a/nemo_curator/utils/semdedup_utils.py
+++ b/nemo_curator/utils/semdedup_utils.py
@@ -18,7 +18,7 @@ import os
 import random
 import shutil
 import time
-from typing import List, Literal, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple
 
 import cudf
 import dask.bag as db

--- a/nemo_curator/utils/semdedup_utils.py
+++ b/nemo_curator/utils/semdedup_utils.py
@@ -192,7 +192,7 @@ def pairwise_cosine_similarity(
     # Normalize embeddings
     cluster_reps = cluster_reps / cluster_reps.norm(dim=1, keepdim=True)
     # Compute pairwise cosine similarity
-    pairwise_sim_matrix = cluster_reps @ (cluster_reps.T)
+    pairwise_sim_matrix = torch.mm(cluster_reps, cluster_reps.T)
     del cluster_reps
     # Set diagonal to 0 to ignore self similarity
     pairwise_sim_matrix.fill_diagonal_(0.0)
@@ -227,7 +227,7 @@ def pairwise_cosine_similarity_batched(
     for start_idx in range(0, cluster_reps.shape[0], batch_size):
         end_idx = min(start_idx + batch_size, cluster_reps.shape[0])
         batch = cluster_reps[start_idx:end_idx]
-        pairwise_sim_matrix = cluster_reps @ batch.T
+        pairwise_sim_matrix = torch.mm(cluster_reps, batch.T)
         triu_sim_matrix = torch.triu(pairwise_sim_matrix, diagonal=1 - start_idx)
         del batch
         max_values_and_indices = torch.max(triu_sim_matrix, dim=0)

--- a/nemo_curator/utils/semdedup_utils.py
+++ b/nemo_curator/utils/semdedup_utils.py
@@ -18,7 +18,7 @@ import os
 import random
 import shutil
 import time
-from typing import List, Optional, Tuple
+from typing import List, Literal, Optional, Tuple, Union
 
 import cudf
 import dask.bag as db
@@ -27,7 +27,6 @@ import numpy as np
 import pandas as pd
 import torch
 from dask.distributed import progress
-
 from nemo_curator.utils.distributed_utils import performance_report_if_with_ts_suffix
 from nemo_curator.utils.file_utils import expand_outdir_and_mkdir
 
@@ -179,24 +178,62 @@ def rank_within_cluster(
     return len(cluster_ids) - missing_files
 
 
-def _semdedup(
-    cluster_reps: torch.Tensor, device: str
+def pairwise_cosine_similarity(
+    cluster_reps: torch.Tensor, 
+    device: Literal["cuda", "cpu"],
 ) -> Tuple[torch.Tensor, List[int]]:
-    # compute pairwise cos sim between cluster items,
-    # then replace to diagonal with zeros to ignore self similarity
-    cluster_reps.to(device)
-    pair_w_sim_matrix = cluster_reps @ (cluster_reps.T)
+    """
+    Compute pairwise cosine similarity between cluster items,
+    then replace to diagonal with zeros to ignore self similarity
+    """
+    # Move to device
+    cluster_reps = cluster_reps.to(device)
+    # Normalize embeddings
+    cluster_reps = cluster_reps / cluster_reps.norm(dim=1, keepdim=True)
+    # Compute pairwise cosine similarity
+    pairwise_sim_matrix = cluster_reps @ (cluster_reps.T)
     del cluster_reps
-    pair_w_sim_matrix.fill_diagonal_(0.0)
-    assert pair_w_sim_matrix.shape[0] == pair_w_sim_matrix.shape[1]
+    # Set diagonal to 0 to ignore self similarity
+    pairwise_sim_matrix.fill_diagonal_(0.0)
+    # Get upper triangular matrix
+    assert pairwise_sim_matrix.shape[0] == pairwise_sim_matrix.shape[1]
+    triu_sim_mat = torch.triu(pairwise_sim_matrix, diagonal=1)
+    # Get max similarity and indices
+    max_values_and_indices = torch.max(triu_sim_mat, dim=0)
+    max_similarity = max_values_and_indices[0].cpu()
+    max_indices = max_values_and_indices[1].cpu().numpy().tolist()
+    return max_similarity, max_indices
 
-    triu_sim_mat = torch.triu(pair_w_sim_matrix, diagonal=1)
+def pairwise_cosine_similarity_batched(
+    cluster_reps: torch.Tensor, 
+    device: Literal["cuda", "cpu"],
+    batch_size: int = 1024,
+) -> Tuple[torch.Tensor, List[int]]:
+    """
+    Computes pairwise cosine similarity between cluster items,
+    then replace to diagonal with zeros to ignore self similarity. 
+    This function is useful for large clusters where the pairwise similarity matrix
+    does not fit into memory.
+    We use a batched approach to compute the pairwise similarity matrix in batches.
+    Memory requirements are O(N*B) where N is the number of items in the cluster and B is the batch size 
+    instead of O(N^2) for the full matrix.
+    """
+    cluster_reps = cluster_reps.to(device)
+    cluster_reps = cluster_reps / cluster_reps.norm(dim=1, keepdim=True)
+    max_similarity = torch.zeros(cluster_reps.shape[0], device=device)
+    max_indices = torch.zeros(cluster_reps.shape[0], dtype=torch.int64, device=device)
+    for start_idx in range(0, cluster_reps.shape[0], batch_size):
+        end_idx = min(start_idx + batch_size, cluster_reps.shape[0])
+        batch = cluster_reps[start_idx:end_idx]
+        pairwise_sim_matrix = cluster_reps @ batch.T
+        triu_sim_matrix = torch.triu(pairwise_sim_matrix, diagonal=1 - start_idx)
+        del batch
+        max_values_and_indices = torch.max(triu_sim_matrix, dim=0)
+        max_similarity[start_idx:end_idx] = max_values_and_indices[0]
+        max_indices[start_idx:end_idx] = max_values_and_indices[1]
 
-    M = torch.max(triu_sim_mat, dim=0)[0].cpu()
-    M1 = torch.max(triu_sim_mat, dim=0)[1].cpu().numpy().tolist()
-    return M, M1
-
-
+    return max_similarity.cpu(), max_indices.cpu().numpy().tolist()
+        
 def get_cluster_reps(
     cluster_id: int,
     emb_by_clust_dir: str,
@@ -233,6 +270,7 @@ def get_semantic_matches_per_cluster(
     output_dir: str,
     embedding_col: str,
     which_to_keep: str,
+    batched_cosine_similarity: int = 1024,
 ) -> None:
 
     output_df_file_path = os.path.join(output_dir, f"cluster_{cluster_id}.parquet")
@@ -269,19 +307,21 @@ def get_semantic_matches_per_cluster(
     cluster_reps = get_cluster_reps(
         cluster_id, emb_by_clust_dir, id_col, embedding_col, text_ids
     )
-    M, M1 = _semdedup(cluster_reps, "cuda")
+    if batched_cosine_similarity > 0:
+        max_similarity, max_indices = pairwise_cosine_similarity_batched(cluster_reps, "cuda", batched_cosine_similarity)
+    else:
+        max_similarity, max_indices = pairwise_cosine_similarity(cluster_reps, "cuda")
     assert cluster_reps.shape[0] == len(text_ids)
-
-    M1_id = [text_ids[m] for m in M1]
+    max_indices_id = [text_ids[m] for m in max_indices]
 
     points_to_remove_df = cudf.DataFrame()
     points_to_remove_df["indices"] = clutser_items_indices
     points_to_remove_df["id"] = text_ids
-    points_to_remove_df["max_id"] = M1_id
-    points_to_remove_df["cosine_sim_score"] = M.numpy().tolist()
+    points_to_remove_df["max_id"] = max_indices_id
+    points_to_remove_df["cosine_sim_score"] = max_similarity.numpy().tolist()
 
     for eps in eps_list:
-        eps_points_to_remove = M > 1 - eps
+        eps_points_to_remove = max_similarity > 1 - eps
         points_to_remove_df[f"eps={eps}"] = eps_points_to_remove
 
     points_to_remove_df.to_parquet(output_df_file_path)

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import Literal
+from typing import Literal, TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -24,17 +24,23 @@ from transformers import AutoConfig, AutoModel, AutoTokenizer
 from nemo_curator import SemDedup, SemDedupConfig
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.utils.import_utils import gpu_only_import, gpu_only_import_from
-from nemo_curator.utils.semdedup_utils import (
-    pairwise_cosine_similarity,
-    pairwise_cosine_similarity_batched,
-)
 
 cudf = gpu_only_import("cudf")
 dask_cudf = gpu_only_import("dask_cudf")
 EmbeddingCreator = gpu_only_import_from(
     "nemo_curator.modules.semantic_dedup.embeddings", "EmbeddingCreator"
 )
-
+pairwise_cosine_similarity = gpu_only_import_from(
+    "nemo_curator.utils.semdedup_utils", "pairwise_cosine_similarity"
+)
+pairwise_cosine_similarity_batched = gpu_only_import_from(
+    "nemo_curator.utils.semdedup_utils", "pairwise_cosine_similarity_batched"
+)
+if TYPE_CHECKING:
+    from nemo_curator.utils.semdedup_utils import (
+        pairwise_cosine_similarity,
+        pairwise_cosine_similarity_batched,
+    )
 
 @pytest.fixture
 def dedup_data():
@@ -253,9 +259,8 @@ class TestPairwiseCosineSimilarity:
         )
         self.expected_indices = [0, 0, 1, 2, 0]
 
-    # paramterize device
     @pytest.mark.parametrize(
-        "device", ["cpu", pytest.param("cuda", marks=pytest.mark.gpu)]
+        "device", [pytest.param("cuda", marks=pytest.mark.gpu)]
     )
     def test_pairwise_cosine_similarity(self, device: Literal["cpu", "cuda"]):
         max_similarity, max_indices = pairwise_cosine_similarity(
@@ -267,7 +272,7 @@ class TestPairwiseCosineSimilarity:
         assert max_indices == self.expected_indices
 
     @pytest.mark.parametrize(
-        "device", ["cpu", pytest.param("cuda", marks=pytest.mark.gpu)]
+        "device", [pytest.param("cuda", marks=pytest.mark.gpu)]
     )
     @pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 5])
     def test_pairwise_cosine_similarity_batched(
@@ -282,7 +287,7 @@ class TestPairwiseCosineSimilarity:
         assert max_indices == self.expected_indices
 
     @pytest.mark.parametrize(
-        "device", ["cpu", pytest.param("cuda", marks=pytest.mark.gpu)]
+        "device", [pytest.param("cuda", marks=pytest.mark.gpu)]
     )
     @pytest.mark.parametrize("batch_size", [100, 512, 1024, 2048])
     def test_pairwise_cosine_similarity_batched_rand_array(

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -249,16 +249,20 @@ def get_reference_embeddings(
 
 class TestPairwiseCosineSimilarity:
     def setup_method(self):
-        self.input_arr = torch.tensor(
+        # We create a 5x3 array where each row is a unit vector
+        # The second and last two rows are the same
+        input_arr = torch.tensor(
             np.asarray(
-                [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [1, 2, 3]],
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [1, 2, 3], [1, 2, 3]],
             ),
             dtype=torch.float32,
         )
+        # Normalize the input array
+        self.input_arr = input_arr / torch.norm(input_arr, dim=1, keepdim=True)
         self.expected_similarity = torch.tensor(
-            [0.0000, 0.974631, 0.998190, 0.999618, 1.0000]
+            [0.0000, 0.974631, 0.998190, 0.999618, 1.0000, 1.0000]
         )
-        self.expected_indices = [0, 0, 1, 2, 0]
+        self.expected_indices = [0, 0, 1, 2, 0, 0]
 
     @pytest.mark.parametrize("device", [pytest.param("cuda", marks=pytest.mark.gpu)])
     def test_pairwise_cosine_similarity(self, device: Literal["cpu", "cuda"]):
@@ -279,7 +283,7 @@ class TestPairwiseCosineSimilarity:
             self.input_arr.to(device), device, batch_size
         )
         torch.testing.assert_close(
-            max_similarity, self.expected_similarity, rtol=1e-6, atol=1e-6
+            max_similarity, self.expected_similarity
         )
         assert max_indices == self.expected_indices
 

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from typing import Literal
 
 import numpy as np
 import pytest
@@ -27,7 +28,6 @@ from nemo_curator.utils.semdedup_utils import (
     pairwise_cosine_similarity,
     pairwise_cosine_similarity_batched,
 )
-from typing import Literal
 
 cudf = gpu_only_import("cudf")
 dask_cudf = gpu_only_import("dask_cudf")
@@ -175,9 +175,9 @@ class TestSemDuplicates:
             test_texts, pooling_strategy=pooling_strategy
         )
 
-        assert np.allclose(embeddings, reference_embeddings, atol=1e-3), (
-            "Embeddings should match reference embeddings"
-        )
+        assert np.allclose(
+            embeddings, reference_embeddings, atol=1e-3
+        ), "Embeddings should match reference embeddings"
 
 
 def get_reference_embeddings(
@@ -291,8 +291,8 @@ class TestPairwiseCosineSimilarity:
         D = 512
         rand_arr = torch.randn(N, D, device=device)
         max_similarity, max_indices = pairwise_cosine_similarity(rand_arr, device)
-        max_similarity_batched, max_indices_batched = pairwise_cosine_similarity_batched(
-            rand_arr, device, batch_size=batch_size
+        max_similarity_batched, max_indices_batched = (
+            pairwise_cosine_similarity_batched(rand_arr, device, batch_size=batch_size)
         )
         assert torch.allclose(max_similarity, max_similarity_batched, atol=1e-3)
         assert max_indices == max_indices_batched

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -185,59 +185,59 @@ def get_reference_embeddings(
     model_name="sentence-transformers/all-MiniLM-L6-v2",
     pooling_strategy="last_token",
 ):
-#     """
-#     Get embeddings using either last token or mean pooling strategy.
+    """
+    Get embeddings using either last token or mean pooling strategy.
 
-#     Args:
-#         texts: List of input texts
-#         model_name: Name or path of the model to use
-#         pooling_strategy: Either "last_token" for last token or "mean" for mean pooling
-#     """
-#     tokenizer = AutoTokenizer.from_pretrained(model_name)
-#     model = AutoModel.from_pretrained(model_name)
-#     model = model.to("cuda")
-#     model.eval()
-#     max_len_to_use = tokenizer.model_max_length
-#     if max_len_to_use > 1e5:
-#         max_len_to_use = AutoConfig.from_pretrained(model_name).max_position_embeddings
-#     max_seq_length: int = max_len_to_use
+    Args:
+        texts: List of input texts
+        model_name: Name or path of the model to use
+        pooling_strategy: Either "last_token" for last token or "mean" for mean pooling
+    """
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModel.from_pretrained(model_name)
+    model = model.to("cuda")
+    model.eval()
+    max_len_to_use = tokenizer.model_max_length
+    if max_len_to_use > 1e5:
+        max_len_to_use = AutoConfig.from_pretrained(model_name).max_position_embeddings
+    max_seq_length: int = max_len_to_use
 
-#     embs = []
-#     for text in texts:
-#         inputs = tokenizer(
-#             text,
-#             return_tensors="pt",
-#             padding=True,
-#             truncation=True,
-#             max_length=max_seq_length,
-#         )
-#         inputs = {k: v.to("cuda") for k, v in inputs.items()}
+    embs = []
+    for text in texts:
+        inputs = tokenizer(
+            text,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_seq_length,
+        )
+        inputs = {k: v.to("cuda") for k, v in inputs.items()}
 
-#         with torch.no_grad():
-#             with torch.autocast(device_type="cuda"):
-#                 outputs = model(**inputs)
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda"):
+                outputs = model(**inputs)
 
-#         if pooling_strategy == "last_token":
-#             embeddings = outputs.last_hidden_state[:, -1, :]
-#         elif pooling_strategy == "mean_pooling":
-#             token_embeddings = outputs.last_hidden_state
-#             attention_mask = inputs["attention_mask"]
-#             input_mask_expanded = (
-#                 attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-#             )
-#             sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, dim=1)
-#             sum_mask = torch.clamp(input_mask_expanded.sum(dim=1), min=1e-9)
-#             embeddings = sum_embeddings / sum_mask
-#         else:
-#             raise ValueError(
-#                 "pooling_strategy must be either 'last_token' or 'mean_pooling'"
-#             )
+        if pooling_strategy == "last_token":
+            embeddings = outputs.last_hidden_state[:, -1, :]
+        elif pooling_strategy == "mean_pooling":
+            token_embeddings = outputs.last_hidden_state
+            attention_mask = inputs["attention_mask"]
+            input_mask_expanded = (
+                attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+            )
+            sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, dim=1)
+            sum_mask = torch.clamp(input_mask_expanded.sum(dim=1), min=1e-9)
+            embeddings = sum_embeddings / sum_mask
+        else:
+            raise ValueError(
+                "pooling_strategy must be either 'last_token' or 'mean_pooling'"
+            )
 
-#         normed_emb = F.normalize(embeddings, dim=1).cpu()
-#         normed_emb = normed_emb.squeeze(0)
-#         embs.append(normed_emb)
+        normed_emb = F.normalize(embeddings, dim=1).cpu()
+        normed_emb = normed_emb.squeeze(0)
+        embs.append(normed_emb)
 
-#     return np.array(embs)
+    return np.array(embs)
 
 
 class TestPairwiseCosineSimilarity:

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -275,16 +275,14 @@ class TestPairwiseCosineSimilarity:
         assert max_indices == self.expected_indices
 
     @pytest.mark.parametrize("device", [pytest.param("cuda", marks=pytest.mark.gpu)])
-    @pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 5])
+    @pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 5, 6])
     def test_pairwise_cosine_similarity_batched(
         self, device: Literal["cpu", "cuda"], batch_size: int
     ):
         max_similarity, max_indices = pairwise_cosine_similarity_batched(
             self.input_arr.to(device), device, batch_size
         )
-        torch.testing.assert_close(
-            max_similarity, self.expected_similarity
-        )
+        torch.testing.assert_close(max_similarity, self.expected_similarity)
         assert max_indices == self.expected_indices
 
     @pytest.mark.parametrize("device", [pytest.param("cuda", marks=pytest.mark.gpu)])

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -297,5 +297,7 @@ class TestPairwiseCosineSimilarity:
         max_similarity_batched, max_indices_batched = (
             pairwise_cosine_similarity_batched(rand_arr, device, batch_size=batch_size)
         )
-        torch.testing.assert_close(max_similarity, max_similarity_batched)
+        torch.testing.assert_close(
+            max_similarity, max_similarity_batched, rtol=1e-5, atol=1e-5
+        )
         assert max_indices == max_indices_batched

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pytest
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
         pairwise_cosine_similarity,
         pairwise_cosine_similarity_batched,
     )
+
 
 @pytest.fixture
 def dedup_data():
@@ -259,9 +260,7 @@ class TestPairwiseCosineSimilarity:
         )
         self.expected_indices = [0, 0, 1, 2, 0]
 
-    @pytest.mark.parametrize(
-        "device", [pytest.param("cuda", marks=pytest.mark.gpu)]
-    )
+    @pytest.mark.parametrize("device", [pytest.param("cuda", marks=pytest.mark.gpu)])
     def test_pairwise_cosine_similarity(self, device: Literal["cpu", "cuda"]):
         max_similarity, max_indices = pairwise_cosine_similarity(
             self.input_arr.to(device), device
@@ -271,9 +270,7 @@ class TestPairwiseCosineSimilarity:
         )
         assert max_indices == self.expected_indices
 
-    @pytest.mark.parametrize(
-        "device", [pytest.param("cuda", marks=pytest.mark.gpu)]
-    )
+    @pytest.mark.parametrize("device", [pytest.param("cuda", marks=pytest.mark.gpu)])
     @pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 5])
     def test_pairwise_cosine_similarity_batched(
         self, device: Literal["cpu", "cuda"], batch_size: int
@@ -286,9 +283,7 @@ class TestPairwiseCosineSimilarity:
         )
         assert max_indices == self.expected_indices
 
-    @pytest.mark.parametrize(
-        "device", [pytest.param("cuda", marks=pytest.mark.gpu)]
-    )
+    @pytest.mark.parametrize("device", [pytest.param("cuda", marks=pytest.mark.gpu)])
     @pytest.mark.parametrize("batch_size", [100, 512, 1024, 2048])
     def test_pairwise_cosine_similarity_batched_rand_array(
         self, device: Literal["cpu", "cuda"], batch_size: int

--- a/tutorials/dapt-curation/code/configs/text_semantic_dedupe_config.yaml
+++ b/tutorials/dapt-curation/code/configs/text_semantic_dedupe_config.yaml
@@ -18,6 +18,7 @@ clustering_save_loc: "clustering_results"
 random_state: 1234
 sim_metric: "cosine"
 which_to_keep: "hard"
+batched_cosine_similarity: 1024
 sort_clusters: true
 kmeans_with_cos_dist: false
 clustering_input_partition_size: "2gb"

--- a/tutorials/image-curation/image-curation.ipynb
+++ b/tutorials/image-curation/image-curation.ipynb
@@ -681,6 +681,7 @@
     "    id_column_type=\"str\",\n",
     "    embedding_col=\"image_embedding\",\n",
     "    which_to_keep=\"hard\",\n",
+    "    batched_cosine_similarity=1024,\n",
     "    output_dir=duplicate_output,\n",
     ")\n",
     "semantic_dedup.compute_semantic_match_dfs([0.01, 0.001])\n",

--- a/tutorials/peft-curation-with-sdg/config/sem_dedup_config.yaml
+++ b/tutorials/peft-curation-with-sdg/config/sem_dedup_config.yaml
@@ -18,6 +18,7 @@ clustering_save_loc: "clustering_results"
 random_state: 1234
 sim_metric: "cosine"
 which_to_keep: "hard"
+batched_cosine_similarity: 1024
 sort_clusters: true
 kmeans_with_cos_dist: false
 clustering_input_partition_size: "2gb"


### PR DESCRIPTION
## Description
Resolves https://github.com/NVIDIA/NeMo-Curator/issues/520

Currently if a single cluster is large enough, we'll likely OOM since `M @ M.T` requires `N**2` storage. A batched version breaks it up into smaller batches B and performs `M @ B.T`. The only thing we need to be careful is how to zero out the diagonals and get the upper triangular matrix.

## other nits
1. `get_cluster_reps -> get_normalized_cluster_reps` : now **always** l2 normalize the embedding vector so that `M @ M.T` results in an absolute max value of 1
1. renamed `_semdedup` to `pairwise_similarity`
3. added tests for existing function + the batched approach.
4. default now is batched implementation

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
