### PR TITLE
Add asyncio to PyTest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,8 @@ Homepage = "https://github.com/NVIDIA/NeMo-Curator"
 
 [tool.pytest.ini_options]
 markers = [
-    "gpu: marks tests as GPU tests (deselect with '-m \"not gpu\"')"
+    "gpu: marks tests as GPU tests (deselect with '-m \"not gpu\"')",
+    "asyncio: mark a test as asyncio (used by pytest-asyncio)"
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Not having it does not break anything, but adding the "asyncio" marker to our `pyproject.toml` file allows us to silence the `PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html` warnings on our GPU CI.