### PR TITLE
Fix cuda context bug in NeMo Container

### DIFF
--- a/nemo_curator/classifiers/aegis.py
+++ b/nemo_curator/classifiers/aegis.py
@@ -24,7 +24,6 @@ import torch.nn.functional as F
 from crossfit import op
 from crossfit.backend.torch.hf.model import HFModel
 from huggingface_hub import PyTorchModelHubMixin
-from peft import PeftModel
 from torch.nn import Dropout, Linear
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
@@ -116,6 +115,11 @@ class AegisModel(nn.Module):
         base_model = AutoModelForCausalLM.from_pretrained(
             pretrained_model_name_or_path, torch_dtype=dtype, token=token
         )
+        # Importing PeftModel here to prevent cuda context issues
+        # that seem to happen on Transformers 4.48.3
+        # See related: https://github.com/rapidsai/crossfit/pull/113
+        from peft import PeftModel
+
         self.model = PeftModel.from_pretrained(base_model, peft_model_name_or_path)
         self.autocast = autocast
         self.add_instruction_data_guard = add_instruction_data_guard

--- a/nemo_curator/package_info.py
+++ b/nemo_curator/package_info.py
@@ -16,7 +16,7 @@
 MAJOR = 0
 MINOR = 7
 PATCH = 0
-PRE_RELEASE = "rc2"
+PRE_RELEASE = "rc3"
 DEV = "dev0"
 
 # Use the following formatting: (major, minor, patch, pre-release)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "beautifulsoup4",
     "charset_normalizer>=3.1.0",
     "comment_parser",
-    "crossfit>=0.0.8",
+    "crossfit>=0.0.8.post1",
     "dask-mpi>=2021.11.0",
     "dask[complete]>=2021.7.1",
     "datasets",


### PR DESCRIPTION
## Description
This PR fixes a bug we saw in the release container which causes cuda context being created on GPU-0. I have not been able to repro this outside this container till now.


```
docker run --rm -it --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 nvcr.io/nvidia/nemo:25.02
```


### NeMo Curator Repro:
```
import time
import dask
import dask_cudf
from nemo_curator import get_client


def main():
    client = get_client(cluster_type="gpu")
    print(f"Client obtained: {client}")

    # Load a sample dataset from dask.datasets
    ddf = dask.datasets.timeseries()

    # Convert Dask DataFrame to Dask-cuDF DataFrame
    cudf_ddf = dask_cudf.from_dask_dataframe(ddf)
    print(cudf_ddf.map_partitions(len).compute())
    time.sleep(100)

if __name__ == "__main__":
    main()

```


### General Repro
```
import time
from dask_cuda import LocalCUDACluster
from dask.distributed import Client
import dask
import dask_cudf
from peft import PeftModel

def get_client():
    cluster = LocalCUDACluster()
    return Client(cluster)

def main():
    client = get_client()
    print(f"Client obtained: {client}")

    # Load a sample dataset from dask.datasets
    ddf = dask.datasets.timeseries()

    # Convert Dask DataFrame to Dask-cuDF DataFrame
    cudf_ddf = dask_cudf.from_dask_dataframe(ddf)
    print(cudf_ddf.map_partitions(len).compute())
    time.sleep(100)

if __name__ == "__main__":
    main()
```