### PR TITLE
Fix gpu ci on push to main

### DIFF
--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -34,13 +34,7 @@ jobs:
       - name: Determine base reference
         id: base-ref
         run: |
-          if [[ "${{ github.ref }}" == refs/heads/pull-request/* ]]; then
-            # For PR branches, use the base branch from PR info
-            echo "base=${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}" >> $GITHUB_OUTPUT
-          else
-            # For other branches, use the last commit
-            echo "base=HEAD~1" >> $GITHUB_OUTPUT
-          fi
+          echo "base=${{ (startsWith(github.ref, 'refs/heads/pull-request/') && fromJSON(steps.get-pr-info.outputs.pr-info).base.ref) || 'HEAD~1' }}" >> $GITHUB_OUTPUT
 
       - name: Get changed files
         id: changed-files


### PR DESCRIPTION
## Description
Fix gpu ci on push to main. The evaluation of the PR info output was happening on the push to main still, causing the CI job to fail there.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
