### PR TITLE
Add initial copy-pr-bot config

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,27 @@
+enabled: true
+additional_trustees:
+  - ryantwolf
+  - ericharper
+  - ko3n1g
+  - chtruong814
+  - thomasdhc
+  - pablo-garay
+  - ayushdg
+  - praateekmahajan
+  - sarahyurick
+  - singhva
+  - VibhuJawa
+  - arhamm1
+additional_vetters:
+  - ryantwolf
+  - ericharper
+  - ko3n1g
+  - chtruong814
+  - thomasdhc
+  - pablo-garay
+  - ayushdg
+  - praateekmahajan
+  - sarahyurick
+  - singhva
+  - VibhuJawa
+  - arhamm1


### PR DESCRIPTION
## Description
Add initial copy-pr-bot config. Once we move to the Nvidia Github runners, this will be used to vet who's PRs are allowed to run on the CI machines. Or who can allow an external user's PR to run in the CI pipeline.

I added names based on members who had write and admin access.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
