### PR TITLE
Using DocumentDataset after removal in tutorials / examples

### DIFF
--- a/examples/exact_deduplication.py
+++ b/examples/exact_deduplication.py
@@ -17,7 +17,7 @@ import time
 
 from nemo_curator.datasets import DocumentDataset
 from nemo_curator.modules import ExactDuplicates
-from nemo_curator.utils.distributed_utils import get_client, write_to_disk
+from nemo_curator.utils.distributed_utils import get_client
 from nemo_curator.utils.script_utils import ArgumentHelper
 
 
@@ -60,7 +60,7 @@ def main(args: argparse.Namespace) -> None:
         duplicates = DocumentDataset.read_parquet(duplicates, backend=backend)
 
     result = exact_dup.remove(input_dataset, duplicates)
-    write_to_disk(result, output_dir, output_type="parquet")
+    result.to_parquet(output_dir)
     print(time.time() - t0)
 
 

--- a/examples/fuzzy_deduplication.py
+++ b/examples/fuzzy_deduplication.py
@@ -19,7 +19,7 @@ import dask
 
 from nemo_curator import FuzzyDuplicates, FuzzyDuplicatesConfig
 from nemo_curator.datasets import DocumentDataset
-from nemo_curator.utils.distributed_utils import get_client, write_to_disk
+from nemo_curator.utils.distributed_utils import get_client
 from nemo_curator.utils.script_utils import ArgumentHelper
 
 
@@ -92,7 +92,7 @@ def main(args: argparse.Namespace) -> None:
             return
 
         result = fuzzy_dup.remove(input_dataset, duplicates)
-        write_to_disk(result, output_dir, output_type=filetype)
+        result.to_parquet(output_dir)
         print(f"Time taken:{time.time() - t0}s")
 
 

--- a/tutorials/dapt-curation/code/utils.py
+++ b/tutorials/dapt-curation/code/utils.py
@@ -274,8 +274,7 @@ def exact_dedupe(dataset: DocumentDataset) -> DocumentDataset:
     deduplicator = ExactDuplicates(id_field="id", text_field="text", hash_method="md5")
     # Find the duplicates
     duplicates = deduplicator(dataset)
-    deduped = deduplicator.remove(dataset, duplicates)
-    return DocumentDataset(deduped)
+    return deduplicator.remove(dataset, duplicates)
 
 
 def fuzzy_dedupe(dataset: DocumentDataset, cache_dir: str) -> DocumentDataset:

--- a/tutorials/multimodal_dapt_curation/curator/utils.py
+++ b/tutorials/multimodal_dapt_curation/curator/utils.py
@@ -162,8 +162,7 @@ def exact_dedupe(dataset: DocumentDataset) -> DocumentDataset:
     deduplicator = ExactDuplicates(id_field="id", text_field="text", hash_method="md5")
     # Find the duplicates
     duplicates = deduplicator(dataset)
-    deduped = deduplicator.remove(dataset, duplicates)
-    return DocumentDataset(deduped)
+    return deduplicator.remove(dataset, duplicates)
 
 
 def fuzzy_dedupe(dataset: DocumentDataset, cache: str) -> DocumentDataset:

--- a/tutorials/tinystories/main.py
+++ b/tutorials/tinystories/main.py
@@ -152,8 +152,7 @@ def dedupe(dataset: DocumentDataset) -> DocumentDataset:
     deduplicator = ExactDuplicates(id_field="id", text_field="text", hash_method="md5")
     # Find the duplicates
     duplicates = deduplicator(dataset)
-    deduped = deduplicator.remove(dataset, duplicates)
-    return DocumentDataset(deduped)
+    return deduplicator.remove(dataset, duplicates)
 
 
 def run_curation_pipeline(args: argparse.Namespace, jsonl_dir: str) -> None:
@@ -173,7 +172,7 @@ def run_curation_pipeline(args: argparse.Namespace, jsonl_dir: str) -> None:
         keep_extensions="jsonl",
     )
     print("Reading the data...")
-    orig_dataset = DocumentDataset.read_json(files, add_filename=True)
+    orig_dataset = DocumentDataset.read_json(files, add_filename="_filename")
     dataset = orig_dataset
 
     curation_steps = Sequential(
@@ -199,7 +198,7 @@ def run_curation_pipeline(args: argparse.Namespace, jsonl_dir: str) -> None:
         shutil.rmtree(out_path)
 
     os.makedirs(out_path)
-    dataset.to_json(out_path, write_to_filename=True)
+    dataset.to_json(out_path, write_to_filename="_filename")
     client.close()
 
 

--- a/tutorials/tinystories/main.py
+++ b/tutorials/tinystories/main.py
@@ -172,7 +172,8 @@ def run_curation_pipeline(args: argparse.Namespace, jsonl_dir: str) -> None:
         keep_extensions="jsonl",
     )
     print("Reading the data...")
-    orig_dataset = DocumentDataset.read_json(files, add_filename="_filename")
+    # We don't read with add_filename because it already exists in the jsonl files.
+    orig_dataset = DocumentDataset.read_json(files)
     dataset = orig_dataset
 
     curation_steps = Sequential(
@@ -198,7 +199,7 @@ def run_curation_pipeline(args: argparse.Namespace, jsonl_dir: str) -> None:
         shutil.rmtree(out_path)
 
     os.makedirs(out_path)
-    dataset.to_json(out_path, write_to_filename="_filename")
+    dataset.to_json(out_path, write_to_filename=True)
     client.close()
 
 


### PR DESCRIPTION
## Description
Closes #719  and other places where we were using the new `remove(..)` api but not relying on the return type being DocDataset but rather expected it to be dask.dataframe

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
