### PR TITLE
 [REVIEW] Fix benchmarking/scripts/arxiv_e2e_pipeline_benchmark.py

### DIFF
--- a/benchmarking/scripts/arxiv_e2e_pipeline_benchmark.py
+++ b/benchmarking/scripts/arxiv_e2e_pipeline_benchmark.py
@@ -47,7 +47,11 @@ from nemo_curator.stages.text.download.arxiv import ArxivDownloadExtractStage
 from nemo_curator.stages.text.download.arxiv.extract import ArxivExtractor
 from nemo_curator.stages.text.download.arxiv.iterator import ArxivIterator
 from nemo_curator.stages.text.download.base import URLGenerator
-from nemo_curator.stages.text.download.base.iterator import DocumentIterateExtractStage
+
+try:
+    from nemo_curator.stages.text.download.base.iterator import DocumentIterateExtractStage
+except ImportError:
+    from nemo_curator.stages.text.download.base.iterator import DocumentIterateStage as DocumentIterateExtractStage
 from nemo_curator.stages.text.download.base.url_generation import URLGenerationStage
 from nemo_curator.stages.text.filters import (
     FastTextLangId,


### PR DESCRIPTION
This pull request updates the import logic in `arxiv_e2e_pipeline_benchmark.py` to improve compatibility with different versions of the `nemo_curator` package. The main change is the use of a fallback import for `DocumentIterateExtractStage` to handle cases where it may not be available.
