### PR TITLE
Making Score and Filter to accept DocumentFilter too

### DIFF
--- a/nemo_curator/modules/filter.py
+++ b/nemo_curator/modules/filter.py
@@ -114,7 +114,7 @@ class Filter(BaseModule):
         Constructs a Filter module
 
         Args:
-          filter_fn (Callable | DocumentFilter): A function that returns True if the document is to be kept or a DocumentFilter object, 
+          filter_fn (Callable | DocumentFilter): A function that returns True if the document is to be kept or a DocumentFilter object,
           in which case the filter_fn will be the keep_document method of the DocumentFilter.
           filter_field (str): The field(s) to be passed into the filter function.
           invert (bool): Whether to invert the filter condition.

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -286,7 +286,6 @@ class TestFilterModule:
         assert all_equal(
             expected_data, filtered_data
         ), f"Expected {expected_data} but got {filtered_data}"
-    
 
     def test_invert(self, letter_count_data):
         letter_filter = LetterCountFilter()


### PR DESCRIPTION
## Description
Make Score and Filter callable. Fixes #515 

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
