### PR TITLE
Increase ``UV_HTTP_TIMEOUT`` in CI to reduce sporadic test failures

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -29,6 +29,9 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  UV_HTTP_TIMEOUT: 60
+
 jobs:
   pre-flight:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've seen quite a few flaky test failures like this recently ([here's](https://github.com/NVIDIA-NeMo/Curator/actions/runs/18657578744/job/53190359933) an example build):

```
  × Failed to download `nvidia-nccl-cu12==2.27.3`
  ├─▶ Failed to extract archive:
  │   nvidia_nccl_cu12-2.27.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
  ├─▶ I/O operation failed during extraction
  ╰─▶ Failed to download distribution due to network timeout. Try increasing
      UV_HTTP_TIMEOUT (current value: 30s).
  help: `nvidia-nccl-cu12` (v2.27.3) was included because `nemo-curator`
        depends on `torch` (v2.8.0+cu128) which depends on `nvidia-nccl-cu12`
```

This PR increase `UV_HTTP_TIMEOUT` to try to reduce the frequency we run into this sort of issue 