### PR TITLE
ci: Enable pull-cache

### DIFF
--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -51,7 +51,7 @@ jobs:
 
   # First, we build and push a NeMo Curator container
   build-container:
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_build_container.yml@ko3n1g/feat/pull-cache-flag
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_build_container.yml@v0.35.0
     needs: [changed-files]
     if: ${{ needs.changed-files.outputs.any_changed == 'true' }}
     with:

--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -66,6 +66,7 @@ jobs:
       runner: linux-amd64-cpu8
       has-azure-credentials: true
       use-inline-cache: false
+      enable-pull-cache: true
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -51,7 +51,7 @@ jobs:
 
   # First, we build and push a NeMo Curator container
   build-container:
-    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_build_container.yml@v0.29.0
+    uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_build_container.yml@ko3n1g/feat/pull-cache-flag
     needs: [changed-files]
     if: ${{ needs.changed-files.outputs.any_changed == 'true' }}
     with:


### PR DESCRIPTION
## Description

Latest update of NeMo-FW-CI-templates (https://github.com/NVIDIA/NeMo-FW-CI-templates/compare/v0.34.0...v0.35.0) adds an option to enable a pull-through cache for images on public dockerhub.

This should increase resiliency of the docker build

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
