### PR TITLE
Fix bug when removing extensions from a filename

### DIFF
--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -65,10 +65,15 @@ def _enable_spilling():
 
 
 def get_filepath_without_extension(path: str) -> str:
+    known_suffixes = [".jsonl", ".json", ".parquet", ".gz", ".part", ".snappy"]
     p = Path(path)
     filename = p.name
     for s in reversed(p.suffixes):
-        filename = filename.removesuffix(s)
+        if s in known_suffixes:
+            filename = filename.removesuffix(s)
+        else:
+            # Exit loop if we encounter an unknown suffix
+            break
     return filename
 
 

--- a/tests/utils/test_distributed_utils.py
+++ b/tests/utils/test_distributed_utils.py
@@ -38,6 +38,7 @@ from nemo_curator.utils.distributed_utils import (
     check_dask_cwd,
     get_client,
     get_current_client,
+    get_filepath_without_extension,
     get_gpu_memory_info,
     get_network_interfaces,
     get_num_workers,
@@ -1112,3 +1113,15 @@ class TestUtilityFunctions:
 
         except Exception as e:
             pytest.skip(f"Could not create GPU Dask client for testing: {e}")
+
+    def test_get_filepath_without_extension(self):
+        """Test get_filepath_without_extension function."""
+        assert get_filepath_without_extension("test.jsonl") == "test"
+        assert get_filepath_without_extension("test.jsonl.gz") == "test"
+        assert get_filepath_without_extension("test.json") == "test"
+        assert get_filepath_without_extension("test.parquet") == "test"
+        assert get_filepath_without_extension("test.gz") == "test"
+        assert get_filepath_without_extension("test.part") == "test"
+        assert get_filepath_without_extension("test.xyz.jsonl.gz") == "test.xyz"
+        assert get_filepath_without_extension("test.gz.xyz.jsonl") == "test.gz.xyz"
+        assert get_filepath_without_extension("test.0.part") == "test.0"


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Fixes a bug introduced in #626 which ends up truncating filenames of files like `abc.xyz.def.file_ext` style names. 
The current solution is a stopgap but I suspect there's something more robust that can be done here by utilizing fsspec or other filesystem utils and refactoring the IO sections.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
