### PR TITLE
Fix fasttext predict call for numpy>2

### DIFF
--- a/nemo_curator/stages/text/filters/fasttext_filter.py
+++ b/nemo_curator/stages/text/filters/fasttext_filter.py
@@ -44,9 +44,9 @@ class FastTextQualityFilter(DocumentFilter):
         model = self._fasttext_quality_filter_model
 
         text = text.replace("\n", " ").replace("__label__", " ")
-        pred = model.predict(text)
-        document_score = pred[1][0]
-        if pred[0][0] != self._label:
+        label, score = model.predict([text])
+        document_score = score[0][0].item()
+        if label[0][0] != self._label:
             document_score = 1 - document_score
 
         return document_score
@@ -78,9 +78,9 @@ class FastTextLangId(DocumentFilter):
         model = self._fasttext_langid_model
 
         pp = text.strip().replace("\n", " ")
-        label, score = model.predict(pp, k=1)
-        score = score[0]
-        lang_code = label[0][-2:].upper()
+        label, score = model.predict([pp], k=1)
+        score = score[0][0].item()
+        lang_code = label[0][0][-2:].upper()
 
         # Need to convert it to a string to allow backend conversions
         return str([score, lang_code])


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Fixes Fasttext stages failing with numpy>=2.0.0

The solution is to pass in text as a list as discussed [here](https://huggingface.co/facebook/fasttext-language-identification/discussions/9#68a34810033c55f8c7a82e8a) thanks @sarahyurick for suggesting. 

The results are one level more nested and now return a np.float32 scalar so added a another level of indexing and `.item` call to get the raw float.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
