### PR TITLE
Simplifying clustering logic

### DIFF
--- a/nemo_curator/_compat.py
+++ b/nemo_curator/_compat.py
@@ -43,6 +43,7 @@ except (ImportError, TypeError):
 DASK_SHUFFLE_METHOD_ARG = _dask_version > parse_version("2024.1.0")
 DASK_P2P_ERROR = _dask_version < parse_version("2023.10.0")
 DASK_SHUFFLE_CAST_DTYPE = _dask_version > parse_version("2023.12.0")
+DASK_CUDF_PARQUET_READ_INCONSISTENT_SCHEMA = _dask_version > parse_version("2025.2.0")
 
 # Query-planning check (and cache)
 _DASK_QUERY_PLANNING_ENABLED = None

--- a/nemo_curator/_compat.py
+++ b/nemo_curator/_compat.py
@@ -43,7 +43,6 @@ except (ImportError, TypeError):
 DASK_SHUFFLE_METHOD_ARG = _dask_version > parse_version("2024.1.0")
 DASK_P2P_ERROR = _dask_version < parse_version("2023.10.0")
 DASK_SHUFFLE_CAST_DTYPE = _dask_version > parse_version("2023.12.0")
-DASK_CUDF_PARQUET_READ_INCONSISTENT_SCHEMA = _dask_version > parse_version("2025.2.0")
 
 # Query-planning check (and cache)
 _DASK_QUERY_PLANNING_ENABLED = None

--- a/nemo_curator/modules/semantic_dedup/clusteringmodel.py
+++ b/nemo_curator/modules/semantic_dedup/clusteringmodel.py
@@ -116,7 +116,6 @@ class ClusteringModel:
             raise ValueError(msg)
 
         with performance_report_if_with_ts_suffix(self.profile_dir, "clustering-model"):
-            t0 = time.perf_counter()
             if not self.keep_all_columns:
                 embeddings_df = embeddings_df[[self.id_col, self.embedding_column]]
 

--- a/nemo_curator/modules/semantic_dedup/clusteringmodel.py
+++ b/nemo_curator/modules/semantic_dedup/clusteringmodel.py
@@ -135,9 +135,7 @@ class ClusteringModel:
             cupy_normalized_darr = embeddings_df.map_partitions(
                 get_array_from_df, self.embedding_column, meta=cp.ndarray([1, 1])
             )
-            print(f"before persist {type(cupy_normalized_darr)=}", flush=True)
             cupy_normalized_darr.persist()
-            print(f"after persist {type(cupy_normalized_darr)=}", flush=True)
 
             try:
                 cupy_normalized_darr.compute_chunk_sizes()


### PR DESCRIPTION
# TLDR
Existing implementation is both convoluted and can be very slow [unless a user explicitly does `to_backend("cudf")` (read point 1 below).]
A simpler implementation performs similar even when user doesn't do the `to_backend(..)`. 

The code has been testing on 37mn embedding dataset (80gb worth of data) on 7 GPUs and much smaller dataset of 2gb on both Rapids 25.02 and Rapids 25.06.


Here is the GPU utilization for 90 gb of embeddings where we see that during KMeans.fit it spikes to 2x
![image](https://github.com/user-attachments/assets/eec9a17d-ca37-4ce6-8eaf-140e01683676)


Here are the results which show that our existing implementation times out when we don't do `to_backend('cudf')` 

![image](https://github.com/user-attachments/assets/d3dcca15-d578-4ff3-912f-128b86d4f6a9)


# Longer Version
Our existing codes flow was as follows
```python
# Step 1) read df
embeddings_df = DocumentDataset.read_parquet(...., backend="cudf", blocksize or fpp).df
# Step 2) persist to pandas
embeddings_df = embeddings_df.to_backend("pandas").persist()
# Step 3) Assert for len > n_clusters
if len(embeddings_df) > kmeans_n_clusters: raise error
# Step 4) persist to cudf
embeddings_df = embeddings_df.to_backend("cudf")
# Step 5) get embeddings array
embeddings_arr = embeddings_df.map_partitions(get_array)
# Step 6) compute_chunk_sizes
embeddings_arr.compute_chunk_sizes()
# Step 7) train kmeans
KMeans().fit(embeddings_arr)
```

The few takeaways in above code are
1. If between step 1 and step 2 we didn't do `embeddings_df.to_backend("cudf")` the performance at scale was very slow (no idea why this would be the case) **this is the main reason for this PR**
2. Step 3, while a good user experience is super expensive (since the user might've read using FPP in which case all data is read). We expect an error to anyway be thrown at `KMeans().fit`
3. Step 5 started failing atleast from `dask 25.02` due to `Cannot fuse tasks with multiple outputs` (fixed in 25.06 atleast, not sure about 25.04)
2. Step 6 wasn't needed since 25.02 atleast
4. Step 7 persists `embeddings_arr` anyway within the code


The final version of code now looks like this
```python 
# Step 1) read df (this calls `dask_cudf.read_parquet(...)`)
embeddings_df = DocumentDataset.read_parquet(...., backend="cudf", blocksize or fpp).df 
# Step 2) get embeddings array
embeddings_arr = embeddings_df.map_partitions(get_array)
# Step 3) Persist the array
embeddings_arr.persist()
# Step 4) `compute_chunk_sizes` so that we can calculate length
embeddings_arr.compute_chunk_sizes()

# Step 5) Assert for len > n_clusters
if len(embeddings_df) > kmeans_n_clusters: raise error
# Step 6) 
KMeans().fit(embeddings_arr)
```

If we're okay to get rid of the assert `len > n_clusters` the code could be even simpler (however this is prone to runtime errors that the user might not be able to understand)

```python 
# Step 1) read df (this calls `dask_cudf.read_parquet(...)`)
embeddings_df = DocumentDataset.read_parquet(...., backend="cudf", blocksize or fpp).df 
# Step 2) get embeddings array
embeddings_arr = embeddings_df.map_partitions(get_array)
# Step 3) 
KMeans().fit(embeddings_arr)
```


## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
