### PR TITLE
fix(ci): set fail-fast=false so test failures are visible in UI

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -124,7 +124,7 @@ jobs:
 
   cicd-cpu-tests:
     strategy:
-      fail-fast: true
+      fail-fast: false  # Allow all tests to complete so failures are visible in UI
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.12"]


### PR DESCRIPTION
## Problem
When a CPU test fails with ail-fast: true, GitHub Actions cancels all matrix jobs so quickly that even the failed job shows as 'cancelled' instead of 'failed'. This makes it impossible to identify which test actually failed.

## Solution
Set ail-fast: false on CPU tests so:
- All tests run to completion independently
- Failed tests clearly show as 'failed' in the UI
- Easy to identify exactly which tests failed

## Related
Discussed in Slack after https://github.com/NVIDIA-NeMo/Curator/actions/runs/20178087836/job/57932073967 showed all jobs as cancelled with no visible failures.