### PR TITLE
ci: Always require using the /ok to test comment to run tests

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -25,3 +25,5 @@ additional_vetters:
   - singhva
   - VibhuJawa
   - arhamm1
+auto_sync_draft: false
+auto_sync_ready: false


### PR DESCRIPTION
## Description
Always require using the /ok to test comment to run tests

Currently, with the copy-pr-bot config, every commit will trigger GPU tests to run. To align more closely with the gpu-ci label, we'll update the copy-pr-bot config so that the developer needs to intentionally comment `/ok to test` to trigger.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
