### PR TITLE
Revert PiiDeidentifier Import 

### DIFF
--- a/nemo_curator/modifiers/pii_modifier.py
+++ b/nemo_curator/modifiers/pii_modifier.py
@@ -16,7 +16,6 @@
 import pandas as pd
 
 from nemo_curator.modifiers import DocumentModifier
-from nemo_curator.pii.algorithm import PiiDeidentifier
 from nemo_curator.pii.constants import DEFAULT_LANGUAGE, DEFAULT_MAX_DOC_SIZE
 from nemo_curator.utils.decorators import batched
 from nemo_curator.utils.distributed_utils import load_object_on_worker
@@ -86,7 +85,7 @@ class PiiModifier(DocumentModifier):
         output: pd.Series = pd.Series(output, text.index)
         return output
 
-    def load_deidentifier(self) -> PiiDeidentifier:
+    def load_deidentifier(self) -> "PiiDeidentifier":  # noqa: F821
         """
         Helper function to load the de-identifier
         """


### PR DESCRIPTION
## Description
This PR reverts to changes made by @ayushdg in https://github.com/NVIDIA/NeMo-Curator/pull/61/files which were changed back to ruff changes


#### MRE to test:
```python3

#!/usr/bin/env python3
"""
Report which physical GPU (nvidia‑smi index) each NeMo‑Curator Dask worker
is using, and assert uniqueness per host.

Duplicates across hosts are allowed; duplicates on the same host trigger
an AssertionError.
"""

from __future__ import annotations
import socket
import time
from collections import defaultdict
from nemo_curator import get_client, __version__ as curator_version


def _worker_info() -> tuple[str, int]:
    """
    Runs on every Dask worker.

    Returns
    -------
    (hostname, global_gpu_index)
        hostname     – value from socket.gethostname() on that node
        gpu_index    – nvidia‑smi column index of the GPU this worker owns
    """
    import cupy
    import pynvml as nvml

    nvml.nvmlInit()

    # Which CUDA device is active in *this process*?
    cuda_ord = cupy.cuda.runtime.getDevice()
    props = cupy.cuda.runtime.getDeviceProperties(cuda_ord)

    # Construct PCI ID in NVML's 00000000:BB:DD.0 format
    pci_id = (
        f"{props['pciDomainID']:08x}:{props['pciBusID']:02x}:"
        f"{props['pciDeviceID']:02x}.0"
    ).upper()

    # Find the NVML GPU whose bus ID matches
    for i in range(nvml.nvmlDeviceGetCount()):
        h = nvml.nvmlDeviceGetHandleByIndex(i)
        bus = nvml.nvmlDeviceGetPciInfo(h).busId
        bus = bus.decode() if isinstance(bus, (bytes, bytearray)) else bus
        if bus.upper() == pci_id:
            return socket.gethostname(), i

    # Fallback – should not happen unless CUDA/NVML mismatch
    return socket.gethostname(), -1


def main() -> None:
    print(f"NeMo Curator version: {curator_version}")

    client = get_client(cluster_type="gpu", rmm_pool_size="1GB")
    time.sleep(3)  # give workers time to register

    worker_map = client.run(_worker_info)  # {worker_addr: (host, gpu)}
    print(f"Connected Dask workers: {len(worker_map)}\n")

    # Group GPU indices by host
    host_to_gpus: dict[str, list[int]] = defaultdict(list)
    for addr, (host, gpu) in worker_map.items():
        host_to_gpus[host].append(gpu)
        print(f"• {host:<20} {addr:<40} →  GPU {gpu}")

    # Assert uniqueness per host
    for host, gpus in host_to_gpus.items():
        dupes = [g for g in set(gpus) if gpus.count(g) > 1]
        assert not dupes, (
            f"Duplicate GPU indices {dupes} detected on host '{host}'. "
            "Each worker on a host must own a distinct GPU."
        )

    print("\n✔ GPU assignment is unique on every host.")


if __name__ == "__main__":
    main()
 ```
 
 Main:
 ```bash
(nemo_curator_apr_18) vjawa@dgx11:~/NeMo-Curator/tutorials/distributed_data_classification$ python3 cluster_creation.py 
NeMo Curator version: 0.9.0rc0.dev0
cuDF Spilling is enabled
Connected Dask workers: 8

• dgx11                tcp://127.0.0.1:35503                    →  GPU 0
• dgx11                tcp://127.0.0.1:37855                    →  GPU 0
• dgx11                tcp://127.0.0.1:39545                    →  GPU 0
• dgx11                tcp://127.0.0.1:40177                    →  GPU 0
• dgx11                tcp://127.0.0.1:40939                    →  GPU 0
• dgx11                tcp://127.0.0.1:42693                    →  GPU 0
• dgx11                tcp://127.0.0.1:43749                    →  GPU 0
 
 ```


 With PR:
 ```bash
 NeMo Curator version: 0.9.0rc0.dev0
cuDF Spilling is enabled
Connected Dask workers: 8

• dgx11                tcp://127.0.0.1:35219                    →  GPU 2
• dgx11                tcp://127.0.0.1:36031                    →  GPU 7
• dgx11                tcp://127.0.0.1:36525                    →  GPU 6
• dgx11                tcp://127.0.0.1:36765                    →  GPU 0
• dgx11                tcp://127.0.0.1:38017                    →  GPU 5
• dgx11                tcp://127.0.0.1:43371                    →  GPU 3
• dgx11                tcp://127.0.0.1:43981                    →  GPU 4
• dgx11                tcp://127.0.0.1:46111                    →  GPU 1
 ```
 
