### PR TITLE
Remove ftfy pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ text_cpu = [
     # Aegis
     "peft",
     # Modifiers
-    "ftfy==6.1.1",
+    "ftfy",
 ]
 
 text_cuda12 = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
@@ -4129,7 +4129,7 @@ requires-dist = [
     { name = "fasttext", marker = "extra == 'text-cpu'", specifier = "==0.9.3" },
     { name = "flash-attn", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'video-cuda12'", specifier = "<=2.8.3" },
     { name = "fsspec" },
-    { name = "ftfy", marker = "extra == 'text-cpu'", specifier = "==6.1.1" },
+    { name = "ftfy", marker = "extra == 'text-cpu'" },
     { name = "gpustat", marker = "extra == 'cuda12'" },
     { name = "jieba", specifier = "==0.42.1" },
     { name = "justext", marker = "extra == 'text-cpu'" },


### PR DESCRIPTION
Closes https://github.com/NVIDIA-NeMo/Curator/issues/906.

The only part of our codebase that uses ftfy is the `UnicodeReformatter`, which is tested here: https://github.com/NVIDIA-NeMo/Curator/blob/main/tests/stages/text/modules/test_modifiers.py. Assuming the test still passes, we should be safe to merge.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-20 21:51:00 UTC

### Greptile Summary

This PR removes the version pin on the `ftfy` dependency, changing it from `ftfy==6.1.1` to `ftfy` in the `pyproject.toml` file. The change addresses issue #906 and allows the package manager to install any compatible version of ftfy rather than being locked to version 6.1.1. Within the NeMo Curator codebase, ftfy is exclusively used by the `UnicodeReformatter` module for text cleaning operations, which has existing test coverage in `tests/stages/text/modules/test_modifiers.py`. This change aligns with best practices for dependency management by relying on semantic versioning rather than hard pins, giving users more flexibility while still maintaining compatibility through ftfy's API stability.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| pyproject.toml | 4/5 | Removed version pin from ftfy dependency (changed from `ftfy==6.1.1` to `ftfy`) in the text_cpu optional dependencies |

</details>

### Confidence score: 4/5

- This PR is safe to merge with low risk, provided existing tests pass
- Score reflects minimal change scope (single dependency pin removal) and existing test coverage for the affected module (`UnicodeReformatter`), though slightly lowered because the PR depends on runtime validation rather than compile-time guarantees that newer ftfy versions maintain API compatibility
- No files require special attention; the change is straightforward and limited to dependency management

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->