### PR TITLE
Support writing gzip compressed jsonl files

### DIFF
--- a/nemo_curator/datasets/doc_dataset.py
+++ b/nemo_curator/datasets/doc_dataset.py
@@ -232,6 +232,7 @@ class DocumentDataset:
         write_to_filename: Union[bool, str] = False,
         keep_filename_column: bool = False,
         partition_on: Optional[str] = None,
+        compression: Optional[str] = None,
     ):
         """
         Writes the dataset to the specified path in JSONL format.
@@ -251,6 +252,9 @@ class DocumentDataset:
             partition_on (Optional[str]): The column name used to partition the data.
                 If specified, data is partitioned based on unique values in this column,
                 with each partition written to a separate directory.
+            compression (Optional[str]): The compression to use for the output file.
+                If specified, the output file will be compressed using the specified compression.
+                Supported compression types are "gzip" or "none".
 
         For more details, refer to the `write_to_disk` function in
         `nemo_curator.utils.distributed_utils`.
@@ -262,6 +266,7 @@ class DocumentDataset:
             keep_filename_column=keep_filename_column,
             partition_on=partition_on,
             output_type="jsonl",
+            compression=compression,
         )
 
     def to_parquet(

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -62,6 +62,14 @@ def _enable_spilling():
     cudf.set_option("spill", True)
 
 
+def get_filepath_without_extension(path: str) -> str:
+    p = Path(path)
+    filename = p.name
+    for s in reversed(p.suffixes):
+        filename = filename.removesuffix(s)
+    return filename
+
+
 def start_dask_gpu_local_cluster(
     nvlink_only: bool = False,
     protocol: str = "tcp",
@@ -739,6 +747,7 @@ def single_partition_write_with_filename(
     keep_filename_column: bool = False,
     output_type: str = "jsonl",
     filename_col: str = "file_name",
+    compression: Optional[str] = None,
 ):
     """
     This function processes a DataFrame and writes it to disk
@@ -780,12 +789,22 @@ def single_partition_write_with_filename(
                 out_df = out_df.drop(filename_col, axis=1)
 
             filename = (
-                Path(filename).stem if output_type != "bitext" else Path(filename).name
+                get_filepath_without_extension(filename)
+                if output_type != "bitext"
+                else Path(filename).name
             )
             output_file_path = os.path.join(output_file_dir, filename)
 
             if output_type == "jsonl":
                 output_file_path = output_file_path + ".jsonl"
+                SUPPORTED_COMPRESSIONS = {"gzip", None}
+                if compression not in SUPPORTED_COMPRESSIONS:
+                    raise ValueError(
+                        f"Unsupported compression type: {compression}. "
+                        f"Supported types: {SUPPORTED_COMPRESSIONS}"
+                    )
+                if compression == "gzip":
+                    output_file_path = output_file_path + ".gz"
 
                 if isinstance(df, pd.DataFrame):
                     out_df.to_json(
@@ -794,6 +813,7 @@ def single_partition_write_with_filename(
                         lines=True,
                         force_ascii=False,
                         index=False,  # Only index=False is supported for orient="records"
+                        compression=compression,
                     )
                 else:
                     # See open issue here: https://github.com/rapidsai/cudf/issues/15211
@@ -903,6 +923,7 @@ def write_to_disk(
     keep_filename_column: bool = False,
     output_type: str = "jsonl",
     partition_on: Optional[str] = None,
+    compression: Optional[str] = None,
 ):
     """
     This function writes a Dask DataFrame to the specified file path.
@@ -920,6 +941,7 @@ def write_to_disk(
         partition_on: The column name to partition the data on.
                       If specified, the data will be partitioned based on the unique values in this column,
                       and each partition will be written to a separate directory
+        compression: The compression type to use. Can be "gzip" or None
     """
 
     filename_col = _resolve_filename_col(write_to_filename)
@@ -927,7 +949,10 @@ def write_to_disk(
     if isinstance(output_path, str) and output_path.endswith(".jsonl"):
         if df.npartitions == 1:
             df.map_partitions(
-                _write_to_jsonl_or_parquet, output_path, output_type
+                _write_to_jsonl_or_parquet,
+                output_path,
+                output_type,
+                compression=compression,
             ).compute()
             return
         else:
@@ -963,6 +988,7 @@ def write_to_disk(
             keep_filename_column=keep_filename_column,
             output_type=output_type,
             filename_col=filename_col,
+            compression=compression,
             meta=output_meta,
             enforce_metadata=False,
         )
@@ -976,6 +1002,7 @@ def write_to_disk(
                 output_path=output_path,
                 output_type=output_type,
                 partition_on=partition_on,
+                compression=compression,
             )
         elif output_type == "bitext":
             if write_to_filename:
@@ -1011,8 +1038,16 @@ def _write_to_jsonl_or_parquet(
     output_path: str,
     output_type: Literal["jsonl", "parquet"] = "jsonl",
     partition_on: Optional[str] = None,
+    compression: Optional[str] = None,
 ):
     if output_type == "jsonl":
+        SUPPORTED_COMPRESSIONS = {"gzip", None}
+        if compression not in SUPPORTED_COMPRESSIONS:
+            raise ValueError(
+                f"Unsupported compression type: {compression}. "
+                f"Supported types: {SUPPORTED_COMPRESSIONS}"
+            )
+
         if partition_on is not None:
             unique_values = (
                 df[partition_on]
@@ -1032,6 +1067,7 @@ def _write_to_jsonl_or_parquet(
                     lines=True,
                     force_ascii=False,
                     index=False,  # Only index=False is supported for orient="records"
+                    compression=compression,
                 )
         else:
             if is_cudf_type(df):
@@ -1043,6 +1079,7 @@ def _write_to_jsonl_or_parquet(
                     lines=True,
                     force_ascii=False,
                     index=False,
+                    compression=compression,
                 )  # Only index=False is supported for orient="records"
             else:
                 df.to_json(
@@ -1051,8 +1088,13 @@ def _write_to_jsonl_or_parquet(
                     lines=True,
                     force_ascii=False,
                     index=False,
+                    compression=compression,
                 )  # Only index=False is supported for orient="records"
     elif output_type == "parquet":
+        if compression is not None:
+            raise ValueError(
+                "Setting a custom compression type is not supported for Parquet files at this time."
+            )
         df.to_parquet(output_path, write_index=False, partition_on=partition_on)
     else:
         raise ValueError(f"Unknown output type: {output_type}")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gzip
 import json
 import math
 import os
@@ -190,19 +191,27 @@ class TestIO:
 
 class TestWriteWithFilename:
     @pytest.mark.parametrize("keep_filename_column", [True, False])
-    @pytest.mark.parametrize("file_ext", ["jsonl", "parquet"])
+    @pytest.mark.parametrize("file_ext", ["jsonl", "parquet", "jsonl.gz"])
     @pytest.mark.parametrize("filename_col", ["file_name", "filename"])
     def test_multifile_single_partition(
         self, tmp_path, keep_filename_column, file_ext, filename_col
     ):
+        if file_ext == "jsonl.gz":
+            compression = "gzip"
+            file_type = "jsonl"
+        else:
+            compression = None
+            file_type = file_ext
+
         df = pd.DataFrame({"a": [1, 2, 3], filename_col: ["file0", "file1", "file1"]})
 
         single_partition_write_with_filename(
             df=df,
             output_file_dir=tmp_path,
             keep_filename_column=keep_filename_column,
-            output_type=file_ext,
+            output_type=file_type,
             filename_col=filename_col,
+            compression=compression,
         )
         assert os.path.exists(tmp_path / f"file0.{file_ext}")
         assert os.path.exists(tmp_path / f"file1.{file_ext}")
@@ -211,30 +220,42 @@ class TestWriteWithFilename:
             df = df.drop(filename_col, axis=1)
 
         df1 = read_single_partition(
-            files=[tmp_path / f"file0.{file_ext}"], backend="pandas", file_type=file_ext
+            files=[tmp_path / f"file0.{file_ext}"],
+            backend="pandas",
+            file_type=file_type,
         )
         assert_eq(df1, df.iloc[0:1], check_index=False)
 
         df2 = read_single_partition(
-            files=[tmp_path / f"file1.{file_ext}"], backend="pandas", file_type=file_ext
+            files=[tmp_path / f"file1.{file_ext}"],
+            backend="pandas",
+            file_type=file_type,
         )
         assert_eq(df2, df.iloc[1:3], check_index=False)
 
     @pytest.mark.parametrize("keep_filename_column", [True, False])
-    @pytest.mark.parametrize("file_ext", ["jsonl", "parquet"])
+    @pytest.mark.parametrize("file_ext", ["jsonl", "parquet", "jsonl.gz"])
     def test_singlefile_single_partition(
         self,
         tmp_path,
         keep_filename_column,
         file_ext,
     ):
+        if file_ext == "jsonl.gz":
+            compression = "gzip"
+            file_type = "jsonl"
+        else:
+            compression = None
+            file_type = file_ext
+
         df = pd.DataFrame({"a": [1, 2, 3], "file_name": ["file2", "file2", "file2"]})
 
         single_partition_write_with_filename(
             df=df,
             output_file_dir=tmp_path,
             keep_filename_column=keep_filename_column,
-            output_type=file_ext,
+            output_type=file_type,
+            compression=compression,
         )
         assert len(os.listdir(tmp_path)) == 1
         assert os.path.exists(tmp_path / f"file2.{file_ext}")
@@ -242,7 +263,9 @@ class TestWriteWithFilename:
         if not keep_filename_column:
             df = df.drop("file_name", axis=1)
         got = read_single_partition(
-            files=[tmp_path / f"file2.{file_ext}"], backend="pandas", file_type=file_ext
+            files=[tmp_path / f"file2.{file_ext}"],
+            backend="pandas",
+            file_type=file_type,
         )
         assert_eq(got, df)
 
@@ -260,10 +283,18 @@ class TestWriteWithFilename:
         [
             ("jsonl", DocumentDataset.read_json),
             ("parquet", DocumentDataset.read_parquet),
+            ("jsonl.gz", DocumentDataset.read_json),
         ],
     )
     @pytest.mark.parametrize("filename_col", ["file_name", "filename"])
     def test_multifile_multi_partition(self, tmp_path, file_ext, read_f, filename_col):
+        if file_ext == "jsonl.gz":
+            compression = "gzip"
+            file_type = "jsonl"
+        else:
+            compression = None
+            file_type = file_ext
+
         df1 = pd.DataFrame({"a": [1, 2, 3], filename_col: ["file1", "file2", "file2"]})
         df2 = df1.copy()
         df2[filename_col] = "file3"
@@ -275,7 +306,8 @@ class TestWriteWithFilename:
             df=ddf,
             output_path=tmp_path / file_ext,
             write_to_filename=filename_col,
-            output_type=file_ext,
+            output_type=file_type,
+            compression=compression,
         )
 
         got_df = read_f(
@@ -371,8 +403,9 @@ class TestPartitionOn:
             [1.0, 2.0, 1.0, 2.0],
         ],
     )
+    @pytest.mark.parametrize("compression", [None, "gzip"])
     def test_write_to_disk_with_partition_on_jsonl(
-        self, tmp_path, backend, category_values
+        self, tmp_path, backend, category_values, compression
     ):
         """
         Test writing a partitioned JSONL dataset.
@@ -387,7 +420,11 @@ class TestPartitionOn:
         ddf = ddf.to_backend(backend)
         output_dir = tmp_path / "output_jsonl"
         dataset = DocumentDataset(ddf)
-        dataset.to_json(output_path=str(output_dir), partition_on="category")
+        dataset.to_json(
+            output_path=str(output_dir),
+            partition_on="category",
+            compression=compression,
+        )
         # Check that the output directory contains subdirectories for each partition.
         # Unique partition values (as strings) to be used in the directory names.
         unique_partitions = {str(x) for x in category_values}
@@ -405,7 +442,9 @@ class TestPartitionOn:
                 jsonl_files
             ), f"No JSONL files found in partition directory {part_dir}"
             for file in jsonl_files:
-                with open(file, "r") as f:
+                with (
+                    gzip.open(file, "rt") if compression == "gzip" else open(file, "r")
+                ) as f:
                     for line in f:
                         record = json.loads(line)
                         if "category" in record:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Adds support for writing gzip compressed jsonl files which was always supported in the pandas backend but also added in recent releases for the cuDF backend as well.

## Usage
<!-- Potentially add a usage example below -->
```python
doc_dataset.to_json(..., compression="gzip")
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
