### PR TITLE
[benchmarking] Increases dedup_removal timeout for raydata benchmark to 1100s

### DIFF
--- a/benchmarking/nightly-benchmark.yaml
+++ b/benchmarking/nightly-benchmark.yaml
@@ -212,7 +212,7 @@ entries:
       --id-field=_curator_dedup_id
       --duplicate-id-field=_curator_dedup_id
       --blocksize=1.5GiB
-    timeout_s: 1000
+    timeout_s: 1100
     sink_data:
       - name: slack
         additional_metrics:


### PR DESCRIPTION
Increases `dedup_removal` timeout for raydata benchmark to 1100s.

<s>Note: This is being tested locally. I'll move this out of Draft once it passes</s>