### PR TITLE
SemDedup bug fix for single element cluster

### DIFF
--- a/nemo_curator/utils/semdedup_utils.py
+++ b/nemo_curator/utils/semdedup_utils.py
@@ -143,7 +143,7 @@ def get_semantic_matches_per_cluster(  # noqa: PLR0913
     if len(cluster_df) == 1:
         cluster_df["id"] = cluster_df[id_col]
         cluster_df["max_id"] = cluster_df[id_col]
-        cluster_df["cosine_sim_score"] = [0]
+        cluster_df["cosine_sim_score"] = cudf.Series([0], dtype="float32")
         cluster_df = cluster_df[["id", "max_id", "cosine_sim_score"]]
         cluster_df.to_parquet(output_df_file_path)
         return


### PR DESCRIPTION
## Description
Without this that one single cluster will have datatype of int32 vs float32 for other columns and hence all of `semdedup_pruning_tables` won't be read in case some one tries to read it combined

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
