### PR TITLE
Semantic Dedup bug fix to support string id types

### DIFF
--- a/nemo_curator/utils/semdedup_utils.py
+++ b/nemo_curator/utils/semdedup_utils.py
@@ -179,8 +179,9 @@ def get_semantic_matches_per_cluster(
         max_similarity, max_indices = pairwise_cosine_similarity(
             cluster_embeddings, "cuda"
         )
-
-    max_indices_id = cluster_df[id_col].iloc[max_indices].values
+    # Ideally we could do .values and have a cupy array and hence stay in gpu memory
+    # but string arrays are not supported in cupy
+    max_indices_id = ids.iloc[max_indices].to_arrow()
     points_to_remove_df = cudf.DataFrame(
         {
             "id": ids,

--- a/nemo_curator/utils/semdedup_utils.py
+++ b/nemo_curator/utils/semdedup_utils.py
@@ -179,9 +179,7 @@ def get_semantic_matches_per_cluster(
         max_similarity, max_indices = pairwise_cosine_similarity(
             cluster_embeddings, "cuda"
         )
-    # Ideally we could do .values and have a cupy array and hence stay in gpu memory
-    # but string arrays are not supported in cupy
-    max_indices_id = ids.iloc[max_indices].to_arrow()
+    max_indices_id = ids.iloc[max_indices].reset_index(drop=True)
     points_to_remove_df = cudf.DataFrame(
         {
             "id": ids,


### PR DESCRIPTION
## Description
`cupy` doesn't support string arrays, therefore `.values` won't work as intended. 

Originally I was going to use `.to_arrow()` to solve this problem, but then i figured we could just let it be a cudf.Series



## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
