### PR TITLE
Minhash Script Bugfix - removed extra argparse 

### DIFF
--- a/nemo_curator/scripts/fuzzy_deduplication/minhash_lsh.py
+++ b/nemo_curator/scripts/fuzzy_deduplication/minhash_lsh.py
@@ -76,7 +76,7 @@ def main(args: argparse.Namespace) -> None:
     logger.info(f"Computing and writing buckets took {time.time() - t1} s")
 
 
-def attach_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+def attach_args() -> argparse.ArgumentParser:
     description = """
 Computes buckets from existing minhashes and writes the output
 to files. Each row corresponds to a document ID, followed by the columns


### PR DESCRIPTION
## Description
Unintentionally in the Ruff PR looks like parser was added as a required arg in parser. This is how it was before the Ruff changes https://github.com/NVIDIA/NeMo-Curator/blame/81983ad74f59f9c9477612ce88853a186b3474b8/nemo_curator/scripts/fuzzy_deduplication/minhash_lsh.py#L83

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
