### PR TITLE
Sem Dedup Refactor (bug fixes / tests / simplifcation)

### DIFF
--- a/config/sem_dedup_config.yaml
+++ b/config/sem_dedup_config.yaml
@@ -20,14 +20,8 @@ random_state: 1234
 sim_metric: "cosine"
 which_to_keep: "hard"
 batched_cosine_similarity: 1024
-sort_clusters: true
-kmeans_with_cos_dist: false
 clustering_input_partition_size: "2gb"
 
 # Extract dedup configuration
-eps_thresholds:
-  - 0.01
-  - 0.001
-
 # Which threshold to use for extracting deduped data
 eps_to_extract: 0.01

--- a/docs/user-guide/semdedup.rst
+++ b/docs/user-guide/semdedup.rst
@@ -58,15 +58,9 @@ Semantic deduplication in NeMo Curator can be configured using a YAML file. Here
     sim_metric: "cosine"
     which_to_keep: "hard"
     batched_cosine_similarity: 1024
-    sort_clusters: true
-    kmeans_with_cos_dist: false
     clustering_input_partition_size: "2gb"
 
     # Extract dedup configuration
-    eps_thresholds:
-      - 0.01
-      - 0.001
-
     # Which threshold to use for extracting deduped data
     eps_to_extract: 0.01
 
@@ -112,17 +106,10 @@ The semantic deduplication process is controlled by two key threshold parameters
 
 .. code-block:: yaml
 
-    eps_thresholds:
-      - 0.01
-      - 0.001
-
     eps_to_extract: 0.01
 
-1. ``eps_thresholds``: A list of similarity thresholds used to compute semantic matches. Each threshold represents a different level of strictness in determining duplicates.
+1. ``eps_to_extract``: The specific threshold used for the final extraction of deduplicated data.
                      Lower values are more strict, requiring higher similarity for documents to be considered duplicates.
-
-2. ``eps_to_extract``: The specific threshold used for the final extraction of deduplicated data.
-                     This value must be one of the thresholds listed in ``eps_thresholds``.
 
 This two-step approach offers several advantages:
 
@@ -137,8 +124,6 @@ When choosing appropriate thresholds:
 
 We recommended that you experiment with different threshold values to find the optimal balance between data reduction and maintaining dataset diversity and quality.
 The impact of these thresholds can vary depending on the nature and size of your dataset.
-
-Remember, if you want to extract data using a threshold that's not in ``eps_thresholds``, you'll need to recompute the semantic matches with the new threshold included in the list.
 
 -----------------------------------------
 Usage
@@ -206,10 +191,9 @@ Use Individual Components
     semantic_dedup = SemanticClusterLevelDedup(
         n_clusters=50000,
         emb_by_clust_dir="path/to/embeddings/by/cluster",
-        sorted_clusters_dir="path/to/sorted/clusters",
         id_column="doc_id",
-        id_column_type="str",
         which_to_keep="hard",
+        sim_metric="cosine",
         batched_cosine_similarity=1024,
         output_dir="path/to/output/deduped",
         logger="path/to/log/dir"
@@ -239,7 +223,6 @@ Alternatively, you can use the SemDedup class to perform all steps:
         config=config,
         input_column="text",
         id_column="doc_id",
-        id_column_type="str",
         logger="path/to/log/dir",
     )
 
@@ -259,6 +242,7 @@ Key parameters in the configuration file include:
 - ``n_clusters``: Number of clusters for k-means clustering.
 - ``eps_to_extract``: Deduplication threshold. Higher values result in more aggressive deduplication.
 - ``which_to_keep``: Strategy for choosing which duplicate to keep ("hard" or "soft").
+- ``sim_metric``: Similarity metric to use to rank within cluster. The order is determined by which_to_keep.
 - ``batched_cosine_similarity``: Whether to use batched cosine similarity (has less memory usage, O(N*B) where B is the batch size) or vanilla cosine similarity (O(N^2) memory usage).
 -----------------------------------------
 Output

--- a/docs/user-guide/semdedup.rst
+++ b/docs/user-guide/semdedup.rst
@@ -241,8 +241,11 @@ Key parameters in the configuration file include:
 - ``embedding_batch_size``: Number of samples to process in each embedding batch.
 - ``n_clusters``: Number of clusters for k-means clustering.
 - ``eps_to_extract``: Deduplication threshold. Higher values result in more aggressive deduplication.
-- ``which_to_keep``: Strategy for choosing which duplicate to keep ("hard" or "soft").
-- ``sim_metric``: Similarity metric to use to rank within cluster. The order is determined by which_to_keep.
+- ``which_to_keep``: Strategy for choosing which duplicate to keep ("hard" / "easy" / "random").
+    - ``hard``: Retains edge-case or outlier items farthest from the centroid by sorting points by decreasing distance from the centroid.
+    - ``easy``: Retains representative items closest to the centroid by sorting points by increasing distance from the centroid.
+    - ``random``: Retains items randomly.
+- ``sim_metric``: Similarity metric to use to rank within cluster. ``which_to_keep`` determines how points within each cluster are ranked, based on the similarity to the centroid defined by ``sim_metric``
 - ``batched_cosine_similarity``: Whether to use batched cosine similarity (has less memory usage, O(N*B) where B is the batch size) or vanilla cosine similarity (O(N^2) memory usage).
 -----------------------------------------
 Output

--- a/nemo_curator/modules/config.py
+++ b/nemo_curator/modules/config.py
@@ -175,11 +175,11 @@ class SemDedupConfig(BaseConfig):
         clustering_save_loc (str): Location to save clustering results.
             Default is "clustering_results".
         random_state (int): KMeans random state used for reproducibility. Default is 1234.
-        sim_metric ("cosine" or "l2"): Similarity metric to use to rank within cluster. The order is determined by which_to_keep.
-            Default is "cosine". Supports "l2" as well.
+        sim_metric ("cosine" or "l2"): Similarity metric to use to rank within cluster. Default is "cosine".
+            `which_to_keep` determines how points within each cluster are ranked, based on the similarity to the centroid defined by `sim_metric`
         which_to_keep (str): Method to determine which duplicates to keep. Default is "hard".
-            - hard retains edge-case or outlier items farthest from the centroid.
-            - easy retains representative items closest to the centroid.
+            - hard retains edge-case or outlier items farthest from the centroid by sorting points by decreasing distance from the centroid.
+            - easy retains representative items closest to the centroid by sorting points by increasing distance from the centroid.
             - random retains items randomly.
         batched_cosine_similarity (Union[bool, int]): Whether to use batched cosine similarity (has less memory usage).
             Default is 1024. When False or 0, no batching is used and memory requirements are O(N^2) where N is the number of items in the cluster.

--- a/nemo_curator/modules/semantic_dedup/clusteringmodel.py
+++ b/nemo_curator/modules/semantic_dedup/clusteringmodel.py
@@ -17,7 +17,7 @@ import logging
 import os
 import shutil
 import time
-from typing import Literal, Optional, Union
+from typing import Optional, Union
 
 import cudf
 import cupy as cp

--- a/nemo_curator/modules/semantic_dedup/clusteringmodel.py
+++ b/nemo_curator/modules/semantic_dedup/clusteringmodel.py
@@ -201,6 +201,7 @@ class ClusteringModel:
             )
             embeddings_df = embeddings_df.reset_index(drop=True)
             centroids = kmeans.cluster_centers_
+            print(f"{centroids=}")
             kmeans_centroids_file = os.path.join(
                 self.clustering_output_dir, "kmeans_centroids.npy"
             )

--- a/nemo_curator/modules/semantic_dedup/semanticclusterleveldedup.py
+++ b/nemo_curator/modules/semantic_dedup/semanticclusterleveldedup.py
@@ -17,17 +17,19 @@ import logging
 import os
 import shutil
 import time
-from typing import List, Optional, Union
+from typing import Literal, Optional, Union
 
 import dask.bag as db
+import dask.dataframe as dd
 
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.log import create_logger
 from nemo_curator.utils.distributed_utils import performance_report_if_with_ts_suffix
 from nemo_curator.utils.file_utils import expand_outdir_and_mkdir
 from nemo_curator.utils.semdedup_utils import (
-    extract_dedup_data,
     get_semantic_matches_per_cluster,
+    prune_single_cluster,
+    write_pruned_summary_file,
 )
 
 
@@ -36,10 +38,9 @@ class SemanticClusterLevelDedup:
         self,
         n_clusters: int = 1000,
         emb_by_clust_dir: str = "./clustering_results/embs_by_nearest_center",
-        sorted_clusters_dir: str = "./clustering_results/sorted",
         id_column: str = "id",
-        id_column_type: str = "int",
         which_to_keep: str = "hard",
+        sim_metric: Literal["cosine", "l2"] = "cosine",
         output_dir: str = "./clustering_results",
         embedding_column: str = "embeddings",
         batched_cosine_similarity: int = 1024,
@@ -53,13 +54,14 @@ class SemanticClusterLevelDedup:
             n_clusters (int): Number of clusters. Default is 1000.
             emb_by_clust_dir (str): Directory containing embeddings by cluster.
                 Default is "./clustering_results/embs_by_nearest_center".
-            sorted_clusters_dir (str): Directory containing sorted clusters.
-                Default is "./clustering_results/sorted".
             id_column (str): Column name used as the identifier in the dataset.
                 Default is "id".
-            id_column_type (str): Data type of id_column. Default is "int".
-            which_to_keep (str): Method to determine which duplicates to keep.
-                Default is "hard".
+            which_to_keep (str): Method to determine which duplicates to keep. Default is "hard".
+                - hard retains edge-case or outlier items farthest from the centroid.
+                - easy retains representative items closest to the centroid.
+                - random retains items randomly.
+            sim_metric ("cosine" or "l2"): Similarity metric to use to rank within cluster. The order is determined by which_to_keep.
+                Default is "cosine". Supports "l2" as well.
             output_dir (str): Directory to save output files.
                 Default is "./clustering_results".
             embedding_column (str): The column name that stores the embeddings.
@@ -75,10 +77,9 @@ class SemanticClusterLevelDedup:
         """
         self.n_clusters = n_clusters
         self.emb_by_clust_dir = emb_by_clust_dir
-        self.sorted_clusters_dir = sorted_clusters_dir
         self.id_col = id_column
-        self.id_col_type = id_column_type
         self.which_to_keep = which_to_keep
+        self.sim_metric = sim_metric
         self.output_dir = output_dir
         self.semdedup_pruning_tables_dir = os.path.join(
             output_dir, "semdedup_pruning_tables"
@@ -110,20 +111,7 @@ class SemanticClusterLevelDedup:
         else:
             return logger
 
-    def compute_semantic_match_dfs(
-        self, eps_list: Optional[List[float]] = None
-    ) -> None:
-        """
-        Compute semantic match dataframes for clusters.
-
-        Args:
-            eps_list (Optional[List[float]]): List of epsilon values for clustering.
-        """
-        if eps_list is None:
-            eps_list1 = [1.0e-2, 1.0e-3, 1.0e-4, 1.0e-5, 1.0e-6]
-            eps_list2 = [0.1 + x * 0.005 for x in range(34)]
-            eps_list = eps_list1 + eps_list2
-
+    def compute_semantic_match_dfs(self) -> None:
         if os.path.exists(self.semdedup_pruning_tables_dir):
             self.logger.info(
                 f"Removing existing directory {self.semdedup_pruning_tables_dir}"
@@ -141,13 +129,11 @@ class SemanticClusterLevelDedup:
                 lambda cluster_id: get_semantic_matches_per_cluster(
                     cluster_id=cluster_id,
                     emb_by_clust_dir=self.emb_by_clust_dir,
-                    sorted_clusters_dir=self.sorted_clusters_dir,
                     id_col=self.id_col,
-                    id_col_type=self.id_col_type,
-                    eps_list=eps_list,
                     output_dir=self.semdedup_pruning_tables_dir,
                     embedding_col=self.embedding_column,
                     which_to_keep=self.which_to_keep,
+                    sim_metric=self.sim_metric,
                     batched_cosine_similarity=self.batched_cosine_similarity,
                 )
             )
@@ -172,28 +158,39 @@ class SemanticClusterLevelDedup:
                 "Run compute_semantic_match_dfs before calling extract_dedup_data"
             )
         assert isinstance(eps_to_extract, float), "eps_to_extract must be a float"
-
-        output_summary_file = os.path.join(
-            self.output_dir, f"dedup_summary_{eps_to_extract}.csv"
-        )
         output_parquet_path = os.path.join(
             self.output_dir, f"unique_ids_{eps_to_extract}.parquet"
         )
-        extract_dedup_data(
-            eps=eps_to_extract,
-            n_clusters=self.n_clusters,
-            id_col=self.id_col,
-            id_col_type=self.id_col_type,
-            sorted_clusters_dir=self.sorted_clusters_dir,
-            semdedup_pruning_tables_dir=self.semdedup_pruning_tables_dir,
-            output_summary_file=output_summary_file,
-            output_parquet_path=output_parquet_path,
-            logger=self.logger,
-            profile_dir=self.profile_dir,
-        )
 
-        fps = [
-            os.path.join(output_parquet_path, file_name)
-            for file_name in os.listdir(output_parquet_path)
-        ]
-        return DocumentDataset.read_parquet(fps, backend="cudf")
+        t0 = time.time()
+        with performance_report_if_with_ts_suffix(
+            self.profile_dir,
+            "extracting-pruned-from-clusters",
+        ):
+            results_df = dd.from_map(
+                prune_single_cluster,
+                range(self.n_clusters),
+                id_col=self.id_col,
+                emb_by_clust_dir=self.emb_by_clust_dir,
+                semdedup_pruning_tables_dir=self.semdedup_pruning_tables_dir,
+                eps=eps_to_extract,
+            )
+            results_df.to_parquet(output_parquet_path, index=False, ignore_index=True)
+            self.logger.info(
+                f"Time taken for Extracting Pruned Data : {time.time() - t0} and output written at {output_parquet_path}"
+            )
+
+        # Write out summary file
+        output_summary_file = os.path.join(
+            self.output_dir, f"dedup_summary_{eps_to_extract}.csv"
+        )
+        write_pruned_summary_file(
+            eps=eps_to_extract,
+            emb_by_clust_dir=self.emb_by_clust_dir,
+            filtered_unique_ids_path=output_parquet_path,
+            output_summary_file=output_summary_file,
+            logger=self.logger,
+        )
+        return DocumentDataset.read_parquet(
+            output_parquet_path, blocksize="1gb", backend="cudf"
+        )

--- a/nemo_curator/modules/semantic_dedup/semanticclusterleveldedup.py
+++ b/nemo_curator/modules/semantic_dedup/semanticclusterleveldedup.py
@@ -171,6 +171,7 @@ class SemanticClusterLevelDedup:
             raise ValueError(
                 "Run compute_semantic_match_dfs before calling extract_dedup_data"
             )
+        assert isinstance(eps_to_extract, float), "eps_to_extract must be a float"
 
         output_summary_file = os.path.join(
             self.output_dir, f"dedup_summary_{eps_to_extract}.csv"

--- a/nemo_curator/modules/semantic_dedup/semanticclusterleveldedup.py
+++ b/nemo_curator/modules/semantic_dedup/semanticclusterleveldedup.py
@@ -57,11 +57,11 @@ class SemanticClusterLevelDedup:
             id_column (str): Column name used as the identifier in the dataset.
                 Default is "id".
             which_to_keep (str): Method to determine which duplicates to keep. Default is "hard".
-                - hard retains edge-case or outlier items farthest from the centroid.
-                - easy retains representative items closest to the centroid.
+                - hard retains edge-case or outlier items farthest from the centroid by sorting points by decreasing distance from the centroid.
+                - easy retains representative items closest to the centroid by sorting points by increasing distance from the centroid.
                 - random retains items randomly.
-            sim_metric ("cosine" or "l2"): Similarity metric to use to rank within cluster. The order is determined by which_to_keep.
-                Default is "cosine". Supports "l2" as well.
+            sim_metric ("cosine" or "l2"): Similarity metric to use to rank within cluster. Default is "cosine".
+                `which_to_keep` determines how points within each cluster are ranked, based on the similarity to the centroid defined by `sim_metric`
             output_dir (str): Directory to save output files.
                 Default is "./clustering_results".
             embedding_column (str): The column name that stores the embeddings.

--- a/nemo_curator/modules/semantic_dedup/semdedup.py
+++ b/nemo_curator/modules/semantic_dedup/semdedup.py
@@ -75,7 +75,6 @@ class SemDedup(BaseModule):
             sim_metric=config.sim_metric,
             which_to_keep=config.which_to_keep,
             sort_clusters=config.sort_clusters,
-            kmeans_with_cos_dist=config.kmeans_with_cos_dist,
             clustering_input_partition_size=config.clustering_input_partition_size,
             logger=logger,
             profile_dir=self.config.profile_dir,

--- a/nemo_curator/scripts/semdedup/clustering.py
+++ b/nemo_curator/scripts/semdedup/clustering.py
@@ -68,10 +68,6 @@ def main(args):
         clustering_output_dir=clustering_output_dir,
         embedding_column=semdedup_config.embedding_column,
         random_state=semdedup_config.random_state,
-        sim_metric=semdedup_config.sim_metric,
-        which_to_keep=semdedup_config.which_to_keep,
-        sort_clusters=semdedup_config.sort_clusters,
-        kmeans_with_cos_dist=semdedup_config.kmeans_with_cos_dist,
         clustering_input_partition_size=semdedup_config.clustering_input_partition_size,
         logger=logger,
     )
@@ -101,7 +97,6 @@ def attach_args():
             " clustering_save_loc for the location to save clustering results,"
             " n_clusters for the number of clusters,"
             " max_iter for the maximum iterations for clustering,"
-            " kmeans_with_cos_dist for using K-Means with cosine distance."
         ),
     )
     return parser

--- a/nemo_curator/scripts/semdedup/extract_dedup_data.py
+++ b/nemo_curator/scripts/semdedup/extract_dedup_data.py
@@ -48,12 +48,9 @@ def main(args):
         emb_by_clust_dir=os.path.join(
             cache_dir, semdedup_config.clustering_save_loc, "embs_by_nearest_center"
         ),
-        sorted_clusters_dir=os.path.join(
-            cache_dir, semdedup_config.clustering_save_loc, "sorted"
-        ),
         id_column=args.id_column,
-        id_column_type=args.id_column_type,
         which_to_keep=semdedup_config.which_to_keep,
+        sim_metric=semdedup_config.sim_metric,
         batched_cosine_similarity=semdedup_config.batched_cosine_similarity,
         output_dir=os.path.join(
             semdedup_config.cache_dir, semdedup_config.clustering_save_loc
@@ -62,10 +59,11 @@ def main(args):
         logger=logger,
     )
 
-    semantic_dedup.compute_semantic_match_dfs(semdedup_config.eps_thresholds)
-    for eps in semdedup_config.eps_thresholds:
-        dedup_id_dataset = semantic_dedup.extract_dedup_data(eps_to_extract=eps)
-        print(dedup_id_dataset.df.head(10))
+    semantic_dedup.compute_semantic_match_dfs()
+    dedup_id_dataset = semantic_dedup.extract_dedup_data(
+        eps_to_extract=semdedup_config.eps_to_extract
+    )
+    print(dedup_id_dataset.df.head(10))
 
     dt2 = datetime.now()
     logger.info(f"End: {dt2}")
@@ -90,7 +88,6 @@ def attach_args():
             " cache_dir for the directory to store cache"
             " which_to_keep for specifying which duplicates to keep,"
             " sim_metric for the similarity metric for deduplication,"
-            " eps_thresholds for epsilon thresholds to calculate if semantically similar or not"
             " and eps_to_extract for the epsilon value to extract deduplicated data."
         ),
     )

--- a/nemo_curator/utils/import_utils.py
+++ b/nemo_curator/utils/import_utils.py
@@ -313,15 +313,13 @@ def safe_import_from(module, symbol, *, msg=None, alt=None):
         return getattr(imported_module, symbol)
     except ImportError:
         exception_text = traceback.format_exc()
-        print(f"Import of {module} failed with: {exception_text}")
+        logger.debug(f"Import of {module} failed with: {exception_text}")
     except AttributeError:
         exception_text = traceback.format_exc()
-        print(f"Import of {symbol} from {module} failed with: {exception_text}")
+        logger.info(f"Import of {symbol} from {module} failed with: {exception_text}")
     except Exception:
         exception_text = traceback.format_exc()
-        print(f"Import of {symbol} from {module} failed with: {exception_text}")
         raise
-    print("HEREHERHERHE ")
     if msg is None:
         msg = f"{module}.{symbol} could not be imported"
     if alt is None:
@@ -353,7 +351,7 @@ def gpu_only_import(module, *, alt=None):
         The imported module, the given alternate, or a class derived from
         UnavailableMeta.
     """
-    print("HERE 1")
+
     return safe_import(
         module,
         msg=f"{module} is not enabled in non GPU-enabled installations or environments. {GPU_INSTALL_STRING}",

--- a/nemo_curator/utils/import_utils.py
+++ b/nemo_curator/utils/import_utils.py
@@ -313,13 +313,15 @@ def safe_import_from(module, symbol, *, msg=None, alt=None):
         return getattr(imported_module, symbol)
     except ImportError:
         exception_text = traceback.format_exc()
-        logger.debug(f"Import of {module} failed with: {exception_text}")
+        print(f"Import of {module} failed with: {exception_text}")
     except AttributeError:
         exception_text = traceback.format_exc()
-        logger.info(f"Import of {symbol} from {module} failed with: {exception_text}")
+        print(f"Import of {symbol} from {module} failed with: {exception_text}")
     except Exception:
         exception_text = traceback.format_exc()
+        print(f"Import of {symbol} from {module} failed with: {exception_text}")
         raise
+    print("HEREHERHERHE ")
     if msg is None:
         msg = f"{module}.{symbol} could not be imported"
     if alt is None:
@@ -351,7 +353,7 @@ def gpu_only_import(module, *, alt=None):
         The imported module, the given alternate, or a class derived from
         UnavailableMeta.
     """
-
+    print("HERE 1")
     return safe_import(
         module,
         msg=f"{module} is not enabled in non GPU-enabled installations or environments. {GPU_INSTALL_STRING}",

--- a/nemo_curator/utils/script_utils.py
+++ b/nemo_curator/utils/script_utils.py
@@ -592,7 +592,6 @@ class ArgumentHelper:
         argumentHelper.add_arg_input_file_type()
         argumentHelper.add_arg_input_text_field()
         argumentHelper.add_arg_id_column()
-        argumentHelper.add_arg_id_column_type()
 
         argumentHelper.parser.add_argument(
             "--config-file",

--- a/nemo_curator/utils/semdedup_utils.py
+++ b/nemo_curator/utils/semdedup_utils.py
@@ -15,22 +15,15 @@
 
 import logging
 import os
-import random
-import shutil
-import time
-from typing import List, Literal, Optional, Tuple
+from typing import Literal, Tuple
 
 import cudf
 import cupy as cp
-import dask.bag as db
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import torch
-from dask.distributed import progress
-
-from nemo_curator.utils.distributed_utils import performance_report_if_with_ts_suffix
-from nemo_curator.utils.file_utils import expand_outdir_and_mkdir
+from crossfit.backend.cudf.series import create_list_series_from_1d_or_2d_ar
 
 L2_DIST_TO_CENT_COL = "l2_dist_to_cent"
 COSINE_DIST_TO_CENT_COL = "cosine_dist_to_cent"
@@ -41,7 +34,9 @@ def normalize_embeddings_col_in_df(
 ) -> cudf.DataFrame:
     tensor = torch.Tensor(get_array_from_df(df, embedding_col))
     normalized_tensor = tensor / torch.norm(tensor, dim=1, keepdim=True)
-    df[embedding_col] = normalized_tensor.tolist()
+    df[embedding_col] = create_list_series_from_1d_or_2d_ar(
+        cp.asarray(normalized_tensor), index=df.index
+    )
     return df
 
 
@@ -49,150 +44,31 @@ def get_array_from_df(df: cudf.DataFrame, embedding_col: str) -> cp.ndarray:
     return df[embedding_col].list.leaves.values.reshape(len(df), -1)
 
 
-def assign_and_sort_clusters(
-    id_col: str,
-    kmeans_centroids_file: str,
-    nearest_cent_dir: str,
-    output_sorted_clusters_dir: str,
-    cluster_ids: List[int],
-    # TODO : add l2 distance support
-    sim_metric: Literal["cosine"],
-    embedding_col: str,
-    keep_hard: bool = True,
-    logger: Optional[logging.Logger] = None,
-    profile_dir: Optional[str] = None,
-):
+def add_l2_cosine_dist_to_centroid(
+    df: cudf.DataFrame, embedding_col: str, centroids: cp.ndarray
+) -> cudf.DataFrame:
     """
-    Args:
-        id_col (str): The column name representing the unique identifier for each data point.
-        centroids_path (str): The location of the K-means centroids file.
-        nearest_cent_dir (str): The location of the nearest center files.
-        output_sorted_clusters_dir (str): The location to save the sorted clusters.
-        sim_metric (str): The similarity metric to use for clustering. Currently only "cosine" is supported.
-        keep_hard (bool): When True, sorts cluster items in descending order by similarity to the cluster centroid. Defaults to True.
-        sorted_clusters_file_loc (str): The location to save the sorted clusters file. Defaults to an empty string.
-        cluster_ids (list): The range of cluster IDs to sort.
-        logger (logging.Logger): A logger object to log messages. Defaults to None.
-        profile_dir (str): If specified directory to write dask profile. Default is None.
-
-    Returns:
-        None
+    Computes the L2 distance to nearest centroid to each embedding in the DataFrame.
+    Embeddings are normalized. For cosine we'll need to normalize the centroids as well.
     """
-    # Step 3: Sort each class/cluster
-    logger.info("Ranking...")
-    if os.path.exists(output_sorted_clusters_dir):
-        logger.info(
-            f"Removing existing sorted cluster directory: {output_sorted_clusters_dir}"
-        )
-        shutil.rmtree(output_sorted_clusters_dir)
+    normalized_embeddings = get_array_from_df(df, embedding_col)
+    centroids_ar = centroids[df["nearest_cent"].values]
+    dist_to_cents = cp.sqrt(cp.sum((normalized_embeddings - centroids_ar) ** 2, axis=1))
+    df[L2_DIST_TO_CENT_COL] = dist_to_cents
+    del centroids_ar
 
-    expand_outdir_and_mkdir(output_sorted_clusters_dir)
-
-    kmeans_centroids = np.load(kmeans_centroids_file)
-    start_time = time.time()
-
-    with performance_report_if_with_ts_suffix(
-        profile_dir,
-        "ranking-clusters",
-    ):
-        cluster_ids_bag = db.from_sequence(cluster_ids, npartitions=len(cluster_ids))
-        completed_count = cluster_ids_bag.map(
-            lambda cluster_c: rank_within_cluster(
-                id_col=id_col,
-                nearest_cent_dir=nearest_cent_dir,
-                output_sorted_clusters_dir=output_sorted_clusters_dir,
-                centroids=kmeans_centroids,
-                embedding_col=embedding_col,
-                sim_metric=sim_metric,
-                keep_hard=keep_hard,
-                cluster_ids=[cluster_c],
-            )
-        ).compute()
-
-        missing = len(cluster_ids) - sum(completed_count)
-    logger.info(
-        f"Completed {sum(completed_count)} clusters. Missing {missing} clusters."
-    )
-    logger.info(f"Time taken for Ranking Clusters: {time.time() - start_time}")
-    logger.info("DONE!")
-
-
-# TODO : Deprecate this function and just add cosine distance to the cluster df
-def rank_within_cluster(
-    id_col: str,
-    nearest_cent_dir: str,
-    output_sorted_clusters_dir: str,
-    centroids: np.ndarray,
-    embedding_col: str,
-    sim_metric: Literal["cosine"],
-    keep_hard: bool = True,
-    cluster_ids: List[int] = range(50000),
-):
-    """
-    Sorts each cluster's items by their distance (based on cosine similarity) to the cluster centroid.
-
-    Args:
-        id_col (str): The column name representing the unique identifier for each data point.
-        nearest_cent_dir (str): The location of the nearest center files.
-        output_sorted_clusters_dir (str): The location to save the sorted clusters.
-        centroids (np.ndarray): The centroids for each cluster.
-        sim_metric (str): The similarity metric used to compute distances. Currently only "cosine" is supported.
-        keep_hard (bool): When True, sorts cluster items in descending order by similarity to the cluster centroid. Defaults to True.
-        cluster_ids (List[int]): The list of cluster IDs to process. Defaults to range(50000).
-
-    Returns:
-        None
-    """
-    assert sim_metric in ["cosine"], "sim_metric should be in ['cosine']"
-    missing_files = 0
-    for cluster_c in cluster_ids:
-        cluster_c_path = os.path.join(nearest_cent_dir, f"nearest_cent={cluster_c}")
-        if not os.path.exists(cluster_c_path):
-            missing_files += 1
-            continue
-
-        cluster_df = cudf.read_parquet(cluster_c_path, columns=[id_col, embedding_col])
-
-        embeds = torch.as_tensor(
-            get_array_from_df(cluster_df, embedding_col),
-            device="cuda",
-        )
-        cluster_df = cluster_df.to_pandas()
-
-        if sim_metric == "cosine":
-            cluster_c_centroid = torch.as_tensor(centroids[cluster_c], device="cuda")
-            # TODO because emebds are already normalized we can just use the dot product after normalizing the centroid
-            sim_to_cent = torch.nn.CosineSimilarity(dim=1)(embeds, cluster_c_centroid)
-            # cosine_similarity increases as the similarity increases
-            sim_to_cent = sim_to_cent.cpu().numpy()
-            # distance increases as the similarity decreases
-            cluster_dists_to_cent = (1 - sim_to_cent).tolist()
-        elif sim_metric == "l2":
-            # Used when kmeans_with_cos_dist is True
-            cluster_dists_to_cent = list(cluster_df["dist_to_cent"])
-
-        cluster_label = np.full((len(cluster_df)), cluster_c).tolist()
-        example_id = list(cluster_df[id_col])
-
-        # when keep_hard is True, most dissimilar items first, those with highest distance to the centroid
-        # when keep_hard is False, most similar items first, those with lowest distance to the centroid
-        cluster_sorted = sorted(
-            zip(example_id, cluster_dists_to_cent, cluster_label),
-            key=lambda x: (x[1], x[0]),
-            reverse=keep_hard,
-        )
-
-        sorted_cluster_file_path = os.path.join(
-            output_sorted_clusters_dir, f"cluster_{cluster_c}.npy"
-        )
-        np.save(sorted_cluster_file_path, cluster_sorted)
-    return len(cluster_ids) - missing_files
+    centroids_norm = centroids / cp.linalg.norm(centroids, axis=1, keepdims=True)
+    centroids_ar = centroids_norm[df["nearest_cent"].values]
+    # We normalize the centroids as well
+    cosine_similarities = cp.sum(normalized_embeddings * centroids_ar, axis=1)
+    df[COSINE_DIST_TO_CENT_COL] = 1 - cosine_similarities
+    return df
 
 
 def pairwise_cosine_similarity(
     cluster_reps: torch.Tensor,
     device: Literal["cuda", "cpu"],
-) -> Tuple[torch.Tensor, List[int]]:
+) -> Tuple[cp.ndarray, cp.ndarray]:
     """
     Compute pairwise cosine similarity between cluster items,
     then replace to diagonal with zeros to ignore self similarity
@@ -207,16 +83,16 @@ def pairwise_cosine_similarity(
     triu_sim_mat = torch.triu(pairwise_sim_matrix, diagonal=1)
     # Get max similarity and indices
     max_values_and_indices = torch.max(triu_sim_mat, dim=0)
-    max_similarity = max_values_and_indices[0].cpu()
-    max_indices = max_values_and_indices[1].cpu().numpy().tolist()
-    return max_similarity, max_indices
+    max_similarity = max_values_and_indices[0]
+    max_indices = max_values_and_indices[1]
+    return cp.asarray(max_similarity, dtype=cp.float32), cp.asarray(max_indices)
 
 
 def pairwise_cosine_similarity_batched(
     cluster_reps: torch.Tensor,
     device: Literal["cuda", "cpu"],
     batch_size: int = 1024,
-) -> Tuple[torch.Tensor, List[int]]:
+) -> Tuple[cp.ndarray, cp.ndarray]:
     """
     Computes pairwise cosine similarity between cluster items,
     then replace to diagonal with zeros to ignore self similarity.
@@ -227,7 +103,9 @@ def pairwise_cosine_similarity_batched(
     instead of O(N^2) for the full matrix.
     """
     cluster_reps = cluster_reps.to(device)
-    max_similarity = torch.zeros(cluster_reps.shape[0], device=device)
+    max_similarity = torch.zeros(
+        cluster_reps.shape[0], dtype=torch.float32, device=device
+    )
     max_indices = torch.zeros(cluster_reps.shape[0], dtype=torch.int64, device=device)
     for start_idx in range(0, cluster_reps.shape[0], batch_size):
         end_idx = min(start_idx + batch_size, cluster_reps.shape[0])
@@ -239,137 +117,85 @@ def pairwise_cosine_similarity_batched(
         max_similarity[start_idx:end_idx] = max_values_and_indices[0]
         max_indices[start_idx:end_idx] = max_values_and_indices[1]
 
-    return max_similarity.cpu(), max_indices.cpu().numpy().tolist()
-
-
-def read_cluster_embeddings_and_sort_by_id(
-    cluster_id: int,
-    emb_by_clust_dir: str,
-    id_col: str,
-    embedding_col: str,
-    sorted_ids: np.ndarray,
-) -> torch.Tensor:
-    # TODO remove this logic so we can just sort here based on which_to_keep
-    cluster_i_path = os.path.join(emb_by_clust_dir, f"nearest_cent={cluster_id}")
-    cluster_reps = cudf.read_parquet(
-        cluster_i_path, columns=[embedding_col, id_col]
-    ).sort_values(by=id_col)
-    num = cluster_reps.shape[0]
-    df_ = pd.DataFrame(
-        {"sorted_ids": sorted_ids, "inverse_sort": list(range(num))}
-    ).sort_values(by="sorted_ids")
-    cluster_reps["inverse_sort_id"] = df_["inverse_sort"].values
-    cluster_reps = cluster_reps.sort_values(by="inverse_sort_id")
-
-    cluster_reps = torch.as_tensor(
-        cluster_reps[embedding_col].list.leaves.values.reshape(len(cluster_reps), -1),
-        device="cuda",
-    )
-    return cluster_reps
-
-
-def get_ids_within_cluster(
-    cluster_id: int,
-    sorted_clusters_dir: str,
-    id_col_type: str,
-    which_to_keep: Literal["hard", "random", "easy"],
-) -> Optional[np.ndarray]:
-    sorted_file = os.path.join(sorted_clusters_dir, f"cluster_{cluster_id}.npy")
-    if not os.path.exists(sorted_file):
-        logging.info(f"{sorted_file} does not exist. Continue")
-        return
-
-    cluster_i = np.load(sorted_file)
-    cluster_size = cluster_i.shape[0]
-    cluster_items_indices = list(range(cluster_size))
-    which_to_keep = which_to_keep.lower()
-    if which_to_keep == "random":
-        random.shuffle(cluster_items_indices)
-        cluster_i = cluster_i[cluster_items_indices]
-    return cluster_i[:, 0].astype(id_col_type)
+    return cp.asarray(max_similarity), cp.asarray(max_indices)
 
 
 def get_semantic_matches_per_cluster(
     cluster_id: int,
     emb_by_clust_dir: str,
-    sorted_clusters_dir: str,
     id_col: str,
-    id_col_type: str,
-    eps_list: List[float],
     output_dir: str,
     embedding_col: str,
-    which_to_keep: str,
+    which_to_keep: Literal["hard", "easy", "random"],
+    sim_metric: Literal["cosine", "l2"],
     batched_cosine_similarity: int = 1024,
 ) -> None:
-    output_df_file_path = os.path.join(output_dir, f"cluster_{cluster_id}.parquet")
-    ids = get_ids_within_cluster(
-        cluster_id, sorted_clusters_dir, id_col_type, which_to_keep
+    """
+    Get the semantic matches for a single cluster.
+    Reads the cluster embeddings and then computes pairwise cosine similarity between them.
+    """
+    if sim_metric == "cosine":
+        distance_col = COSINE_DIST_TO_CENT_COL
+    elif sim_metric == "l2":
+        distance_col = L2_DIST_TO_CENT_COL
+    else:
+        msg = f"Invalid similarity metric: {sim_metric}. Only cosine and l2 are supported."
+        raise ValueError(msg)
+
+    cluster_df = cudf.read_parquet(
+        os.path.join(emb_by_clust_dir, f"nearest_cent={cluster_id}"),
+        columns=[embedding_col, id_col, distance_col],
     )
-    if ids is None:
-        return
-    # Handle edge case where cluster is a singleton
-    if len(ids) == 1:
-        points_to_remove_df = pd.DataFrame()
-        points_to_remove_df["indices"] = [0]
-        for eps in eps_list:
-            points_to_remove_df[f"eps={eps}"] = [False]
-        points_to_remove_df.to_parquet(output_df_file_path)
+    output_df_file_path = os.path.join(output_dir, f"cluster_{cluster_id}.parquet")
+    if len(cluster_df) == 1:
+        cluster_df["id"] = cluster_df[id_col]
+        cluster_df["max_id"] = cluster_df[id_col]
+        cluster_df["cosine_sim_score"] = [0]
+        cluster_df = cluster_df[["id", "max_id", "cosine_sim_score"]]
+        cluster_df.to_parquet(output_df_file_path)
         return
 
-    cluster_reps = read_cluster_embeddings_and_sort_by_id(
-        cluster_id, emb_by_clust_dir, id_col, embedding_col, sorted_ids=ids
+    if which_to_keep == "hard":
+        cluster_df = cluster_df.sort_values(
+            by=[distance_col, id_col], ascending=False, ignore_index=True
+        )
+    elif which_to_keep == "easy":
+        cluster_df = cluster_df.sort_values(
+            by=[distance_col, id_col], ascending=True, ignore_index=True
+        )
+    elif which_to_keep == "random":
+        cluster_df = cluster_df.sample(frac=1).reset_index(drop=True)
+
+    cluster_embeddings = torch.as_tensor(
+        get_array_from_df(cluster_df, embedding_col), device="cuda"
     )
+    ids = cluster_df[id_col]
+    assert cluster_embeddings.shape[0] == len(ids)
+
     if batched_cosine_similarity > 0:
         max_similarity, max_indices = pairwise_cosine_similarity_batched(
-            cluster_reps, "cuda", batched_cosine_similarity
+            cluster_embeddings, "cuda", batched_cosine_similarity
         )
     else:
-        max_similarity, max_indices = pairwise_cosine_similarity(cluster_reps, "cuda")
-    assert cluster_reps.shape[0] == len(ids)
-    max_indices_id = [ids[m] for m in max_indices]
+        max_similarity, max_indices = pairwise_cosine_similarity(
+            cluster_embeddings, "cuda"
+        )
 
-    points_to_remove_df = cudf.DataFrame()
-    # TODO we can remove this column indixes
-    points_to_remove_df["indices"] = list(range(len(ids)))
-    points_to_remove_df["id"] = ids
-    points_to_remove_df["max_id"] = max_indices_id
-    points_to_remove_df["cosine_sim_score"] = max_similarity.numpy().tolist()
-
-    # TODO : what's the benefit of having this as a column?
-    for eps in eps_list:
-        eps_points_to_remove = max_similarity > 1 - eps
-        points_to_remove_df[f"eps={eps}"] = eps_points_to_remove
-
-    points_to_remove_df.to_parquet(output_df_file_path)
-
-
-def get_num_records_from_npy(file_path: str) -> int:
-    if not os.path.exists(file_path):
-        return 0
-    with open(file_path, "rb") as f:
-        # Read the header of the npy file
-        version = np.lib.format.read_magic(f)
-        shape, _, _ = np.lib.format._read_array_header(f, version)
-    return shape[0]
-
-
-def _get_empty_results_df(id_col, id_col_type):
-    meta_df = pd.DataFrame(
+    max_indices_id = cluster_df[id_col].iloc[max_indices].values
+    points_to_remove_df = cudf.DataFrame(
         {
-            id_col: np.empty(0, dtype="int64"),
-            "dist": np.empty(0, dtype="float32"),
-            "cluster": np.empty(0, dtype="int32"),
+            "id": ids,
+            "max_id": max_indices_id,
+            "cosine_sim_score": max_similarity,
         }
     )
-    meta_df[id_col] = meta_df[id_col].astype(id_col_type)
-    return meta_df
+    points_to_remove_df.to_parquet(output_df_file_path)
 
 
 def prune_single_cluster(
     cluster_id: int,
     id_col: str,
-    id_col_type: str,
-    sorted_clusters_dir: str,
+    emb_by_clust_dir: str,
     semdedup_pruning_tables_dir: str,
     eps: float,
 ) -> cudf.DataFrame:
@@ -379,148 +205,49 @@ def prune_single_cluster(
     Args:
         cluster_id (int): The specific cluster ID to process.
         id_col (str): The name of the ID column.
-        id_col_type (str): The data type of the ID column.
-        sorted_clusters_dir (str): Path to the sorted clusters directory.
+        emb_by_clust_dir (str): Path to where clustered embeddings are stored.
         semdedup_pruning_tables_dir (str): Path to the pruning tables directory.
         eps (float): Epsilon value for pruning.
 
     Returns:
         cudf.DataFrame: A DataFrame of the pruned cluster data
     """
-    sorted_fname = os.path.join(sorted_clusters_dir, f"cluster_{cluster_id}.npy")
-    if not os.path.exists(sorted_fname):
-        return _get_empty_results_df(id_col, id_col_type)
+    cluster_dir = os.path.join(emb_by_clust_dir, f"nearest_cent={cluster_id}")
+    # For the output we only return id, cosine_dist_to_cent, and cluster
+    df_cluster = cudf.read_parquet(
+        cluster_dir, columns=[id_col, COSINE_DIST_TO_CENT_COL]
+    ).assign(cluster=cluster_id)
 
-    # Read the sorted cluster file
-    # Once we change sorted file to parquet we can just read the DF here instead of loading the npy file and converting to DF
-    cluster_data = np.load(sorted_fname)
-    df_cluster = cudf.DataFrame(
-        {
-            id_col: cluster_data[:, 0],
-            "dist": cluster_data[:, 1],
-            "cluster": cluster_data[:, 2],
-        }
-    )
-
-    df_cluster[id_col] = df_cluster[id_col].astype(id_col_type)
-    df_cluster["dist"] = df_cluster["dist"].astype("float32")
-    df_cluster["cluster"] = df_cluster["cluster"].astype("int32")
-
-    # TODO : we don't need to read the pruning table here as we can just filter on the cosine_sim_score in the sorted cluster file once we add it
-    # Read the pruning table
     pruning_table_fname = os.path.join(
         semdedup_pruning_tables_dir, f"cluster_{cluster_id}.parquet"
     )
-    pruning_table = cudf.read_parquet(pruning_table_fname)
+    # In future we can add more columns to the pruning table like max_id etc.
+    pruning_table = cudf.read_parquet(
+        pruning_table_fname, columns=["id", "cosine_sim_score"]
+    )
     if pruning_table.shape[0] == 1:
         return df_cluster
-
-    # TODO: Fix this without going to host
-    items_to_keep = (
-        pruning_table[pruning_table[f"eps={eps}"] == False]["id"].to_arrow().to_pylist()
+    pruning_table = pruning_table[pruning_table["cosine_sim_score"] < 1 - eps][["id"]]
+    # In future we can avoid this merge if we add more columns to the pruning table
+    # However that might increase memory consumption at that stage, keeping it as is for now
+    return df_cluster.merge(
+        pruning_table.rename(columns={"id": id_col}), on=id_col, how="inner"
     )
-    pruned_cluster = df_cluster[df_cluster[id_col].isin(items_to_keep)]
-    pruned_cluster[id_col] = pruned_cluster[id_col].astype(id_col_type)
-    return pruned_cluster
 
 
-def extract_pruned_data(
-    id_col: str,
-    id_col_type: str,
-    sorted_clusters_dir: str,
-    semdedup_pruning_tables_dir: str,
+def write_pruned_summary_file(
     eps: float,
-    n_clusters: int,
-    output_parquet_path: str,
-    logger: Optional[logging.Logger] = None,
-    profile_dir: Optional[str] = None,
-) -> Tuple[int, int, int]:
-    """
-    Extracts pruned data from sorted clusters and saves it to a CSV file.
-
-    Args:
-        id_col (str): The name of the ID column.
-        id_col_type (str): The data type of the ID column.
-        sorted_clusters_dir (str): Path to the sorted clusters directory.
-        semdedup_pruning_tables_dir (str): Path to the pruning tables directory.
-        eps (float): Epsilon value for pruning.
-        n_clusters (int): Number of clusters.
-        output_csv_path (str): Path to save the output CSV file.
-        logger (Optional[logging.Logger]): Logger object or path to store logs, defaults to None.
-        profile_dir (str): If specified directory to write dask profile. Default is None.
-
-    Returns:
-        Tuple[int, int, int]: Number of kept records, removed records, and total records.
-    """
-
-    t0 = time.time()
-
-    with performance_report_if_with_ts_suffix(
-        profile_dir,
-        "extracting-pruned-from-clusters",
-    ):
-        results_df = dd.from_map(
-            prune_single_cluster,
-            range(n_clusters),
-            id_col=id_col,
-            id_col_type=id_col_type,
-            sorted_clusters_dir=sorted_clusters_dir,
-            semdedup_pruning_tables_dir=semdedup_pruning_tables_dir,
-            eps=eps,
-        )
-        results_df[id_col] = results_df[id_col].astype(id_col_type)
-        results_df = results_df.persist()
-        progress(results_df)
-
-        results_df.to_parquet(output_parquet_path)
-    if logger:
-        logger.info(
-            f"Time taken for Extracting Pruned Data : {time.time() - t0} and output written at {output_parquet_path}"
-        )
-
-    total_kept = len(results_df)
-
-    sorted_npy_files = [
-        os.path.join(sorted_clusters_dir, f"cluster_{i}.npy") for i in range(n_clusters)
-    ]
-    total_records = sum(
-        get_num_records_from_npy(file_path) for file_path in sorted_npy_files
-    )
-    # Aggregate results
-    total_removed = total_records - total_kept
-    return total_kept, total_removed, total_records
-
-
-def extract_dedup_data(
-    eps,
-    n_clusters,
-    id_col,
-    id_col_type,
-    sorted_clusters_dir,
-    semdedup_pruning_tables_dir,
-    output_summary_file,
-    output_parquet_path,
+    emb_by_clust_dir: str,
+    filtered_unique_ids_path: str,
+    output_summary_file: str,
     logger: logging.Logger,
-    profile_dir: Optional[str] = None,
-) -> dd.DataFrame:
+):
     """
-    Extracts deduplicated data based on provided parameters and logs the process.
-
-    Args:
-
+    Writes a summary file for the pruned data.
     """
-
-    kept, removed, total = extract_pruned_data(
-        id_col=id_col,
-        id_col_type=id_col_type,
-        sorted_clusters_dir=sorted_clusters_dir,
-        semdedup_pruning_tables_dir=semdedup_pruning_tables_dir,
-        eps=eps,
-        n_clusters=n_clusters,
-        output_parquet_path=output_parquet_path,
-        logger=logger,
-        profile_dir=profile_dir,
-    )
+    kept = len(dd.read_parquet(filtered_unique_ids_path))
+    total = len(dd.read_parquet(emb_by_clust_dir))
+    removed = total - kept
 
     logger.info(
         f"DONE saving {kept} out of {total}. Removed: {removed}. Epsilon: {eps:.4f}"
@@ -533,10 +260,3 @@ def extract_dedup_data(
     }
     df = pd.DataFrame(result_dict)
     df.to_csv(output_summary_file, index=False)
-
-    fps = [
-        os.path.join(output_parquet_path, file_name)
-        for file_name in os.listdir(output_parquet_path)
-    ]
-    ids_to_keep_df = dd.from_map(cudf.read_parquet, fps)
-    return ids_to_keep_df

--- a/nemo_curator/utils/semdedup_utils.py
+++ b/nemo_curator/utils/semdedup_utils.py
@@ -20,7 +20,6 @@ from typing import Literal, Tuple
 import cudf
 import cupy as cp
 import dask.dataframe as dd
-import numpy as np
 import pandas as pd
 import torch
 from crossfit.backend.cudf.series import create_list_series_from_1d_or_2d_ar

--- a/nemo_curator/utils/semdedup_utils.py
+++ b/nemo_curator/utils/semdedup_utils.py
@@ -163,7 +163,7 @@ def get_semantic_matches_per_cluster(
             by=[distance_col, id_col], ascending=True, ignore_index=True
         )
     elif which_to_keep == "random":
-        cluster_df = cluster_df.sample(frac=1).reset_index(drop=True)
+        cluster_df = cluster_df.sample(frac=1, random_state=42, ignore_index=True)
 
     cluster_embeddings = torch.as_tensor(
         get_array_from_df(cluster_df, embedding_col), device="cuda"

--- a/tests/test_argument_helper.py
+++ b/tests/test_argument_helper.py
@@ -367,7 +367,6 @@ class TestArgumentHelper:
         assert "--input-file-type" in parser.format_help()
         assert "--input-text-field" in parser.format_help()
         assert "--id-column" in parser.format_help()
-        assert "--id-column-type" in parser.format_help()
 
         assert "--config-file" in parser.format_help()
 

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -16,24 +16,43 @@ from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pytest
+from unittest import mock
 import torch
 import torch.nn.functional as F
+import dask
 from dask.dataframe.utils import assert_eq
 from transformers import AutoConfig, AutoModel, AutoTokenizer
 import tempfile
 import pandas as pd
 import cupy as cp
-
+from sklearn.datasets import make_blobs
+import dask.dataframe as dd
 from nemo_curator import SemDedup, SemDedupConfig
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.utils.import_utils import gpu_only_import, gpu_only_import_from
-from nemo_curator.modules.semantic_dedup.clusteringmodel import add_l2_dist_to_cents
-from nemo_curator.utils.semdedup_utils import rank_within_cluster, get_normalized_embedding_array
 
 cudf = gpu_only_import("cudf")
 dask_cudf = gpu_only_import("dask_cudf")
 EmbeddingCreator = gpu_only_import_from(
     "nemo_curator.modules.semantic_dedup.embeddings", "EmbeddingCreator"
+)
+ClusteringModel = gpu_only_import_from(
+    "nemo_curator.modules.semantic_dedup.clusteringmodel", "ClusteringModel"
+)
+SemanticClusterLevelDedup = gpu_only_import_from(
+    "nemo_curator.modules.semantic_dedup.semanticclusterleveldedup", "SemanticClusterLevelDedup"
+)
+add_l2_dist_to_cents = gpu_only_import_from(
+    "nemo_curator.modules.semantic_dedup.clusteringmodel", "add_l2_dist_to_cents"
+)
+rank_within_cluster = gpu_only_import_from(
+    "nemo_curator.utils.semdedup_utils", "rank_within_cluster"
+)
+normalize_embeddings_col_in_df = gpu_only_import_from(
+    "nemo_curator.utils.semdedup_utils", "normalize_embeddings_col_in_df"
+)
+get_array_from_df = gpu_only_import_from(
+    "nemo_curator.utils.semdedup_utils", "get_array_from_df"
 )
 pairwise_cosine_similarity = gpu_only_import_from(
     "nemo_curator.utils.semdedup_utils", "pairwise_cosine_similarity"
@@ -41,388 +60,634 @@ pairwise_cosine_similarity = gpu_only_import_from(
 pairwise_cosine_similarity_batched = gpu_only_import_from(
     "nemo_curator.utils.semdedup_utils", "pairwise_cosine_similarity_batched"
 )
+get_ids_within_cluster = gpu_only_import_from(
+    "nemo_curator.utils.semdedup_utils", "get_ids_within_cluster"
+)
+
+read_cluster_embeddings_and_sort_by_id = gpu_only_import_from(
+    "nemo_curator.utils.semdedup_utils", "read_cluster_embeddings_and_sort_by_id"
+)
+
 if TYPE_CHECKING:
+    from nemo_curator.modules.semantic_dedup.semanticclusterleveldedup import (
+        SemanticClusterLevelDedup,
+    )   
+    from nemo_curator.modules.semantic_dedup.clusteringmodel import (
+        ClusteringModel,
+        add_l2_dist_to_cents,
+    )
     from nemo_curator.utils.semdedup_utils import (
+        rank_within_cluster,
+        get_array_from_df,
+        normalize_embeddings_col_in_df,
         pairwise_cosine_similarity,
         pairwise_cosine_similarity_batched,
+        read_cluster_embeddings_and_sort_by_id,
+        get_ids_within_cluster,
     )
 
 
-@pytest.fixture
-def dedup_data():
-    df = cudf.DataFrame(
-        {
-            "id": [1, 2, 3, 4, 100, 200, 300],
-            "text": [
-                "The quick brown fox jumps over the lazy dog",
-                "The quick brown foxes jumps over the lazy dog",
-                "The quick brown wolf jumps over the lazy dog",
-                "The quick black cat jumps over the lazy dog",
-                "A test string",
-                "Another test string",
-                "A different object",
-            ],
-        }
-    )
-    df = dask_cudf.from_cudf(df, 2)
-    return DocumentDataset(df)
+# @pytest.fixture
+# def dedup_data():
+#     df = cudf.DataFrame(
+#         {
+#             "id": [1, 2, 3, 4, 100, 200, 300],
+#             "text": [
+#                 "The quick brown fox jumps over the lazy dog",
+#                 "The quick brown foxes jumps over the lazy dog",
+#                 "The quick brown wolf jumps over the lazy dog",
+#                 "The quick black cat jumps over the lazy dog",
+#                 "A test string",
+#                 "Another test string",
+#                 "A different object",
+#             ],
+#         }
+#     )
+#     df = dask_cudf.from_cudf(df, 2)
+#     return DocumentDataset(df)
 
 
-@pytest.fixture
-def non_dedup_data():
-    df = cudf.DataFrame(
-        {
-            "doc_id": ["doc_1", "doc_2"],
-            "text": [
-                "The quick brown fox jumps over the lazy dog",
-                "A test string",
-            ],
-        }
-    )
-    df = dask_cudf.from_cudf(df, 2)
-    return DocumentDataset(df)
+# @pytest.fixture
+# def non_dedup_data():
+#     df = cudf.DataFrame(
+#         {
+#             "doc_id": ["doc_1", "doc_2"],
+#             "text": [
+#                 "The quick brown fox jumps over the lazy dog",
+#                 "A test string",
+#             ],
+#         }
+#     )
+#     df = dask_cudf.from_cudf(df, 2)
+#     return DocumentDataset(df)
 
 
-@pytest.mark.gpu
-class TestSemDuplicates:
-    @pytest.mark.parametrize("n_clusters", [3, 10])
-    def test_sem_dedup(
-        self,
-        dedup_data,
-        tmpdir,
-        n_clusters,
-        gpu_client,
-    ):
-        print("client", gpu_client)
+# @pytest.mark.gpu
+# class TestSemDuplicates:
+#     @pytest.mark.parametrize("n_clusters", [3, 10])
+#     def test_sem_dedup(
+#         self,
+#         dedup_data,
+#         tmpdir,
+#         n_clusters,
+#         gpu_client,
+#     ):
+#         print("client", gpu_client)
 
-        cache_dir = os.path.join(tmpdir, "test_sem_dedup_cache")
-        config = SemDedupConfig(
-            cache_dir=cache_dir,
-            n_clusters=n_clusters,
-            eps_thresholds=[0.10],
-            eps_to_extract=0.10,
-        )
+#         cache_dir = os.path.join(tmpdir, "test_sem_dedup_cache")
+#         config = SemDedupConfig(
+#             cache_dir=cache_dir,
+#             n_clusters=n_clusters,
+#             eps_thresholds=[0.10],
+#             eps_to_extract=0.10,
+#         )
 
-        sem_duplicates = SemDedup(
-            config=config,
-            input_column="text",
-            id_column="id",
-            id_column_type="int",
-        )
+#         sem_duplicates = SemDedup(
+#             config=config,
+#             input_column="text",
+#             id_column="id",
+#             id_column_type="int",
+#         )
 
-        dedup_data_len = dedup_data.df.shape[0].compute()
-        if n_clusters > dedup_data_len:
-            # Number of records in the dataset should never be less than n_clusters
-            with pytest.raises(ValueError):
-                result = sem_duplicates(dedup_data)
-        else:
-            # Correctly returns the original dataset with no duplicates removed
-            result = sem_duplicates(dedup_data)
-            result_df = result.df.compute()
-            duplicate_docs = [2, 3, 4, 200, 300]
-            expected_df = cudf.Series(duplicate_docs, name="id")
-            assert_eq(result_df["id"].sort_values(), expected_df, check_index=False)
+#         dedup_data_len = dedup_data.df.shape[0].compute()
+#         if n_clusters > dedup_data_len:
+#             # Number of records in the dataset should never be less than n_clusters
+#             with pytest.raises(ValueError):
+#                 result = sem_duplicates(dedup_data)
+#         else:
+#             # Correctly returns the original dataset with no duplicates removed
+#             result = sem_duplicates(dedup_data)
+#             result_df = result.df.compute()
+#             duplicate_docs = [2, 3, 4, 200, 300]
+#             expected_df = cudf.Series(duplicate_docs, name="id")
+#             assert_eq(result_df["id"].sort_values(), expected_df, check_index=False)
 
-    @pytest.mark.parametrize("n_clusters", [2, 3])
-    def test_no_sem_dedup(
-        self,
-        non_dedup_data,
-        tmpdir,
-        n_clusters,
-        gpu_client,
-    ):
-        print("client", gpu_client)
+#     @pytest.mark.parametrize("n_clusters", [2, 3])
+#     def test_no_sem_dedup(
+#         self,
+#         non_dedup_data,
+#         tmpdir,
+#         n_clusters,
+#         gpu_client,
+#     ):
+#         print("client", gpu_client)
 
-        cache_dir = os.path.join(tmpdir, "test_no_sem_dedup")
-        config = SemDedupConfig(
-            cache_dir=cache_dir,
-            n_clusters=n_clusters,
-            eps_thresholds=[0.10],
-            eps_to_extract=0.10,
-        )
+#         cache_dir = os.path.join(tmpdir, "test_no_sem_dedup")
+#         config = SemDedupConfig(
+#             cache_dir=cache_dir,
+#             n_clusters=n_clusters,
+#             eps_thresholds=[0.10],
+#             eps_to_extract=0.10,
+#         )
 
-        sem_duplicates = SemDedup(
-            config=config,
-            input_column="text",
-            id_column="doc_id",
-            id_column_type="str",
-        )
+#         sem_duplicates = SemDedup(
+#             config=config,
+#             input_column="text",
+#             id_column="doc_id",
+#             id_column_type="str",
+#         )
 
-        non_dedup_data_len = non_dedup_data.df.shape[0].compute()
-        if n_clusters > non_dedup_data_len:
-            # Number of records in the dataset should never be less than n_clusters
-            with pytest.raises(ValueError):
-                result = sem_duplicates(non_dedup_data)
-        else:
-            # Correctly returns the original dataset with no duplicates removed
-            result = sem_duplicates(non_dedup_data)
-            result_df = result.df.compute()
-            duplicate_docs = ["doc_1", "doc_2"]
-            expected_df = cudf.Series(duplicate_docs, name="doc_id")
-            assert_eq(result_df["doc_id"].sort_values(), expected_df, check_index=False)
+#         non_dedup_data_len = non_dedup_data.df.shape[0].compute()
+#         if n_clusters > non_dedup_data_len:
+#             # Number of records in the dataset should never be less than n_clusters
+#             with pytest.raises(ValueError):
+#                 result = sem_duplicates(non_dedup_data)
+#         else:
+#             # Correctly returns the original dataset with no duplicates removed
+#             result = sem_duplicates(non_dedup_data)
+#             result_df = result.df.compute()
+#             duplicate_docs = ["doc_1", "doc_2"]
+#             expected_df = cudf.Series(duplicate_docs, name="doc_id")
+#             assert_eq(result_df["doc_id"].sort_values(), expected_df, check_index=False)
 
-    @pytest.mark.parametrize("pooling_strategy", ["last_token", "mean_pooling"])
-    def test_embedding_creator_pooling_strategies(self, tmpdir, pooling_strategy):
-        test_text_1 = "The quick brown fox jumps over the lazy dog"
-        test_text_2 = "The brown fox jumps over the dog"
-        test_texts = [test_text_1, test_text_2] * 32
-        df = cudf.DataFrame({"text": test_texts})
-        ddf = dask_cudf.from_cudf(df, 1)
+#     @pytest.mark.parametrize("pooling_strategy", ["last_token", "mean_pooling"])
+#     def test_embedding_creator_pooling_strategies(self, tmpdir, pooling_strategy):
+#         test_text_1 = "The quick brown fox jumps over the lazy dog"
+#         test_text_2 = "The brown fox jumps over the dog"
+#         test_texts = [test_text_1, test_text_2] * 32
+#         df = cudf.DataFrame({"text": test_texts})
+#         ddf = dask_cudf.from_cudf(df, 1)
 
-        cache_dir = os.path.join(tmpdir, "test_embeddings_cache")
+#         cache_dir = os.path.join(tmpdir, "test_embeddings_cache")
 
-        embedding_creator = EmbeddingCreator(
-            embedding_model_name_or_path="sentence-transformers/all-MiniLM-L6-v2",
-            embedding_batch_size=32,
-            embedding_pooling_strategy=pooling_strategy,
-            input_column="text",
-            embedding_output_dir=os.path.join(cache_dir, "mean_embeddings"),
-        )
+#         embedding_creator = EmbeddingCreator(
+#             embedding_model_name_or_path="sentence-transformers/all-MiniLM-L6-v2",
+#             embedding_batch_size=32,
+#             embedding_pooling_strategy=pooling_strategy,
+#             input_column="text",
+#             embedding_output_dir=os.path.join(cache_dir, "mean_embeddings"),
+#         )
 
-        embeddings = embedding_creator.create_embeddings(ddf).compute()
-        embeddings = embeddings["embeddings"].to_arrow().to_pylist()
-        embeddings = np.array(embeddings)
+#         embeddings = embedding_creator.create_embeddings(ddf).compute()
+#         embeddings = embeddings["embeddings"].to_arrow().to_pylist()
+#         embeddings = np.array(embeddings)
 
-        reference_embeddings = get_reference_embeddings(
-            test_texts, pooling_strategy=pooling_strategy
-        )
+#         reference_embeddings = get_reference_embeddings(
+#             test_texts, pooling_strategy=pooling_strategy
+#         )
 
-        assert np.allclose(
-            embeddings, reference_embeddings, atol=1e-3
-        ), "Embeddings should match reference embeddings"
-
-
-def get_reference_embeddings(
-    texts,
-    model_name="sentence-transformers/all-MiniLM-L6-v2",
-    pooling_strategy="last_token",
-):
-    """
-    Get embeddings using either last token or mean pooling strategy.
-
-    Args:
-        texts: List of input texts
-        model_name: Name or path of the model to use
-        pooling_strategy: Either "last_token" for last token or "mean" for mean pooling
-    """
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModel.from_pretrained(model_name)
-    model = model.to("cuda")
-    model.eval()
-    max_len_to_use = tokenizer.model_max_length
-    if max_len_to_use > 1e5:
-        max_len_to_use = AutoConfig.from_pretrained(model_name).max_position_embeddings
-    max_seq_length: int = max_len_to_use
-
-    embs = []
-    for text in texts:
-        inputs = tokenizer(
-            text,
-            return_tensors="pt",
-            padding=True,
-            truncation=True,
-            max_length=max_seq_length,
-        )
-        inputs = {k: v.to("cuda") for k, v in inputs.items()}
-
-        with torch.no_grad():
-            with torch.autocast(device_type="cuda"):
-                outputs = model(**inputs)
-
-        if pooling_strategy == "last_token":
-            embeddings = outputs.last_hidden_state[:, -1, :]
-        elif pooling_strategy == "mean_pooling":
-            token_embeddings = outputs.last_hidden_state
-            attention_mask = inputs["attention_mask"]
-            input_mask_expanded = (
-                attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-            )
-            sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, dim=1)
-            sum_mask = torch.clamp(input_mask_expanded.sum(dim=1), min=1e-9)
-            embeddings = sum_embeddings / sum_mask
-        else:
-            raise ValueError(
-                "pooling_strategy must be either 'last_token' or 'mean_pooling'"
-            )
-
-        normed_emb = F.normalize(embeddings, dim=1).cpu()
-        normed_emb = normed_emb.squeeze(0)
-        embs.append(normed_emb)
-
-    return np.array(embs)
+#         assert np.allclose(
+#             embeddings, reference_embeddings, atol=1e-3
+#         ), "Embeddings should match reference embeddings"
 
 
-class TestSemDedupUtils:
-    def setup_method(self):
-        # We create a 6x3 array where each row is a unit vector
-        # The second and last two rows are the same
-        input_embeddings = torch.tensor(
-            np.asarray(
-                [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [1, 2, 3], [1, 2, 3]],
-            ),
-            dtype=torch.float32,
-        )
-        # Normalize the input array
-        self.input_embeddings = input_embeddings / torch.norm(
-            input_embeddings, dim=1, keepdim=True
-        )
-        self.expected_pairwise_similarity = torch.tensor(
-            [0.0000, 0.974631, 0.998190, 0.999618, 1.0000, 1.0000]
-        )
-        self.expected_indices = [0, 0, 1, 2, 0, 0]
+# def get_reference_embeddings(
+#     texts,
+#     model_name="sentence-transformers/all-MiniLM-L6-v2",
+#     pooling_strategy="last_token",
+# ):
+#     """
+#     Get embeddings using either last token or mean pooling strategy.
 
-    @pytest.mark.parametrize("device", [pytest.param("cuda", marks=pytest.mark.gpu)])
-    def test_pairwise_cosine_similarity(self, device: Literal["cpu", "cuda"]):
-        max_similarity, max_indices = pairwise_cosine_similarity(
-            self.input_embeddings.to(device), device
-        )
-        torch.testing.assert_close(
-            max_similarity, self.expected_pairwise_similarity, rtol=1e-6, atol=1e-6
-        )
-        assert max_indices == self.expected_indices
+#     Args:
+#         texts: List of input texts
+#         model_name: Name or path of the model to use
+#         pooling_strategy: Either "last_token" for last token or "mean" for mean pooling
+#     """
+#     tokenizer = AutoTokenizer.from_pretrained(model_name)
+#     model = AutoModel.from_pretrained(model_name)
+#     model = model.to("cuda")
+#     model.eval()
+#     max_len_to_use = tokenizer.model_max_length
+#     if max_len_to_use > 1e5:
+#         max_len_to_use = AutoConfig.from_pretrained(model_name).max_position_embeddings
+#     max_seq_length: int = max_len_to_use
 
-    @pytest.mark.parametrize("device", [pytest.param("cuda", marks=pytest.mark.gpu)])
-    @pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 5, 6])
-    def test_pairwise_cosine_similarity_batched(
-        self, device: Literal["cpu", "cuda"], batch_size: int
-    ):
-        max_similarity, max_indices = pairwise_cosine_similarity_batched(
-            self.input_embeddings.to(device), device, batch_size
-        )
-        torch.testing.assert_close(max_similarity, self.expected_pairwise_similarity)
-        assert max_indices == self.expected_indices
+#     embs = []
+#     for text in texts:
+#         inputs = tokenizer(
+#             text,
+#             return_tensors="pt",
+#             padding=True,
+#             truncation=True,
+#             max_length=max_seq_length,
+#         )
+#         inputs = {k: v.to("cuda") for k, v in inputs.items()}
 
-    @pytest.mark.parametrize("device", [pytest.param("cuda", marks=pytest.mark.gpu)])
-    @pytest.mark.parametrize("batch_size", [100, 512, 1024, 2048])
-    def test_pairwise_cosine_similarity_batched_rand_array(
-        self, device: Literal["cpu", "cuda"], batch_size: int
-    ):
-        N = 1024
-        D = 512
-        rand_arr = torch.randn(N, D, device=device)
-        max_similarity, max_indices = pairwise_cosine_similarity(rand_arr, device)
-        max_similarity_batched, max_indices_batched = (
-            pairwise_cosine_similarity_batched(rand_arr, device, batch_size=batch_size)
-        )
-        torch.testing.assert_close(
-            max_similarity, max_similarity_batched, rtol=1e-5, atol=1e-5
-        )
-        assert max_indices == max_indices_batched
+#         with torch.no_grad():
+#             with torch.autocast(device_type="cuda"):
+#                 outputs = model(**inputs)
 
-    @pytest.mark.gpu
-    @pytest.mark.parametrize("keep_hard", [True, False])
-    def test_rank_within_cluster(self, keep_hard: bool):
-        # Create a temporary directory for output
-        with tempfile.TemporaryDirectory() as temp_dir:
-            # Mock data setup
-            cluster_id = 0
-            id_col = "id"
-            embedding_col = "embedding"
-            nearest_cent_dir = temp_dir
-            output_sorted_clusters_dir = temp_dir
+#         if pooling_strategy == "last_token":
+#             embeddings = outputs.last_hidden_state[:, -1, :]
+#         elif pooling_strategy == "mean_pooling":
+#             token_embeddings = outputs.last_hidden_state
+#             attention_mask = inputs["attention_mask"]
+#             input_mask_expanded = (
+#                 attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+#             )
+#             sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, dim=1)
+#             sum_mask = torch.clamp(input_mask_expanded.sum(dim=1), min=1e-9)
+#             embeddings = sum_embeddings / sum_mask
+#         else:
+#             raise ValueError(
+#                 "pooling_strategy must be either 'last_token' or 'mean_pooling'"
+#             )
 
-            # Create mock centroids and cluster data
-            centroids = self.input_embeddings[:1]
-            cluster_data = cudf.DataFrame(
-                {
-                    id_col: list(range(self.input_embeddings.shape[0])),
-                    embedding_col: self.input_embeddings.tolist(),
-                }
-            )
+#         normed_emb = F.normalize(embeddings, dim=1).cpu()
+#         normed_emb = normed_emb.squeeze(0)
+#         embs.append(normed_emb)
 
-            # Save mock cluster data to a file
-            cluster_data_path = os.path.join(
-                nearest_cent_dir, f"nearest_cent={cluster_id}"
-            )
-            cluster_data.to_parquet(cluster_data_path)
+#     return np.array(embs)
 
-            # Call the function
-            rank_within_cluster(
-                id_col=id_col,
-                nearest_cent_dir=nearest_cent_dir,
-                output_sorted_clusters_dir=output_sorted_clusters_dir,
-                centroids=centroids,
-                embedding_col=embedding_col,
-                sim_metric="cosine",
-                keep_hard=keep_hard,
-                cluster_ids=[cluster_id],
-            )
+# @pytest.mark.gpu
+# class TestSemDedupUtils:
+#     def setup_method(self):
+#         # We create a 6x3 array where each row is a unit vector
+#         # The second and last two rows are the same
+#         input_embeddings = torch.tensor(
+#             np.asarray(
+#                 [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [1, 2, 3], [1, 2, 3]],
+#             ),
+#             dtype=torch.float32,
+#         )
+#         # Normalize the input array
+#         self.input_embeddings = input_embeddings / torch.norm(
+#             input_embeddings, dim=1, keepdim=True
+#         )
+#         self.expected_pairwise_similarity = torch.tensor(
+#             [0.0000, 0.974631, 0.998190, 0.999618, 1.0000, 1.0000]
+#         )
+#         self.expected_indices = [0, 0, 1, 2, 0, 0]
+    
 
-            # Load the sorted cluster
-            sorted_cluster_file_path = os.path.join(
-                output_sorted_clusters_dir, f"cluster_{cluster_id}.npy"
-            )
-            sorted_cluster = np.load(sorted_cluster_file_path)
+#     def test_pairwise_cosine_similarity(self):
+#         max_similarity, max_indices = pairwise_cosine_similarity(
+#             self.input_embeddings, "cuda"
+#         )
+#         torch.testing.assert_close(
+#             max_similarity, self.expected_pairwise_similarity, rtol=1e-6, atol=1e-6
+#         )
+#         assert max_indices == self.expected_indices
 
-            # Expected order based on cosine similarity
-            if keep_hard:
-                expected_order = [
-                    # id, dist_to_cent, cluster_id
-                    [3, 0.9513, 0],
-                    [2, 0.9594, 0],
-                    [1, 0.9746, 0],
-                    [0, 1.0, 0],
-                    [4, 1.0000, 0],
-                    [5, 1.0000, 0],
-                ]
-            else:
-                expected_order = [
-                    # id, dist_to_cent, cluster_id
-                    [0, 1.0, 0],
-                    [4, 1.0000, 0],
-                    [5, 1.0000, 0],
-                    [1, 0.9746, 0],
-                    [2, 0.9594, 0],
-                    [3, 0.9513, 0],
-                ]
-            expected_order = np.array(expected_order)
-            expected_order[:, 1] = 1 - expected_order[:, 1]
-            pd.testing.assert_frame_equal(
-                pd.DataFrame(sorted_cluster),
-                pd.DataFrame(expected_order),
-                check_exact=False,
-                rtol=1e-3,
-                atol=1e-3,
-            )
+#     @pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 5, 6])
+#     def test_pairwise_cosine_similarity_batched(
+#         self, batch_size: int
+#     ):
+#         max_similarity, max_indices = pairwise_cosine_similarity_batched(
+#             self.input_embeddings, "cuda", batch_size
+#         )
+#         torch.testing.assert_close(max_similarity, self.expected_pairwise_similarity)
+#         assert max_indices == self.expected_indices
 
-    @pytest.mark.gpu
-    def test_get_normalized_embedding_array(self):
-        # Mock data setup
-        df = cudf.DataFrame({
-            "embedding": [[3, 4, 5], [1, 2, 2], [1, 0, 0]],
-        })
-        expected_normalized = cp.array([
-            [0.42426407, 0.565685, 0.707107],
-            [0.33333334, 0.6666667, 0.6666667],
-            [1.0, 0.0, 0.0],
-        ])
+#     @pytest.mark.parametrize("batch_size", [100, 512, 1024, 2048])
+#     def test_pairwise_cosine_similarity_batched_rand_array(
+#         self, batch_size: int
+#     ):
+#         N = 1024
+#         D = 512
+#         rand_arr = torch.randn(N, D, device="cuda")
+#         max_similarity, max_indices = pairwise_cosine_similarity(rand_arr, "cuda")
+#         max_similarity_batched, max_indices_batched = (
+#             pairwise_cosine_similarity_batched(rand_arr, "cuda", batch_size=batch_size)
+#         )
+#         torch.testing.assert_close(
+#             max_similarity, max_similarity_batched, rtol=1e-5, atol=1e-5
+#         )
+#         assert max_indices == max_indices_batched
 
-        # Call the function
-        normalized_embeddings = get_normalized_embedding_array(df, "embedding")
+#     @pytest.mark.parametrize("keep_hard", [True, False])
+#     def test_rank_within_cluster(self, keep_hard: bool):
+#         # Create a temporary directory for output
+#         with tempfile.TemporaryDirectory() as temp_dir:
+#             # Mock data setup
+#             cluster_id = 0
+#             id_col = "id"
+#             embedding_col = "embedding"
+#             nearest_cent_dir = temp_dir
+#             output_sorted_clusters_dir = temp_dir
 
-        # Assert the normalized embeddings match the expected values
-        cp.testing.assert_allclose(normalized_embeddings, expected_normalized, rtol=1e-5, atol=1e-5)
+#             # Create mock centroid with the first embedding i.e normalized([1, 2, 3])
+#             centroids = self.input_embeddings[:1]
+#             # Use all the embeddings
+#             cluster_data = cudf.DataFrame(
+#                 {
+#                     id_col: list(range(self.input_embeddings.shape[0])),
+#                     embedding_col: self.input_embeddings.tolist(),
+#                 }
+#             )
+
+#             # Save mock cluster data to a file
+#             cluster_data_path = os.path.join(
+#                 nearest_cent_dir, f"nearest_cent={cluster_id}"
+#             )
+#             cluster_data.to_parquet(cluster_data_path)
+
+#             # Call the function
+#             rank_within_cluster(
+#                 id_col=id_col,
+#                 nearest_cent_dir=nearest_cent_dir,
+#                 output_sorted_clusters_dir=output_sorted_clusters_dir,
+#                 centroids=centroids,
+#                 embedding_col=embedding_col,
+#                 sim_metric="cosine",
+#                 keep_hard=keep_hard,
+#                 cluster_ids=[cluster_id],
+#             )
+
+#             # Load the sorted cluster
+#             sorted_cluster_file_path = os.path.join(
+#                 output_sorted_clusters_dir, f"cluster_{cluster_id}.npy"
+#             )
+#             sorted_cluster = np.load(sorted_cluster_file_path)
+
+#             # Expected order based on cosine distance
+#             if keep_hard:
+#                 # When hard we write dissimilar items first
+#                 # and in case of ties we write the items with the highest id first
+#                 expected_cosine_distance = [
+#                     # id, dist_to_cent, cluster_id
+#                     [3, 1 - 0.9513, 0],
+#                     [2, 1 - 0.9594, 0],
+#                     [1, 1 - 0.9746, 0],
+#                     [5, 1 - 1.0000, 0],
+#                     [4, 1 - 1.0000, 0],
+#                     [0, 1 - 1.0, 0],
+#                 ]
+#             else:
+#                 # When easy/random we write similar items first
+#                 # and in case of ties we write the items with the lowest id first
+#                 expected_cosine_distance = [
+#                     [0, 1 - 1.0, 0],
+#                     [4, 1 - 1.0000, 0],
+#                     [5, 1 - 1.0000, 0],
+#                     [1, 1 - 0.9746, 0],
+#                     [2, 1 - 0.9594, 0],
+#                     [3, 1 - 0.9513, 0],
+#                 ]
+#             expected_cosine_distance = np.array(expected_cosine_distance)
+#             pd.testing.assert_frame_equal(
+#                 pd.DataFrame(sorted_cluster),
+#                 pd.DataFrame(expected_cosine_distance),
+#                 check_exact=False,
+#                 rtol=1e-3,
+#                 atol=1e-3,
+#             )
+
+#     @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
+#     def test_get_ids_within_cluster(self, tmpdir, which_to_keep : Literal["hard", "random", "easy"]):
+#         # write a tempfile to cluster_0.npy
+#         cluster_0_file_path = os.path.join(tmpdir, "cluster_0.npy")
+#         # Save id, cosine_dist, cluster_id
+#         # The order is 2 >= 1 > 3 > 5 >= 4
+#         if which_to_keep == "hard":
+#             # When hard then we write dissimilar items first, and in case of ties we write the items with the highest id first
+#             cluster_0 = np.array([[2, 1.0, 0], [1, 1.0, 0], [3, 0.8, 0], [5, 0.0, 0], [4, 0.0, 0]])
+#         else:
+#             # When easy then we write similar items first, and in case of ties we write the items with the lowest id first
+#             cluster_0 = np.array([[4, 0.0, 0], [5, 0.0, 0], [3, 0.8, 0], [1, 1.0, 0], [2, 1.0, 0]])
+        
+#         np.save(cluster_0_file_path, cluster_0)
+#         # mock random.shuffle so that we can test the order
+#         with mock.patch("random.shuffle", return_value=None) as mock_shuffle:
+#             ids = get_ids_within_cluster(
+#                 cluster_id=0,
+#                 sorted_clusters_dir=tmpdir,
+#                 id_col_type="int",
+#                 which_to_keep=which_to_keep,
+#             )
+#             if which_to_keep == "random":
+#                 mock_shuffle.assert_called_once()
+#             else:
+#                 mock_shuffle.assert_not_called()
+#         if which_to_keep == "hard":
+#             np.testing.assert_array_equal(ids, np.array([2, 1, 3, 5, 4]))
+#         elif which_to_keep in {"easy", "random"}:
+#             # because of the mock, both random and easy should behave the same
+#             np.testing.assert_array_equal(ids, np.array([4, 5, 3, 1, 2]))
+
+#     def test_normalize_embeddings_col_in_df(self):
+#         # Mock data setup
+#         df = cudf.DataFrame({
+#             "embedding": [[3, 4, 5], [1, 2, 2], [1, 0, 0]],
+#         })
+#         expected_normalized = cp.array([
+#             [0.42426407, 0.565685, 0.707107],
+#             [0.33333334, 0.6666667, 0.6666667],
+#             [1.0, 0.0, 0.0],
+#         ])
+
+#         # Call the function
+#         normalized_embeddings = normalize_embeddings_col_in_df(df, "embedding")
+
+#         # Assert the normalized embeddings match the expected values
+#         cp.testing.assert_allclose(
+#             get_array_from_df(normalized_embeddings, "embedding"), 
+#             expected_normalized, 
+#             rtol=1e-5, 
+#             atol=1e-5
+#         )
+
+#     def test_add_l2_dist_to_cents(self):
+#         # Mock data setup
+#         df = cudf.DataFrame({
+#             "nearest_cent": [0, 1, 0],
+#             "embedding": [[1, 0], [0, 1], [1, 1]],
+#         })
+#         centroids = cp.array([[1, 0], [0, 1]])
+#         expected_distances = cp.array([0.0, 0.0,  1.0])
+#         # Call the function
+#         df_with_distances = add_l2_dist_to_cents(df, "embedding", centroids)
+
+#         # Assert the distances match the expected values
+#         np.testing.assert_almost_equal(
+#             df_with_distances["l2_dist_to_cent"].to_arrow().to_pylist(),
+#             expected_distances.tolist(),
+#             decimal=4
+#         )
 
 
-    @pytest.mark.gpu
-    def test_add_l2_dist_to_cents(self):
-        # Mock data setup
-        df = cudf.DataFrame({
-            "nearest_cent": [0, 1, 0],
-            # Here 1,1 is not normalized therefore it'll get normalized to 0.707107, 0.707107
-            "embedding": [[1, 0], [0, 1], [1, 1]],
-        })
-        centroids = cp.array([[1, 0], [0, 1]])
-        # The distance between [0.707107, 0.707107] and [1, 0] is 
-        # [(0.707 - 1) ** 2 + (0.707 - 0) ** 2]**0.5 = sqrt(0.085 + 0.499) = sqrt(0.585) = 0.7653
-        expected_distances = cp.array([0.0, 0.0,  0.76530])
-        # Call the function
-        df_with_distances = add_l2_dist_to_cents(df, "embedding", centroids)
+# @pytest.mark.gpu
+# class TestSemanticDedupWithoutEmbeddingCreation:
+#     def setup_method(self):
+#         self.n_clusters = 5
+#         self.n_samples_per_cluster = [100 * (i + 1) for i in range(self.n_clusters)]
+#         self.n_features = 3
 
-        # Assert the distances match the expected values
-        np.testing.assert_almost_equal(
-            df_with_distances["l2_dist_to_cent"].to_arrow().to_pylist(), 
-            expected_distances.tolist(), 
-            decimal=4
-        )
-            
+#         self.X, _ = make_blobs(
+#             n_samples=self.n_samples_per_cluster,
+#             centers=None,
+#             n_features=self.n_features,
+#             random_state=42,
+#         )
+#         # Convert to Dask DataFrame and then to cuDF
+#         df = pd.DataFrame({"id": np.arange(len(self.X)), "embeddings": self.X.tolist()})
+#         ddf = dd.from_pandas(df, npartitions=2)
+#         self.ddf = ddf.to_backend("cudf")
+
+#     @pytest.mark.parametrize("sort_clusters", [True, False])
+#     @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
+#     def test_clustering_model(self, tmpdir, sort_clusters, which_to_keep):
+#         clustering_output_dir = os.path.join(tmpdir, "clustering_output")
+#         # Initialize ClusteringModel
+#         clustering_model = ClusteringModel(
+#             id_column="id",
+#             n_clusters=self.n_clusters,
+#             clustering_output_dir=clustering_output_dir,
+#             embedding_column="embeddings",
+#             random_state=42,
+#             sort_clusters=sort_clusters,
+#             which_to_keep=which_to_keep,
+#             sim_metric="cosine",
+#         )
+#         # TODO : remove this once we figure out why fusing is causing issues
+#         with dask.config.set({"optimization.fuse.active": False}):
+#             _ = clustering_model(DocumentDataset(self.ddf))
+
+#         # Check Directory Structure
+#         files = os.listdir(clustering_output_dir)
+#         expected_files = ["embs_by_nearest_center", "kmeans_centroids.npy"]
+
+#         if sort_clusters:
+#             expected_files.append("sorted")
+
+#         for expected_file in expected_files:
+#             assert expected_file in files, f"The {expected_file} file should exist."
+
+#         # Check the results of embs_by_nearest_center
+#         for i in range(self.n_clusters):
+#             assert os.path.exists(
+#                 os.path.join(
+#                     clustering_output_dir, "embs_by_nearest_center", f"nearest_cent={i}"
+#                 )
+#             ), f"The nearest centroid file for cluster {i} should exist."
+#         embss_by_nearest_center = pd.read_parquet(
+#             os.path.join(clustering_output_dir, "embs_by_nearest_center")
+#         )
+#         np.testing.assert_almost_equal(
+#             sorted(np.stack(embss_by_nearest_center["embeddings"]).tolist()),
+#             sorted((self.X / np.linalg.norm(self.X, axis=1, keepdims=True)).tolist()),
+#         )
+#         embeddings_per_cluster = (
+#             embss_by_nearest_center.groupby("nearest_cent")["embeddings"]
+#             .apply(list)
+#             .to_dict()
+#         )
+#         num_samples_per_cluster = (
+#             embss_by_nearest_center["nearest_cent"].value_counts().to_dict()
+#         )
+#         np.testing.assert_allclose(
+#             sorted(num_samples_per_cluster.values()),
+#             sorted(self.n_samples_per_cluster),
+#             rtol=0.02,  # be within 2%
+#         )
+#         assert embss_by_nearest_center.shape[0] == len(self.X)
+#         assert embss_by_nearest_center.columns.tolist() == [
+#             "id",
+#             "embeddings",
+#             "l2_dist_to_cent",
+#             "nearest_cent",
+#         ]
+#         # Check the results of kmeans_centroids.npy
+#         centroids = np.load(os.path.join(clustering_output_dir, "kmeans_centroids.npy"))
+#         assert centroids.shape == (self.n_clusters, self.n_features)
+
+#         # Check the results of sorted directory
+#         if sort_clusters:
+#             sorted_dir = os.path.join(clustering_output_dir, "sorted")
+#             assert os.path.exists(sorted_dir)
+#             for i in range(self.n_clusters):
+#                 assert os.path.exists(os.path.join(sorted_dir, f"cluster_{i}.npy"))
+#                 # id, dist_to_cent, cluster_id
+#                 sorted_cluster = np.load(os.path.join(sorted_dir, f"cluster_{i}.npy"))
+#                 assert sorted_cluster.shape[0] == num_samples_per_cluster[i]
+#                 assert (
+#                     sorted_cluster.shape[1] == 3
+#                 )  # We expect 3 columns in the sorted cluster
+#                 assert set(sorted_cluster[:, 2]) == {i}
+#                 centroid = centroids[i] / np.linalg.norm(centroids[i])
+#                 cosine_similarities = embeddings_per_cluster[i] @ centroid
+#                 cosine_distances = 1 - cosine_similarities
+#                 if which_to_keep == "hard":
+#                     # In case of hard, we expect the distances to be sorted in descending order
+#                     np.testing.assert_almost_equal(
+#                         sorted_cluster[:, 1], np.sort(cosine_distances)[::-1]
+#                     )
+#                 else:
+#                     # In case of easy/random, we expect the distances to be sorted in ascending order
+#                     np.testing.assert_almost_equal(
+#                         sorted_cluster[:, 1], np.sort(cosine_distances)
+#                     )
+
+    
+
+#     # @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
+#     # def test_read_cluster_embeddings_and_sort_by_id(self, tmpdir, which_to_keep):
+#     #     clustering_output_dir = os.path.join(tmpdir, "clustering_output")
+#     #     # Initialize ClusteringModel
+#     #     clustering_model = ClusteringModel(
+#     #         id_column="id",
+#     #         n_clusters=self.n_clusters,
+#     #         clustering_output_dir=clustering_output_dir,
+#     #         embedding_column="embeddings",
+#     #         random_state=42,
+#     #         sort_clusters=True,
+#     #         which_to_keep=which_to_keep,
+#     #         sim_metric="cosine",
+#     #     )
+#     #     with dask.config.set({"optimization.fuse.active": False}):
+#     #         _ = clustering_model(DocumentDataset(self.ddf))
+
+#     #     for i in range(self.n_clusters):
+#     #         cluster_reps = read_cluster_embeddings_and_sort_by_id(
+#     #             cluster_id=i,
+#     #             emb_by_clust_dir=os.path.join(clustering_output_dir, "embs_by_nearest_center"),
+#     #             id_col="id",
+#     #             embedding_col="embeddings",
+#     #             sorted_ids=np.arange(self.n_samples_per_cluster[i]),
+#     #         )
+
+#     # @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
+#     # def test_sematnic_cluster_level_dedup(self, tmpdir, which_to_keep):
+#     #     clustering_output_dir = os.path.join(tmpdir, "clustering_output")
+#     #     semantic_extraction_output_dir = os.path.join(tmpdir, "extraction")
+#     #     # Initialize ClusteringModel
+#     #     clustering_model = ClusteringModel(
+#     #         id_column="id",
+#     #         n_clusters=self.n_clusters,
+#     #         clustering_output_dir=clustering_output_dir,
+#     #         embedding_column="embeddings",
+#     #         random_state=42,
+#     #         sort_clusters=True,
+#     #         which_to_keep=which_to_keep,
+#     #         sim_metric="cosine",
+#     #     )
+#     #     with dask.config.set({"optimization.fuse.active": False}):
+#     #         _ = clustering_model(DocumentDataset(self.ddf))
+
+#     #     semantic_cluster_level_dedup = SemanticClusterLevelDedup(
+#     #         n_clusters=self.n_clusters,
+#     #         emb_by_clust_dir=os.path.join(clustering_output_dir, "embs_by_nearest_center"),
+#     #         sorted_clusters_dir=os.path.join(clustering_output_dir, "sorted"),
+#     #         id_column="id",
+#     #         id_column_type="int",
+#     #         which_to_keep=which_to_keep,
+#     #         output_dir=semantic_extraction_output_dir,
+#     #         embedding_column="embeddings",
+#     #         batched_cosine_similarity=20,
+#     #     )
+
+
+
+#     #     # Call compute_semantic_match_dfs
+#     #     semantic_cluster_level_dedup.compute_semantic_match_dfs(eps_list=[0.01, 0.02])
+#     #     # Check content of semdedup_pruning_tables
+#     #     for i in range(self.n_clusters):
+#     #         assert os.path.exists(os.path.join(semantic_extraction_output_dir, f"cluster_{i}.parquet"))
+#     #         df = pd.read_parquet(os.path.join(semantic_extraction_output_dir, f"cluster_{i}.parquet"))
+#     #         np.testing.assert_allclose(
+#     #             df.shape[0],
+#     #             self.n_samples_per_cluster[i],
+#     #             rtol=0.02,  # be within 2%
+#     #         )
+#     #         assert df.columns.tolist() == ["indices", "id", "max_id", "cosine_sim_score", "eps=0.01", "eps=0.02"]
+
+#     #         print(df[["eps=0.01", "eps=0.02"]].sum())
+        
+#     #     # Call extract_dedup_data
+#     #     semantic_cluster_level_dedup.extract_dedup_data(eps_to_extract=[0.01])
+#     #     # Check content of unique_ids
+#     #     assert os.path.exists(os.path.join(semantic_extraction_output_dir, "unique_ids_0.01.parquet"))
+
+#     #     df = pd.read_parquet(os.path.join(semantic_extraction_output_dir, "unique_ids_0.01.parquet"))
+#     #     assert df.columns.tolist() == ["id", "dist", "cluster"]

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -676,9 +676,7 @@ class TestSemanticDedupWithoutEmbeddingCreation:
         elif which_to_keep == "easy":
             _kept, _removed = 5, 1495
         else:
-            # random is not deterministic, so we skip this test
-            return
-
+            _kept, _removed = 17, 1483
         pd.testing.assert_frame_equal(
             df,
             pd.DataFrame(

--- a/tests/test_semdedup.py
+++ b/tests/test_semdedup.py
@@ -29,6 +29,7 @@ from sklearn.datasets import make_blobs
 import dask.dataframe as dd
 from nemo_curator import SemDedup, SemDedupConfig
 from nemo_curator.datasets import DocumentDataset
+import random
 from nemo_curator.utils.import_utils import gpu_only_import, gpu_only_import_from
 
 cudf = gpu_only_import("cudf")
@@ -40,7 +41,8 @@ ClusteringModel = gpu_only_import_from(
     "nemo_curator.modules.semantic_dedup.clusteringmodel", "ClusteringModel"
 )
 SemanticClusterLevelDedup = gpu_only_import_from(
-    "nemo_curator.modules.semantic_dedup.semanticclusterleveldedup", "SemanticClusterLevelDedup"
+    "nemo_curator.modules.semantic_dedup.semanticclusterleveldedup",
+    "SemanticClusterLevelDedup",
 )
 add_l2_dist_to_cents = gpu_only_import_from(
     "nemo_curator.modules.semantic_dedup.clusteringmodel", "add_l2_dist_to_cents"
@@ -71,7 +73,7 @@ read_cluster_embeddings_and_sort_by_id = gpu_only_import_from(
 if TYPE_CHECKING:
     from nemo_curator.modules.semantic_dedup.semanticclusterleveldedup import (
         SemanticClusterLevelDedup,
-    )   
+    )
     from nemo_curator.modules.semantic_dedup.clusteringmodel import (
         ClusteringModel,
         add_l2_dist_to_cents,
@@ -87,607 +89,645 @@ if TYPE_CHECKING:
     )
 
 
-# @pytest.fixture
-# def dedup_data():
-#     df = cudf.DataFrame(
-#         {
-#             "id": [1, 2, 3, 4, 100, 200, 300],
-#             "text": [
-#                 "The quick brown fox jumps over the lazy dog",
-#                 "The quick brown foxes jumps over the lazy dog",
-#                 "The quick brown wolf jumps over the lazy dog",
-#                 "The quick black cat jumps over the lazy dog",
-#                 "A test string",
-#                 "Another test string",
-#                 "A different object",
-#             ],
-#         }
-#     )
-#     df = dask_cudf.from_cudf(df, 2)
-#     return DocumentDataset(df)
+@pytest.fixture
+def dedup_data():
+    df = cudf.DataFrame(
+        {
+            "id": [1, 2, 3, 4, 100, 200, 300],
+            "text": [
+                "The quick brown fox jumps over the lazy dog",
+                "The quick brown foxes jumps over the lazy dog",
+                "The quick brown wolf jumps over the lazy dog",
+                "The quick black cat jumps over the lazy dog",
+                "A test string",
+                "Another test string",
+                "A different object",
+            ],
+        }
+    )
+    df = dask_cudf.from_cudf(df, 2)
+    return DocumentDataset(df)
 
 
-# @pytest.fixture
-# def non_dedup_data():
-#     df = cudf.DataFrame(
-#         {
-#             "doc_id": ["doc_1", "doc_2"],
-#             "text": [
-#                 "The quick brown fox jumps over the lazy dog",
-#                 "A test string",
-#             ],
-#         }
-#     )
-#     df = dask_cudf.from_cudf(df, 2)
-#     return DocumentDataset(df)
+@pytest.fixture
+def non_dedup_data():
+    df = cudf.DataFrame(
+        {
+            "doc_id": ["doc_1", "doc_2"],
+            "text": [
+                "The quick brown fox jumps over the lazy dog",
+                "A test string",
+            ],
+        }
+    )
+    df = dask_cudf.from_cudf(df, 2)
+    return DocumentDataset(df)
 
 
-# @pytest.mark.gpu
-# class TestSemDuplicates:
-#     @pytest.mark.parametrize("n_clusters", [3, 10])
-#     def test_sem_dedup(
-#         self,
-#         dedup_data,
-#         tmpdir,
-#         n_clusters,
-#         gpu_client,
-#     ):
-#         print("client", gpu_client)
+@pytest.mark.gpu
+class TestSemDuplicates:
+    @pytest.mark.parametrize("n_clusters", [3, 10])
+    def test_sem_dedup(
+        self,
+        dedup_data,
+        tmpdir,
+        n_clusters,
+        gpu_client,
+    ):
+        print("client", gpu_client)
 
-#         cache_dir = os.path.join(tmpdir, "test_sem_dedup_cache")
-#         config = SemDedupConfig(
-#             cache_dir=cache_dir,
-#             n_clusters=n_clusters,
-#             eps_thresholds=[0.10],
-#             eps_to_extract=0.10,
-#         )
+        cache_dir = os.path.join(tmpdir, "test_sem_dedup_cache")
+        config = SemDedupConfig(
+            cache_dir=cache_dir,
+            n_clusters=n_clusters,
+            eps_thresholds=[0.10],
+            eps_to_extract=0.10,
+        )
 
-#         sem_duplicates = SemDedup(
-#             config=config,
-#             input_column="text",
-#             id_column="id",
-#             id_column_type="int",
-#         )
+        sem_duplicates = SemDedup(
+            config=config,
+            input_column="text",
+            id_column="id",
+            id_column_type="int",
+        )
 
-#         dedup_data_len = dedup_data.df.shape[0].compute()
-#         if n_clusters > dedup_data_len:
-#             # Number of records in the dataset should never be less than n_clusters
-#             with pytest.raises(ValueError):
-#                 result = sem_duplicates(dedup_data)
-#         else:
-#             # Correctly returns the original dataset with no duplicates removed
-#             result = sem_duplicates(dedup_data)
-#             result_df = result.df.compute()
-#             duplicate_docs = [2, 3, 4, 200, 300]
-#             expected_df = cudf.Series(duplicate_docs, name="id")
-#             assert_eq(result_df["id"].sort_values(), expected_df, check_index=False)
+        dedup_data_len = dedup_data.df.shape[0].compute()
+        if n_clusters > dedup_data_len:
+            # Number of records in the dataset should never be less than n_clusters
+            with pytest.raises(ValueError):
+                result = sem_duplicates(dedup_data)
+        else:
+            # Correctly returns the original dataset with no duplicates removed
+            result = sem_duplicates(dedup_data)
+            result_df = result.df.compute()
+            duplicate_docs = [2, 3, 4, 200, 300]
+            expected_df = cudf.Series(duplicate_docs, name="id")
+            assert_eq(result_df["id"].sort_values(), expected_df, check_index=False)
 
-#     @pytest.mark.parametrize("n_clusters", [2, 3])
-#     def test_no_sem_dedup(
-#         self,
-#         non_dedup_data,
-#         tmpdir,
-#         n_clusters,
-#         gpu_client,
-#     ):
-#         print("client", gpu_client)
+    @pytest.mark.parametrize("n_clusters", [2, 3])
+    def test_no_sem_dedup(
+        self,
+        non_dedup_data,
+        tmpdir,
+        n_clusters,
+        gpu_client,
+    ):
+        print("client", gpu_client)
 
-#         cache_dir = os.path.join(tmpdir, "test_no_sem_dedup")
-#         config = SemDedupConfig(
-#             cache_dir=cache_dir,
-#             n_clusters=n_clusters,
-#             eps_thresholds=[0.10],
-#             eps_to_extract=0.10,
-#         )
+        cache_dir = os.path.join(tmpdir, "test_no_sem_dedup")
+        config = SemDedupConfig(
+            cache_dir=cache_dir,
+            n_clusters=n_clusters,
+            eps_thresholds=[0.10],
+            eps_to_extract=0.10,
+        )
 
-#         sem_duplicates = SemDedup(
-#             config=config,
-#             input_column="text",
-#             id_column="doc_id",
-#             id_column_type="str",
-#         )
+        sem_duplicates = SemDedup(
+            config=config,
+            input_column="text",
+            id_column="doc_id",
+            id_column_type="str",
+        )
 
-#         non_dedup_data_len = non_dedup_data.df.shape[0].compute()
-#         if n_clusters > non_dedup_data_len:
-#             # Number of records in the dataset should never be less than n_clusters
-#             with pytest.raises(ValueError):
-#                 result = sem_duplicates(non_dedup_data)
-#         else:
-#             # Correctly returns the original dataset with no duplicates removed
-#             result = sem_duplicates(non_dedup_data)
-#             result_df = result.df.compute()
-#             duplicate_docs = ["doc_1", "doc_2"]
-#             expected_df = cudf.Series(duplicate_docs, name="doc_id")
-#             assert_eq(result_df["doc_id"].sort_values(), expected_df, check_index=False)
+        non_dedup_data_len = non_dedup_data.df.shape[0].compute()
+        if n_clusters > non_dedup_data_len:
+            # Number of records in the dataset should never be less than n_clusters
+            with pytest.raises(ValueError):
+                result = sem_duplicates(non_dedup_data)
+        else:
+            # Correctly returns the original dataset with no duplicates removed
+            result = sem_duplicates(non_dedup_data)
+            result_df = result.df.compute()
+            duplicate_docs = ["doc_1", "doc_2"]
+            expected_df = cudf.Series(duplicate_docs, name="doc_id")
+            assert_eq(result_df["doc_id"].sort_values(), expected_df, check_index=False)
 
-#     @pytest.mark.parametrize("pooling_strategy", ["last_token", "mean_pooling"])
-#     def test_embedding_creator_pooling_strategies(self, tmpdir, pooling_strategy):
-#         test_text_1 = "The quick brown fox jumps over the lazy dog"
-#         test_text_2 = "The brown fox jumps over the dog"
-#         test_texts = [test_text_1, test_text_2] * 32
-#         df = cudf.DataFrame({"text": test_texts})
-#         ddf = dask_cudf.from_cudf(df, 1)
+    @pytest.mark.parametrize("pooling_strategy", ["last_token", "mean_pooling"])
+    def test_embedding_creator_pooling_strategies(self, tmpdir, pooling_strategy):
+        test_text_1 = "The quick brown fox jumps over the lazy dog"
+        test_text_2 = "The brown fox jumps over the dog"
+        test_texts = [test_text_1, test_text_2] * 32
+        df = cudf.DataFrame({"text": test_texts})
+        ddf = dask_cudf.from_cudf(df, 1)
 
-#         cache_dir = os.path.join(tmpdir, "test_embeddings_cache")
+        cache_dir = os.path.join(tmpdir, "test_embeddings_cache")
 
-#         embedding_creator = EmbeddingCreator(
-#             embedding_model_name_or_path="sentence-transformers/all-MiniLM-L6-v2",
-#             embedding_batch_size=32,
-#             embedding_pooling_strategy=pooling_strategy,
-#             input_column="text",
-#             embedding_output_dir=os.path.join(cache_dir, "mean_embeddings"),
-#         )
+        embedding_creator = EmbeddingCreator(
+            embedding_model_name_or_path="sentence-transformers/all-MiniLM-L6-v2",
+            embedding_batch_size=32,
+            embedding_pooling_strategy=pooling_strategy,
+            input_column="text",
+            embedding_output_dir=os.path.join(cache_dir, "mean_embeddings"),
+        )
 
-#         embeddings = embedding_creator.create_embeddings(ddf).compute()
-#         embeddings = embeddings["embeddings"].to_arrow().to_pylist()
-#         embeddings = np.array(embeddings)
+        embeddings = embedding_creator.create_embeddings(ddf).compute()
+        embeddings = embeddings["embeddings"].to_arrow().to_pylist()
+        embeddings = np.array(embeddings)
 
-#         reference_embeddings = get_reference_embeddings(
-#             test_texts, pooling_strategy=pooling_strategy
-#         )
+        reference_embeddings = get_reference_embeddings(
+            test_texts, pooling_strategy=pooling_strategy
+        )
 
-#         assert np.allclose(
-#             embeddings, reference_embeddings, atol=1e-3
-#         ), "Embeddings should match reference embeddings"
+        assert np.allclose(
+            embeddings, reference_embeddings, atol=1e-3
+        ), "Embeddings should match reference embeddings"
 
 
-# def get_reference_embeddings(
-#     texts,
-#     model_name="sentence-transformers/all-MiniLM-L6-v2",
-#     pooling_strategy="last_token",
-# ):
-#     """
-#     Get embeddings using either last token or mean pooling strategy.
+def get_reference_embeddings(
+    texts,
+    model_name="sentence-transformers/all-MiniLM-L6-v2",
+    pooling_strategy="last_token",
+):
+    """
+    Get embeddings using either last token or mean pooling strategy.
 
-#     Args:
-#         texts: List of input texts
-#         model_name: Name or path of the model to use
-#         pooling_strategy: Either "last_token" for last token or "mean" for mean pooling
-#     """
-#     tokenizer = AutoTokenizer.from_pretrained(model_name)
-#     model = AutoModel.from_pretrained(model_name)
-#     model = model.to("cuda")
-#     model.eval()
-#     max_len_to_use = tokenizer.model_max_length
-#     if max_len_to_use > 1e5:
-#         max_len_to_use = AutoConfig.from_pretrained(model_name).max_position_embeddings
-#     max_seq_length: int = max_len_to_use
+    Args:
+        texts: List of input texts
+        model_name: Name or path of the model to use
+        pooling_strategy: Either "last_token" for last token or "mean" for mean pooling
+    """
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModel.from_pretrained(model_name)
+    model = model.to("cuda")
+    model.eval()
+    max_len_to_use = tokenizer.model_max_length
+    if max_len_to_use > 1e5:
+        max_len_to_use = AutoConfig.from_pretrained(model_name).max_position_embeddings
+    max_seq_length: int = max_len_to_use
 
-#     embs = []
-#     for text in texts:
-#         inputs = tokenizer(
-#             text,
-#             return_tensors="pt",
-#             padding=True,
-#             truncation=True,
-#             max_length=max_seq_length,
-#         )
-#         inputs = {k: v.to("cuda") for k, v in inputs.items()}
+    embs = []
+    for text in texts:
+        inputs = tokenizer(
+            text,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=max_seq_length,
+        )
+        inputs = {k: v.to("cuda") for k, v in inputs.items()}
 
-#         with torch.no_grad():
-#             with torch.autocast(device_type="cuda"):
-#                 outputs = model(**inputs)
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda"):
+                outputs = model(**inputs)
 
-#         if pooling_strategy == "last_token":
-#             embeddings = outputs.last_hidden_state[:, -1, :]
-#         elif pooling_strategy == "mean_pooling":
-#             token_embeddings = outputs.last_hidden_state
-#             attention_mask = inputs["attention_mask"]
-#             input_mask_expanded = (
-#                 attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-#             )
-#             sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, dim=1)
-#             sum_mask = torch.clamp(input_mask_expanded.sum(dim=1), min=1e-9)
-#             embeddings = sum_embeddings / sum_mask
-#         else:
-#             raise ValueError(
-#                 "pooling_strategy must be either 'last_token' or 'mean_pooling'"
-#             )
+        if pooling_strategy == "last_token":
+            embeddings = outputs.last_hidden_state[:, -1, :]
+        elif pooling_strategy == "mean_pooling":
+            token_embeddings = outputs.last_hidden_state
+            attention_mask = inputs["attention_mask"]
+            input_mask_expanded = (
+                attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+            )
+            sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, dim=1)
+            sum_mask = torch.clamp(input_mask_expanded.sum(dim=1), min=1e-9)
+            embeddings = sum_embeddings / sum_mask
+        else:
+            raise ValueError(
+                "pooling_strategy must be either 'last_token' or 'mean_pooling'"
+            )
 
-#         normed_emb = F.normalize(embeddings, dim=1).cpu()
-#         normed_emb = normed_emb.squeeze(0)
-#         embs.append(normed_emb)
+        normed_emb = F.normalize(embeddings, dim=1).cpu()
+        normed_emb = normed_emb.squeeze(0)
+        embs.append(normed_emb)
 
-#     return np.array(embs)
+    return np.array(embs)
 
-# @pytest.mark.gpu
-# class TestSemDedupUtils:
-#     def setup_method(self):
-#         # We create a 6x3 array where each row is a unit vector
-#         # The second and last two rows are the same
-#         input_embeddings = torch.tensor(
-#             np.asarray(
-#                 [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [1, 2, 3], [1, 2, 3]],
-#             ),
-#             dtype=torch.float32,
-#         )
-#         # Normalize the input array
-#         self.input_embeddings = input_embeddings / torch.norm(
-#             input_embeddings, dim=1, keepdim=True
-#         )
-#         self.expected_pairwise_similarity = torch.tensor(
-#             [0.0000, 0.974631, 0.998190, 0.999618, 1.0000, 1.0000]
-#         )
-#         self.expected_indices = [0, 0, 1, 2, 0, 0]
-    
 
-#     def test_pairwise_cosine_similarity(self):
-#         max_similarity, max_indices = pairwise_cosine_similarity(
-#             self.input_embeddings, "cuda"
-#         )
-#         torch.testing.assert_close(
-#             max_similarity, self.expected_pairwise_similarity, rtol=1e-6, atol=1e-6
-#         )
-#         assert max_indices == self.expected_indices
+@pytest.mark.gpu
+class TestSemDedupUtils:
+    def setup_method(self):
+        # We create a 6x3 array where each row is a unit vector
+        # The second and last two rows are the same
+        input_embeddings = torch.tensor(
+            np.asarray(
+                [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [1, 2, 3], [1, 2, 3]],
+            ),
+            dtype=torch.float32,
+        )
+        # Normalize the input array
+        self.input_embeddings = input_embeddings / torch.norm(
+            input_embeddings, dim=1, keepdim=True
+        )
+        self.expected_pairwise_similarity = torch.tensor(
+            [0.0000, 0.974631, 0.998190, 0.999618, 1.0000, 1.0000]
+        )
+        self.expected_indices = [0, 0, 1, 2, 0, 0]
 
-#     @pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 5, 6])
-#     def test_pairwise_cosine_similarity_batched(
-#         self, batch_size: int
-#     ):
-#         max_similarity, max_indices = pairwise_cosine_similarity_batched(
-#             self.input_embeddings, "cuda", batch_size
-#         )
-#         torch.testing.assert_close(max_similarity, self.expected_pairwise_similarity)
-#         assert max_indices == self.expected_indices
+    def test_pairwise_cosine_similarity(self):
+        max_similarity, max_indices = pairwise_cosine_similarity(
+            self.input_embeddings, "cuda"
+        )
+        torch.testing.assert_close(
+            max_similarity, self.expected_pairwise_similarity, rtol=1e-6, atol=1e-6
+        )
+        assert max_indices == self.expected_indices
 
-#     @pytest.mark.parametrize("batch_size", [100, 512, 1024, 2048])
-#     def test_pairwise_cosine_similarity_batched_rand_array(
-#         self, batch_size: int
-#     ):
-#         N = 1024
-#         D = 512
-#         rand_arr = torch.randn(N, D, device="cuda")
-#         max_similarity, max_indices = pairwise_cosine_similarity(rand_arr, "cuda")
-#         max_similarity_batched, max_indices_batched = (
-#             pairwise_cosine_similarity_batched(rand_arr, "cuda", batch_size=batch_size)
-#         )
-#         torch.testing.assert_close(
-#             max_similarity, max_similarity_batched, rtol=1e-5, atol=1e-5
-#         )
-#         assert max_indices == max_indices_batched
+    @pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 5, 6])
+    def test_pairwise_cosine_similarity_batched(self, batch_size: int):
+        max_similarity, max_indices = pairwise_cosine_similarity_batched(
+            self.input_embeddings, "cuda", batch_size
+        )
+        torch.testing.assert_close(max_similarity, self.expected_pairwise_similarity)
+        assert max_indices == self.expected_indices
 
-#     @pytest.mark.parametrize("keep_hard", [True, False])
-#     def test_rank_within_cluster(self, keep_hard: bool):
-#         # Create a temporary directory for output
-#         with tempfile.TemporaryDirectory() as temp_dir:
-#             # Mock data setup
-#             cluster_id = 0
-#             id_col = "id"
-#             embedding_col = "embedding"
-#             nearest_cent_dir = temp_dir
-#             output_sorted_clusters_dir = temp_dir
+    @pytest.mark.parametrize("batch_size", [100, 512, 1024, 2048])
+    def test_pairwise_cosine_similarity_batched_rand_array(self, batch_size: int):
+        N = 1024
+        D = 512
+        rand_arr = torch.randn(N, D, device="cuda")
+        max_similarity, max_indices = pairwise_cosine_similarity(rand_arr, "cuda")
+        max_similarity_batched, max_indices_batched = (
+            pairwise_cosine_similarity_batched(rand_arr, "cuda", batch_size=batch_size)
+        )
+        torch.testing.assert_close(
+            max_similarity, max_similarity_batched, rtol=1e-5, atol=1e-5
+        )
+        assert max_indices == max_indices_batched
 
-#             # Create mock centroid with the first embedding i.e normalized([1, 2, 3])
-#             centroids = self.input_embeddings[:1]
-#             # Use all the embeddings
-#             cluster_data = cudf.DataFrame(
-#                 {
-#                     id_col: list(range(self.input_embeddings.shape[0])),
-#                     embedding_col: self.input_embeddings.tolist(),
-#                 }
-#             )
+    @pytest.mark.parametrize("keep_hard", [True, False])
+    def test_rank_within_cluster(self, keep_hard: bool):
+        # Create a temporary directory for output
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Mock data setup
+            cluster_id = 0
+            id_col = "id"
+            embedding_col = "embedding"
+            nearest_cent_dir = temp_dir
+            output_sorted_clusters_dir = temp_dir
 
-#             # Save mock cluster data to a file
-#             cluster_data_path = os.path.join(
-#                 nearest_cent_dir, f"nearest_cent={cluster_id}"
-#             )
-#             cluster_data.to_parquet(cluster_data_path)
+            # Create mock centroid with the first embedding i.e normalized([1, 2, 3])
+            centroids = self.input_embeddings[:1]
+            # Use all the embeddings
+            cluster_data = cudf.DataFrame(
+                {
+                    id_col: list(range(self.input_embeddings.shape[0])),
+                    embedding_col: self.input_embeddings.tolist(),
+                }
+            )
 
-#             # Call the function
-#             rank_within_cluster(
-#                 id_col=id_col,
-#                 nearest_cent_dir=nearest_cent_dir,
-#                 output_sorted_clusters_dir=output_sorted_clusters_dir,
-#                 centroids=centroids,
-#                 embedding_col=embedding_col,
-#                 sim_metric="cosine",
-#                 keep_hard=keep_hard,
-#                 cluster_ids=[cluster_id],
-#             )
+            # Save mock cluster data to a file
+            cluster_data_path = os.path.join(
+                nearest_cent_dir, f"nearest_cent={cluster_id}"
+            )
+            cluster_data.to_parquet(cluster_data_path)
 
-#             # Load the sorted cluster
-#             sorted_cluster_file_path = os.path.join(
-#                 output_sorted_clusters_dir, f"cluster_{cluster_id}.npy"
-#             )
-#             sorted_cluster = np.load(sorted_cluster_file_path)
+            # Call the function
+            rank_within_cluster(
+                id_col=id_col,
+                nearest_cent_dir=nearest_cent_dir,
+                output_sorted_clusters_dir=output_sorted_clusters_dir,
+                centroids=centroids,
+                embedding_col=embedding_col,
+                sim_metric="cosine",
+                keep_hard=keep_hard,
+                cluster_ids=[cluster_id],
+            )
 
-#             # Expected order based on cosine distance
-#             if keep_hard:
-#                 # When hard we write dissimilar items first
-#                 # and in case of ties we write the items with the highest id first
-#                 expected_cosine_distance = [
-#                     # id, dist_to_cent, cluster_id
-#                     [3, 1 - 0.9513, 0],
-#                     [2, 1 - 0.9594, 0],
-#                     [1, 1 - 0.9746, 0],
-#                     [5, 1 - 1.0000, 0],
-#                     [4, 1 - 1.0000, 0],
-#                     [0, 1 - 1.0, 0],
-#                 ]
-#             else:
-#                 # When easy/random we write similar items first
-#                 # and in case of ties we write the items with the lowest id first
-#                 expected_cosine_distance = [
-#                     [0, 1 - 1.0, 0],
-#                     [4, 1 - 1.0000, 0],
-#                     [5, 1 - 1.0000, 0],
-#                     [1, 1 - 0.9746, 0],
-#                     [2, 1 - 0.9594, 0],
-#                     [3, 1 - 0.9513, 0],
-#                 ]
-#             expected_cosine_distance = np.array(expected_cosine_distance)
-#             pd.testing.assert_frame_equal(
-#                 pd.DataFrame(sorted_cluster),
-#                 pd.DataFrame(expected_cosine_distance),
-#                 check_exact=False,
-#                 rtol=1e-3,
-#                 atol=1e-3,
-#             )
+            # Load the sorted cluster
+            sorted_cluster_file_path = os.path.join(
+                output_sorted_clusters_dir, f"cluster_{cluster_id}.npy"
+            )
+            sorted_cluster = np.load(sorted_cluster_file_path)
 
-#     @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
-#     def test_get_ids_within_cluster(self, tmpdir, which_to_keep : Literal["hard", "random", "easy"]):
-#         # write a tempfile to cluster_0.npy
-#         cluster_0_file_path = os.path.join(tmpdir, "cluster_0.npy")
-#         # Save id, cosine_dist, cluster_id
-#         # The order is 2 >= 1 > 3 > 5 >= 4
-#         if which_to_keep == "hard":
-#             # When hard then we write dissimilar items first, and in case of ties we write the items with the highest id first
-#             cluster_0 = np.array([[2, 1.0, 0], [1, 1.0, 0], [3, 0.8, 0], [5, 0.0, 0], [4, 0.0, 0]])
-#         else:
-#             # When easy then we write similar items first, and in case of ties we write the items with the lowest id first
-#             cluster_0 = np.array([[4, 0.0, 0], [5, 0.0, 0], [3, 0.8, 0], [1, 1.0, 0], [2, 1.0, 0]])
+            # Expected order based on cosine distance
+            if keep_hard:
+                # When hard we write dissimilar items first
+                # and in case of ties we write the items with the highest id first
+                expected_cosine_distance = [
+                    # id, dist_to_cent, cluster_id
+                    [3, 1 - 0.9513, 0],
+                    [2, 1 - 0.9594, 0],
+                    [1, 1 - 0.9746, 0],
+                    [5, 1 - 1.0000, 0],
+                    [4, 1 - 1.0000, 0],
+                    [0, 1 - 1.0, 0],
+                ]
+            else:
+                # When easy/random we write similar items first
+                # and in case of ties we write the items with the lowest id first
+                expected_cosine_distance = [
+                    [0, 1 - 1.0, 0],
+                    [4, 1 - 1.0000, 0],
+                    [5, 1 - 1.0000, 0],
+                    [1, 1 - 0.9746, 0],
+                    [2, 1 - 0.9594, 0],
+                    [3, 1 - 0.9513, 0],
+                ]
+            expected_cosine_distance = np.array(expected_cosine_distance)
+            pd.testing.assert_frame_equal(
+                pd.DataFrame(sorted_cluster),
+                pd.DataFrame(expected_cosine_distance),
+                check_exact=False,
+                rtol=1e-3,
+                atol=1e-3,
+            )
+
+    @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
+    def test_get_ids_within_cluster(
+        self, tmpdir, which_to_keep: Literal["hard", "random", "easy"]
+    ):
+        # write a tempfile to cluster_0.npy
+        cluster_0_file_path = os.path.join(tmpdir, "cluster_0.npy")
+        # Save id, cosine_dist, cluster_id
+        # The order is 2 >= 1 > 3 > 5 >= 4
+        if which_to_keep == "hard":
+            # When hard then we write dissimilar items first, and in case of ties we write the items with the highest id first
+            cluster_0 = np.array(
+                [[2, 1.0, 0], [1, 1.0, 0], [3, 0.8, 0], [5, 0.0, 0], [4, 0.0, 0]]
+            )
+        else:
+            # When easy then we write similar items first, and in case of ties we write the items with the lowest id first
+            cluster_0 = np.array(
+                [[4, 0.0, 0], [5, 0.0, 0], [3, 0.8, 0], [1, 1.0, 0], [2, 1.0, 0]]
+            )
+
+        np.save(cluster_0_file_path, cluster_0)
+        # mock random.shuffle so that we can test the order
+        with mock.patch("random.shuffle", return_value=None) as mock_shuffle:
+            ids = get_ids_within_cluster(
+                cluster_id=0,
+                sorted_clusters_dir=tmpdir,
+                id_col_type="int",
+                which_to_keep=which_to_keep,
+            )
+            if which_to_keep == "random":
+                mock_shuffle.assert_called_once()
+            else:
+                mock_shuffle.assert_not_called()
+        if which_to_keep == "hard":
+            np.testing.assert_array_equal(ids, np.array([2, 1, 3, 5, 4]))
+        elif which_to_keep in {"easy", "random"}:
+            # because of the mock, both random and easy should behave the same
+            np.testing.assert_array_equal(ids, np.array([4, 5, 3, 1, 2]))
+
+    def test_get_array_from_df(self):
+        df = cudf.DataFrame(
+            {
+                "embedding": [[3, 4, 5], [1, 2, 2], [1, 0, 0]],
+            }
+        )
+        expected_array = cp.array(
+            [
+                [3, 4, 5],
+                [1, 2, 2],
+                [1, 0, 0],
+            ]
+        )
+        cp.testing.assert_allclose(
+            get_array_from_df(df, "embedding"), expected_array, rtol=1e-5, atol=1e-5
+        )
+
+    def test_normalize_embeddings_col_in_df(self):
+        # Mock data setup
+        df = cudf.DataFrame(
+            {
+                "embedding": [[3, 4, 5], [1, 2, 2], [1, 0, 0]],
+            }
+        )
+        expected_normalized = cp.array(
+            [
+                [0.42426407, 0.565685, 0.707107],
+                [0.33333334, 0.6666667, 0.6666667],
+                [1.0, 0.0, 0.0],
+            ]
+        )
+
+        # Call the function
+        normalized_embeddings = normalize_embeddings_col_in_df(df, "embedding")
+
+        # Assert the normalized embeddings match the expected values
+        cp.testing.assert_allclose(
+            get_array_from_df(normalized_embeddings, "embedding"),
+            expected_normalized,
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+    def test_add_l2_dist_to_cents(self):
+        # Mock data setup
+        df = cudf.DataFrame(
+            {
+                "nearest_cent": [0, 1, 0],
+                "embedding": [[1, 0], [0, 1], [1, 1]],
+            }
+        )
+        centroids = cp.array([[1, 0], [0, 1]])
+        expected_distances = cp.array([0.0, 0.0, 1.0])
+        # Call the function
+        df_with_distances = add_l2_dist_to_cents(df, "embedding", centroids)
+
+        # Assert the distances match the expected values
+        np.testing.assert_almost_equal(
+            df_with_distances["l2_dist_to_cent"].to_arrow().to_pylist(),
+            expected_distances.tolist(),
+            decimal=4,
+        )
+
+    def test_read_cluster_embeddings_and_sort_by_id(self, tmpdir):
+        # Mock data setup
+        cluster_id = 0
+        num_samples = self.input_embeddings.shape[0]
+        df = cudf.DataFrame(
+            {
+                "id": list(range(num_samples)),
+                "embedding": self.input_embeddings.tolist(),
+            }
+        )
+        os.makedirs(os.path.join(tmpdir, f"nearest_cent={cluster_id}"), exist_ok=True)
+        df.to_parquet(
+            os.path.join(tmpdir, f"nearest_cent={cluster_id}", "file.parquet")
+        )
+        sorted_ids = random.sample(list(range(num_samples)), num_samples)
+        # Call the function
+        cluster_reps = read_cluster_embeddings_and_sort_by_id(
+            cluster_id=cluster_id,
+            emb_by_clust_dir=tmpdir,
+            id_col="id",
+            embedding_col="embedding",
+            sorted_ids=sorted_ids,
+        )
+        # Assert the cluster reps match the expected values
+        np.testing.assert_almost_equal(
+            np.asarray(cluster_reps.tolist()),
+            np.asarray(self.input_embeddings.tolist())[sorted_ids],
+        )
+
+
+@pytest.mark.gpu
+class TestSemanticDedupWithoutEmbeddingCreation:
+    def setup_method(self):
+        self.n_clusters = 5
+        self.n_samples_per_cluster = [100 * (i + 1) for i in range(self.n_clusters)]
+        self.n_features = 3
+
+        self.X, _ = make_blobs(
+            n_samples=self.n_samples_per_cluster,
+            centers=None,
+            n_features=self.n_features,
+            random_state=42,
+        )
+        # Convert to Dask DataFrame and then to cuDF
+        df = pd.DataFrame({"id": np.arange(len(self.X)), "embeddings": self.X.tolist()})
+        ddf = dd.from_pandas(df, npartitions=2)
+        self.ddf = ddf.to_backend("cudf")
+
+    @pytest.mark.parametrize("sort_clusters", [True, False])
+    @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
+    def test_clustering_model(self, tmpdir, sort_clusters, which_to_keep):
+        clustering_output_dir = os.path.join(tmpdir, "clustering_output")
+        # Initialize ClusteringModel
+        clustering_model = ClusteringModel(
+            id_column="id",
+            n_clusters=self.n_clusters,
+            clustering_output_dir=clustering_output_dir,
+            embedding_column="embeddings",
+            random_state=42,
+            sort_clusters=sort_clusters,
+            which_to_keep=which_to_keep,
+            sim_metric="cosine",
+        )
+        # TODO : remove this once we figure out why fusing is causing issues
+        with dask.config.set({"optimization.fuse.active": False}):
+            _ = clustering_model(DocumentDataset(self.ddf))
+
+        # Check Directory Structure
+        files = os.listdir(clustering_output_dir)
+        expected_files = ["embs_by_nearest_center", "kmeans_centroids.npy"]
+
+        if sort_clusters:
+            expected_files.append("sorted")
+
+        for expected_file in expected_files:
+            assert expected_file in files, f"The {expected_file} file should exist."
+
+        # Check the results of embs_by_nearest_center
+        for i in range(self.n_clusters):
+            assert os.path.exists(
+                os.path.join(
+                    clustering_output_dir, "embs_by_nearest_center", f"nearest_cent={i}"
+                )
+            ), f"The nearest centroid file for cluster {i} should exist."
+        embss_by_nearest_center = pd.read_parquet(
+            os.path.join(clustering_output_dir, "embs_by_nearest_center")
+        )
+        np.testing.assert_almost_equal(
+            sorted(np.stack(embss_by_nearest_center["embeddings"]).tolist()),
+            sorted((self.X / np.linalg.norm(self.X, axis=1, keepdims=True)).tolist()),
+        )
+        embeddings_per_cluster = (
+            embss_by_nearest_center.groupby("nearest_cent")["embeddings"]
+            .apply(list)
+            .to_dict()
+        )
+        num_samples_per_cluster = (
+            embss_by_nearest_center["nearest_cent"].value_counts().to_dict()
+        )
+        np.testing.assert_allclose(
+            sorted(num_samples_per_cluster.values()),
+            sorted(self.n_samples_per_cluster),
+            rtol=0.02,  # be within 2%
+        )
+        assert embss_by_nearest_center.shape[0] == len(self.X)
+        assert embss_by_nearest_center.columns.tolist() == [
+            "id",
+            "embeddings",
+            "l2_dist_to_cent",
+            "nearest_cent",
+        ]
+        # Check the results of kmeans_centroids.npy
+        centroids = np.load(os.path.join(clustering_output_dir, "kmeans_centroids.npy"))
+        assert centroids.shape == (self.n_clusters, self.n_features)
+
+        # Check the results of sorted directory
+        if sort_clusters:
+            sorted_dir = os.path.join(clustering_output_dir, "sorted")
+            assert os.path.exists(sorted_dir)
+            for i in range(self.n_clusters):
+                assert os.path.exists(os.path.join(sorted_dir, f"cluster_{i}.npy"))
+                # id, dist_to_cent, cluster_id
+                sorted_cluster = np.load(os.path.join(sorted_dir, f"cluster_{i}.npy"))
+                assert sorted_cluster.shape[0] == num_samples_per_cluster[i]
+                assert (
+                    sorted_cluster.shape[1] == 3
+                )  # We expect 3 columns in the sorted cluster
+                assert set(sorted_cluster[:, 2]) == {i}
+                centroid = centroids[i] / np.linalg.norm(centroids[i])
+                cosine_similarities = embeddings_per_cluster[i] @ centroid
+                cosine_distances = 1 - cosine_similarities
+                if which_to_keep == "hard":
+                    # In case of hard, we expect the distances to be sorted in descending order
+                    np.testing.assert_almost_equal(
+                        sorted_cluster[:, 1], np.sort(cosine_distances)[::-1]
+                    )
+                else:
+                    # In case of easy/random, we expect the distances to be sorted in ascending order
+                    np.testing.assert_almost_equal(
+                        sorted_cluster[:, 1], np.sort(cosine_distances)
+                    )
+
+    @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
+    def test_sematnic_cluster_level_dedup(self, tmpdir, which_to_keep):
+        clustering_output_dir = os.path.join(tmpdir, "clustering_output")
+        semantic_extraction_output_dir = os.path.join(tmpdir, "extraction")
+        print(f"{tmpdir=}\n{clustering_output_dir=}\n{semantic_extraction_output_dir=}")
+        # Initialize ClusteringModel
+        clustering_model = ClusteringModel(
+            id_column="id",
+            n_clusters=self.n_clusters,
+            clustering_output_dir=clustering_output_dir,
+            embedding_column="embeddings",
+            random_state=42,
+            sort_clusters=True,
+            which_to_keep=which_to_keep,
+            sim_metric="cosine",
+        )
+        with dask.config.set({"optimization.fuse.active": False}):
+            _ = clustering_model(DocumentDataset(self.ddf))
+
+        semantic_cluster_level_dedup = SemanticClusterLevelDedup(
+            n_clusters=self.n_clusters,
+            emb_by_clust_dir=os.path.join(
+                clustering_output_dir, "embs_by_nearest_center"
+            ),
+            sorted_clusters_dir=os.path.join(clustering_output_dir, "sorted"),
+            id_column="id",
+            id_column_type="int",
+            which_to_keep=which_to_keep,
+            output_dir=semantic_extraction_output_dir,
+            embedding_column="embeddings",
+            batched_cosine_similarity=20,
+        )
+
+        # Call compute_semantic_match_dfs
+        semantic_cluster_level_dedup.compute_semantic_match_dfs(eps_list=[0.01, 0.02])
         
-#         np.save(cluster_0_file_path, cluster_0)
-#         # mock random.shuffle so that we can test the order
-#         with mock.patch("random.shuffle", return_value=None) as mock_shuffle:
-#             ids = get_ids_within_cluster(
-#                 cluster_id=0,
-#                 sorted_clusters_dir=tmpdir,
-#                 id_col_type="int",
-#                 which_to_keep=which_to_keep,
-#             )
-#             if which_to_keep == "random":
-#                 mock_shuffle.assert_called_once()
-#             else:
-#                 mock_shuffle.assert_not_called()
-#         if which_to_keep == "hard":
-#             np.testing.assert_array_equal(ids, np.array([2, 1, 3, 5, 4]))
-#         elif which_to_keep in {"easy", "random"}:
-#             # because of the mock, both random and easy should behave the same
-#             np.testing.assert_array_equal(ids, np.array([4, 5, 3, 1, 2]))
+        output_samples_per_cluster = []
+        # Check content of semdedup_pruning_tables
+        for i in range(self.n_clusters):
+            cluster_i_path = os.path.join(semantic_extraction_output_dir, "semdedup_pruning_tables", f"cluster_{i}.parquet")
+            assert os.path.exists(cluster_i_path)
+            df = pd.read_parquet(cluster_i_path)
+            output_samples_per_cluster.append(df.shape[0])
+            assert df.columns.tolist() == [
+                "indices",
+                "id",
+                "max_id",
+                "cosine_sim_score",
+                "eps=0.01",
+                "eps=0.02",
+            ]
 
-#     def test_normalize_embeddings_col_in_df(self):
-#         # Mock data setup
-#         df = cudf.DataFrame({
-#             "embedding": [[3, 4, 5], [1, 2, 2], [1, 0, 0]],
-#         })
-#         expected_normalized = cp.array([
-#             [0.42426407, 0.565685, 0.707107],
-#             [0.33333334, 0.6666667, 0.6666667],
-#             [1.0, 0.0, 0.0],
-#         ])
+            print(df[["eps=0.01", "eps=0.02"]].sum())
+        np.testing.assert_allclose(
+            sorted(output_samples_per_cluster),
+            self.n_samples_per_cluster,
+            rtol=0.02,  # be within 2%
+        )
 
-#         # Call the function
-#         normalized_embeddings = normalize_embeddings_col_in_df(df, "embedding")
-
-#         # Assert the normalized embeddings match the expected values
-#         cp.testing.assert_allclose(
-#             get_array_from_df(normalized_embeddings, "embedding"), 
-#             expected_normalized, 
-#             rtol=1e-5, 
-#             atol=1e-5
-#         )
-
-#     def test_add_l2_dist_to_cents(self):
-#         # Mock data setup
-#         df = cudf.DataFrame({
-#             "nearest_cent": [0, 1, 0],
-#             "embedding": [[1, 0], [0, 1], [1, 1]],
-#         })
-#         centroids = cp.array([[1, 0], [0, 1]])
-#         expected_distances = cp.array([0.0, 0.0,  1.0])
-#         # Call the function
-#         df_with_distances = add_l2_dist_to_cents(df, "embedding", centroids)
-
-#         # Assert the distances match the expected values
-#         np.testing.assert_almost_equal(
-#             df_with_distances["l2_dist_to_cent"].to_arrow().to_pylist(),
-#             expected_distances.tolist(),
-#             decimal=4
-#         )
-
-
-# @pytest.mark.gpu
-# class TestSemanticDedupWithoutEmbeddingCreation:
-#     def setup_method(self):
-#         self.n_clusters = 5
-#         self.n_samples_per_cluster = [100 * (i + 1) for i in range(self.n_clusters)]
-#         self.n_features = 3
-
-#         self.X, _ = make_blobs(
-#             n_samples=self.n_samples_per_cluster,
-#             centers=None,
-#             n_features=self.n_features,
-#             random_state=42,
-#         )
-#         # Convert to Dask DataFrame and then to cuDF
-#         df = pd.DataFrame({"id": np.arange(len(self.X)), "embeddings": self.X.tolist()})
-#         ddf = dd.from_pandas(df, npartitions=2)
-#         self.ddf = ddf.to_backend("cudf")
-
-#     @pytest.mark.parametrize("sort_clusters", [True, False])
-#     @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
-#     def test_clustering_model(self, tmpdir, sort_clusters, which_to_keep):
-#         clustering_output_dir = os.path.join(tmpdir, "clustering_output")
-#         # Initialize ClusteringModel
-#         clustering_model = ClusteringModel(
-#             id_column="id",
-#             n_clusters=self.n_clusters,
-#             clustering_output_dir=clustering_output_dir,
-#             embedding_column="embeddings",
-#             random_state=42,
-#             sort_clusters=sort_clusters,
-#             which_to_keep=which_to_keep,
-#             sim_metric="cosine",
-#         )
-#         # TODO : remove this once we figure out why fusing is causing issues
-#         with dask.config.set({"optimization.fuse.active": False}):
-#             _ = clustering_model(DocumentDataset(self.ddf))
-
-#         # Check Directory Structure
-#         files = os.listdir(clustering_output_dir)
-#         expected_files = ["embs_by_nearest_center", "kmeans_centroids.npy"]
-
-#         if sort_clusters:
-#             expected_files.append("sorted")
-
-#         for expected_file in expected_files:
-#             assert expected_file in files, f"The {expected_file} file should exist."
-
-#         # Check the results of embs_by_nearest_center
-#         for i in range(self.n_clusters):
-#             assert os.path.exists(
-#                 os.path.join(
-#                     clustering_output_dir, "embs_by_nearest_center", f"nearest_cent={i}"
-#                 )
-#             ), f"The nearest centroid file for cluster {i} should exist."
-#         embss_by_nearest_center = pd.read_parquet(
-#             os.path.join(clustering_output_dir, "embs_by_nearest_center")
-#         )
-#         np.testing.assert_almost_equal(
-#             sorted(np.stack(embss_by_nearest_center["embeddings"]).tolist()),
-#             sorted((self.X / np.linalg.norm(self.X, axis=1, keepdims=True)).tolist()),
-#         )
-#         embeddings_per_cluster = (
-#             embss_by_nearest_center.groupby("nearest_cent")["embeddings"]
-#             .apply(list)
-#             .to_dict()
-#         )
-#         num_samples_per_cluster = (
-#             embss_by_nearest_center["nearest_cent"].value_counts().to_dict()
-#         )
-#         np.testing.assert_allclose(
-#             sorted(num_samples_per_cluster.values()),
-#             sorted(self.n_samples_per_cluster),
-#             rtol=0.02,  # be within 2%
-#         )
-#         assert embss_by_nearest_center.shape[0] == len(self.X)
-#         assert embss_by_nearest_center.columns.tolist() == [
-#             "id",
-#             "embeddings",
-#             "l2_dist_to_cent",
-#             "nearest_cent",
-#         ]
-#         # Check the results of kmeans_centroids.npy
-#         centroids = np.load(os.path.join(clustering_output_dir, "kmeans_centroids.npy"))
-#         assert centroids.shape == (self.n_clusters, self.n_features)
-
-#         # Check the results of sorted directory
-#         if sort_clusters:
-#             sorted_dir = os.path.join(clustering_output_dir, "sorted")
-#             assert os.path.exists(sorted_dir)
-#             for i in range(self.n_clusters):
-#                 assert os.path.exists(os.path.join(sorted_dir, f"cluster_{i}.npy"))
-#                 # id, dist_to_cent, cluster_id
-#                 sorted_cluster = np.load(os.path.join(sorted_dir, f"cluster_{i}.npy"))
-#                 assert sorted_cluster.shape[0] == num_samples_per_cluster[i]
-#                 assert (
-#                     sorted_cluster.shape[1] == 3
-#                 )  # We expect 3 columns in the sorted cluster
-#                 assert set(sorted_cluster[:, 2]) == {i}
-#                 centroid = centroids[i] / np.linalg.norm(centroids[i])
-#                 cosine_similarities = embeddings_per_cluster[i] @ centroid
-#                 cosine_distances = 1 - cosine_similarities
-#                 if which_to_keep == "hard":
-#                     # In case of hard, we expect the distances to be sorted in descending order
-#                     np.testing.assert_almost_equal(
-#                         sorted_cluster[:, 1], np.sort(cosine_distances)[::-1]
-#                     )
-#                 else:
-#                     # In case of easy/random, we expect the distances to be sorted in ascending order
-#                     np.testing.assert_almost_equal(
-#                         sorted_cluster[:, 1], np.sort(cosine_distances)
-#                     )
-
-    
-
-#     # @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
-#     # def test_read_cluster_embeddings_and_sort_by_id(self, tmpdir, which_to_keep):
-#     #     clustering_output_dir = os.path.join(tmpdir, "clustering_output")
-#     #     # Initialize ClusteringModel
-#     #     clustering_model = ClusteringModel(
-#     #         id_column="id",
-#     #         n_clusters=self.n_clusters,
-#     #         clustering_output_dir=clustering_output_dir,
-#     #         embedding_column="embeddings",
-#     #         random_state=42,
-#     #         sort_clusters=True,
-#     #         which_to_keep=which_to_keep,
-#     #         sim_metric="cosine",
-#     #     )
-#     #     with dask.config.set({"optimization.fuse.active": False}):
-#     #         _ = clustering_model(DocumentDataset(self.ddf))
-
-#     #     for i in range(self.n_clusters):
-#     #         cluster_reps = read_cluster_embeddings_and_sort_by_id(
-#     #             cluster_id=i,
-#     #             emb_by_clust_dir=os.path.join(clustering_output_dir, "embs_by_nearest_center"),
-#     #             id_col="id",
-#     #             embedding_col="embeddings",
-#     #             sorted_ids=np.arange(self.n_samples_per_cluster[i]),
-#     #         )
-
-#     # @pytest.mark.parametrize("which_to_keep", ["hard", "random", "easy"])
-#     # def test_sematnic_cluster_level_dedup(self, tmpdir, which_to_keep):
-#     #     clustering_output_dir = os.path.join(tmpdir, "clustering_output")
-#     #     semantic_extraction_output_dir = os.path.join(tmpdir, "extraction")
-#     #     # Initialize ClusteringModel
-#     #     clustering_model = ClusteringModel(
-#     #         id_column="id",
-#     #         n_clusters=self.n_clusters,
-#     #         clustering_output_dir=clustering_output_dir,
-#     #         embedding_column="embeddings",
-#     #         random_state=42,
-#     #         sort_clusters=True,
-#     #         which_to_keep=which_to_keep,
-#     #         sim_metric="cosine",
-#     #     )
-#     #     with dask.config.set({"optimization.fuse.active": False}):
-#     #         _ = clustering_model(DocumentDataset(self.ddf))
-
-#     #     semantic_cluster_level_dedup = SemanticClusterLevelDedup(
-#     #         n_clusters=self.n_clusters,
-#     #         emb_by_clust_dir=os.path.join(clustering_output_dir, "embs_by_nearest_center"),
-#     #         sorted_clusters_dir=os.path.join(clustering_output_dir, "sorted"),
-#     #         id_column="id",
-#     #         id_column_type="int",
-#     #         which_to_keep=which_to_keep,
-#     #         output_dir=semantic_extraction_output_dir,
-#     #         embedding_column="embeddings",
-#     #         batched_cosine_similarity=20,
-#     #     )
-
-
-
-#     #     # Call compute_semantic_match_dfs
-#     #     semantic_cluster_level_dedup.compute_semantic_match_dfs(eps_list=[0.01, 0.02])
-#     #     # Check content of semdedup_pruning_tables
-#     #     for i in range(self.n_clusters):
-#     #         assert os.path.exists(os.path.join(semantic_extraction_output_dir, f"cluster_{i}.parquet"))
-#     #         df = pd.read_parquet(os.path.join(semantic_extraction_output_dir, f"cluster_{i}.parquet"))
-#     #         np.testing.assert_allclose(
-#     #             df.shape[0],
-#     #             self.n_samples_per_cluster[i],
-#     #             rtol=0.02,  # be within 2%
-#     #         )
-#     #         assert df.columns.tolist() == ["indices", "id", "max_id", "cosine_sim_score", "eps=0.01", "eps=0.02"]
-
-#     #         print(df[["eps=0.01", "eps=0.02"]].sum())
-        
-#     #     # Call extract_dedup_data
-#     #     semantic_cluster_level_dedup.extract_dedup_data(eps_to_extract=[0.01])
-#     #     # Check content of unique_ids
-#     #     assert os.path.exists(os.path.join(semantic_extraction_output_dir, "unique_ids_0.01.parquet"))
-
-#     #     df = pd.read_parquet(os.path.join(semantic_extraction_output_dir, "unique_ids_0.01.parquet"))
-#     #     assert df.columns.tolist() == ["id", "dist", "cluster"]
+        # Call extract_dedup_data
+        semantic_cluster_level_dedup.extract_dedup_data(eps_to_extract=0.01)
+        # Check content of unique_ids
+        unique_ids_path = os.path.join(semantic_extraction_output_dir, "unique_ids_0.01.parquet")
+        assert os.path.exists(unique_ids_path)
+        df = pd.read_parquet(unique_ids_path)
+        assert df.columns.tolist() == ["id", "dist", "cluster"]

--- a/tutorials/dapt-curation/code/configs/text_semantic_dedupe_config.yaml
+++ b/tutorials/dapt-curation/code/configs/text_semantic_dedupe_config.yaml
@@ -14,11 +14,9 @@ n_clusters: 15
 clustering_save_loc: "clustering_results"
 sim_metric: "cosine"
 which_to_keep: "hard"
+batched_cosine_similarity: 1024
+clustering_input_partition_size: "2gb"
 
 # Extract dedup configuration
-eps_thresholds:
-  - 0.1
-  - 0.01
-
 # Which threshold to use for extracting deduped data
 eps_to_extract: 0.1

--- a/tutorials/dapt-curation/code/utils.py
+++ b/tutorials/dapt-curation/code/utils.py
@@ -345,7 +345,7 @@ def semantic_dedupe(
 
     semdedup_config = SemDedupConfig.from_yaml(sem_dedupe_config_yaml_path)
     expand_outdir_and_mkdir(semdedup_config.cache_dir)
-    semdup = SemDedup(config=semdedup_config, id_column_type="str")
+    semdup = SemDedup(config=semdedup_config)
     duplicates = semdup(dataset)
     return duplicates
 

--- a/tutorials/image-curation/image-curation.ipynb
+++ b/tutorials/image-curation/image-curation.ipynb
@@ -676,15 +676,12 @@
     "semantic_dedup = SemanticClusterLevelDedup(\n",
     "    n_clusters=1,\n",
     "    emb_by_clust_dir=emb_by_cluster_output,\n",
-    "    sorted_clusters_dir=sorted_cluster_output,\n",
     "    id_column=id_col,\n",
-    "    id_column_type=\"str\",\n",
     "    embedding_col=\"image_embedding\",\n",
-    "    which_to_keep=\"hard\",\n",
     "    batched_cosine_similarity=1024,\n",
     "    output_dir=duplicate_output,\n",
     ")\n",
-    "semantic_dedup.compute_semantic_match_dfs([0.01, 0.001])\n",
+    "semantic_dedup.compute_semantic_match_dfs()\n",
     "deduplicated_dataset_ids = semantic_dedup.extract_dedup_data(eps_to_extract=0.01)"
    ]
   },

--- a/tutorials/peft-curation-with-sdg/config/sem_dedup_config.yaml
+++ b/tutorials/peft-curation-with-sdg/config/sem_dedup_config.yaml
@@ -19,14 +19,8 @@ random_state: 1234
 sim_metric: "cosine"
 which_to_keep: "hard"
 batched_cosine_similarity: 1024
-sort_clusters: true
-kmeans_with_cos_dist: false
 clustering_input_partition_size: "2gb"
 
 # Extract dedup configuration
-eps_thresholds:
-  - 0.01
-  - 0.001
-
 # Which threshold to use for extracting deduped data
 eps_to_extract: 0.01

--- a/tutorials/peft-curation-with-sdg/main.py
+++ b/tutorials/peft-curation-with-sdg/main.py
@@ -135,7 +135,6 @@ def semantic_dedupe(dataset):
         config=semdedup_config,
         input_column="text",
         id_column="id",
-        id_column_type="str",
     )
     dedup_ids = semdup(dataset)
     # When there are few duplicates we can compute the results to a list and use `isin`.


### PR DESCRIPTION
## Description

## Major (breaking) Changes TLDR
1. `compute_semantic_match_dfs` doesn't need `esp_to_extract_list` as input
2. We normalize embeddings before we perform KMeans
3. We support both L2 and Cosine Distance for `which_to_keep`
4. Intermediate output columns have changed.

## Description
Removed the following 
1. Arguments
   - `sort_clusters`
   - `kmeans_with_cos_dist`
   - `eps_thresholds`
   - `id_col_type` (in `SemanticClusterLevelDedup`)
   -  `sorted_clusters_dir` (in `SemanticClusterLevelDedup`)
6. Functions
 - `assign_and_sort_clusters`
 - `rank_within_cluster`
 - `read_cluster_embeddings_and_sort_by_id`
 - `get_ids_within_cluster`
 - `_get_empty_results_df`
 - `extract_pruned_data`
 - `extract_dedup_data`

## New Flow
Now SemanticDedup is much simpler to follow
1. `ClusteringModel.__call__` performs a 
    1. Embedding Normalization
    2. KMeans.fit / predict
    7. Computes l2 / cosine distance from centroid
    8. Writes the output to `embs_by_nearest_center` partitioned on `nearest_cent`
    9. Also write out centroids (not needed anymore, **so can remove them**)
2. `SemanticClusterLevelDedup.compute_semantic_match_dfs()` 
   1. Reads per cluster `embs_by_nearest_center` 
   2. Sorts as per `which_to_keep` (now we have cosine / l2 distance) already
   3. Computes pairwise similarity (calls `pairwise_cosine_similarity`)
   4. Writes output to `semdedup_pruning_tables` a schema of `id  | max_id | cosine_sim_score`
       - earlier this was `indices | id | max_id | cosine_sim_score`
3. `SemanticClusterLevelDedup.extract_dedup_data(eps_to_extract : float)` 
   1. Calls `prune_single_cluster` 
       - earlier this called `extract_dedup_data` which called `extract_pruned_data` which called `prune_single_cluster`)
   3. Per cluster reads `semdedup_pruning_tables` 
   4. Filters out the rows where `df["cosine_sim_score"] < 1 - eps`
   10. Performs a merge with `embs_by_nearest_center` to return only `id | cosine_dist_to_cent | cluster`
       - earlier this was `id | dist_to_cent | cluster`
       - **please opine if output format should contain other cols too**


## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
