### PR TITLE
Fix bug for running filters on empty batches

### DIFF
--- a/nemo_curator/stages/text/modules/score_filter.py
+++ b/nemo_curator/stages/text/modules/score_filter.py
@@ -64,8 +64,8 @@ class Score(ProcessingStage[DocumentBatch, DocumentBatch]):
 
     def ray_stage_spec(self) -> dict[str, Any]:
         requires_setup = any(
-            hasattr(score_fn, "load_model") or hasattr(score_fn, "load_tokenizer") 
-            for score_fn in self.score_fn 
+            hasattr(score_fn, "load_model") or hasattr(score_fn, "load_tokenizer")
+            for score_fn in self.score_fn
             if isinstance(score_fn, DocumentFilter)
         )
         return {"is_actor_stage": requires_setup}
@@ -259,8 +259,8 @@ class ScoreFilter(ProcessingStage[DocumentBatch, DocumentBatch]):
 
     def ray_stage_spec(self) -> dict[str, Any]:
         requires_setup = any(
-            hasattr(filter_obj, "load_model") or hasattr(filter_obj, "load_tokenizer") 
-            for filter_obj in self.filter_obj 
+            hasattr(filter_obj, "load_model") or hasattr(filter_obj, "load_tokenizer")
+            for filter_obj in self.filter_obj
             if isinstance(filter_obj, DocumentFilter)
         )
         return {"is_actor_stage": requires_setup}

--- a/tests/stages/text/modules/test_filters.py
+++ b/tests/stages/text/modules/test_filters.py
@@ -453,27 +453,27 @@ class TestFilterModule:
 
     def test_ray_stage_spec(self) -> None:
         # Does not have load_model or load_tokenizer
-        filter = ScoreFilter(LetterCountFilter(), text_field="documents")
-        assert filter.ray_stage_spec() == {"is_actor_stage": False}
-        filter = Score(LetterCountFilter(), text_field="documents", score_field="score")
-        assert filter.ray_stage_spec() == {"is_actor_stage": False}
+        test_filter = ScoreFilter(LetterCountFilter(), text_field="documents")
+        assert test_filter.ray_stage_spec() == {"is_actor_stage": False}
+        test_filter = Score(LetterCountFilter(), text_field="documents", score_field="score")
+        assert test_filter.ray_stage_spec() == {"is_actor_stage": False}
 
         # Has load_model
-        filter = ScoreFilter(FakeQualityFilter(), text_field="documents")
-        assert filter.ray_stage_spec() == {"is_actor_stage": True}
-        filter = Score(FakeQualityFilter(), text_field="documents", score_field="score")
-        assert filter.ray_stage_spec() == {"is_actor_stage": True}
-        filter = ScoreFilter(FakeLangId(), text_field="documents")
-        assert filter.ray_stage_spec() == {"is_actor_stage": True}
-        filter = Score(FakeLangId(), text_field="documents", score_field="score")
-        assert filter.ray_stage_spec() == {"is_actor_stage": True}
+        test_filter = ScoreFilter(FakeQualityFilter(), text_field="documents")
+        assert test_filter.ray_stage_spec() == {"is_actor_stage": True}
+        test_filter = Score(FakeQualityFilter(), text_field="documents", score_field="score")
+        assert test_filter.ray_stage_spec() == {"is_actor_stage": True}
+        test_filter = ScoreFilter(FakeLangId(), text_field="documents")
+        assert test_filter.ray_stage_spec() == {"is_actor_stage": True}
+        test_filter = Score(FakeLangId(), text_field="documents", score_field="score")
+        assert test_filter.ray_stage_spec() == {"is_actor_stage": True}
 
         # Has load_tokenizer
         tokenizer = DummyTokenizer()
-        filter = ScoreFilter(TokenCountFilter(tokenizer), text_field="documents")
-        assert filter.ray_stage_spec() == {"is_actor_stage": True}
-        filter = Score(TokenCountFilter(tokenizer), text_field="documents", score_field="score")
-        assert filter.ray_stage_spec() == {"is_actor_stage": True}
+        test_filter = ScoreFilter(TokenCountFilter(tokenizer), text_field="documents")
+        assert test_filter.ray_stage_spec() == {"is_actor_stage": True}
+        test_filter = Score(TokenCountFilter(tokenizer), text_field="documents", score_field="score")
+        assert test_filter.ray_stage_spec() == {"is_actor_stage": True}
 
 
 class TestHeuristicFilters:


### PR DESCRIPTION
Depending on what operation(s) a `DocumentFilter` is computing, our current logic for handling empty data batches can fail with an error that looks like:
```
ValueError: Task DocumentBatch(task_id='file_group_3_processed_ThinkingOnFilter_NanoFilter', dataset_name='split', data=Empty DataFrame
```
This PR resolves that error.

Discovered and debugged while I was working on https://github.com/NVIDIA-NeMo/Curator/pull/1063, which has multiple aggressive filtering stages. This fix allows the entire pipeline to run as intended.