### PR TITLE
Support more flags when serving docs locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@
 #   make docs-html DOCS_ENV=ga         # Build docs for GA
 #   make docs-html                     # Build docs with no special tag
 #   make docs-live DOCS_ENV=draft      # Live server with draft tag
+#   make docs-live SPHINX_AUTOBUILD_FLAGS="--port 8080 --host 0.0.0.0"  # Custom flags
 #   make docs-publish DOCS_ENV=ga      # Production build (fails on warnings)
 
 DOCS_ENV ?=
+SPHINX_AUTOBUILD_FLAGS ?=
 
 # Detect OS for cross-platform compatibility
 ifeq ($(OS),Windows_NT)
@@ -47,7 +49,7 @@ docs-clean:
 
 docs-live:
 	@echo "Starting live-reload server (sphinx-autobuild)..."
-	cd docs && $(VENV_PYTHON) -m sphinx_autobuild $(if $(DOCS_ENV),-t $(DOCS_ENV)) . _build/html
+	cd docs && $(VENV_PYTHON) -m sphinx_autobuild $(if $(DOCS_ENV),-t $(DOCS_ENV)) $(SPHINX_AUTOBUILD_FLAGS) . _build/html
 
 docs-env:
 	@echo "Setting up docs virtual environment with uv..."
@@ -101,4 +103,4 @@ docs-live-ea:
 	$(MAKE) docs-live DOCS_ENV=ea
 
 docs-live-draft:
-	$(MAKE) docs-live DOCS_ENV=draft 
+	$(MAKE) docs-live DOCS_ENV=draft


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
While building/testing out docs on a shared remote machine or container I need to use a custom command to specify an empty port or host ip to get things working. This PR enables passing additional `sphinx_autobuild` flags when calling `make docs-live` to specify these options during testing.

## Usage
<!-- Potentially add a usage example below -->
```bash
make docs-live SPHINX_AUTOBUILD_FLAGS="--port 0 --host=0.0.0.0"
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [N/A] New or Existing tests cover these changes.
- [N/A?] The documentation is up to date with these changes.
