### PR TITLE
Fix fasttext download URL

### DIFF
--- a/tutorials/nemotron-cc/nemotron_cc.ipynb
+++ b/tutorials/nemotron-cc/nemotron_cc.ipynb
@@ -544,7 +544,7 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://dl.fbaipublicfiles.com/fastText/supervised-models/lid.176.bin -P {model_path}"
+    "!wget https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin -P {model_path}"
    ]
   },
   {


### PR DESCRIPTION
## Description
Fixed URL for Fasttext language identification model download

- [✓ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [✓] New or Existing tests cover these changes.
- [✓ ] The documentation is up to date with these changes.
