### PR TITLE
Fix ruff formatting for interleaved module

### DIFF
--- a/benchmarking/scripts/multimodal_mint1t_benchmark.py
+++ b/benchmarking/scripts/multimodal_mint1t_benchmark.py
@@ -54,7 +54,9 @@ def create_pipeline(args: argparse.Namespace) -> Pipeline:
             per_text_fields=tuple(args.per_text_fields) if args.per_text_fields else (),
         )
     )
-    pipeline.add_stage(InterleavedAspectRatioFilterStage(drop_invalid_rows=True, min_aspect_ratio=1.0, max_aspect_ratio=2.0))
+    pipeline.add_stage(
+        InterleavedAspectRatioFilterStage(drop_invalid_rows=True, min_aspect_ratio=1.0, max_aspect_ratio=2.0)
+    )
     pipeline.add_stage(
         InterleavedParquetWriterStage(
             path=args.output_path,

--- a/nemo_curator/stages/interleaved/io/readers/webdataset.py
+++ b/nemo_curator/stages/interleaved/io/readers/webdataset.py
@@ -90,7 +90,11 @@ class WebdatasetReaderStage(BaseInterleavedReader):
     # -- source_ref construction --
 
     def _build_source_ref(
-        self, ctx: _SampleContext, content_key: str | None, *, frame_index: int | None = None,
+        self,
+        ctx: _SampleContext,
+        content_key: str | None,
+        *,
+        frame_index: int | None = None,
     ) -> str:
         if content_key is None:
             return InterleavedBatch.build_source_ref(path=None, member=None)
@@ -101,8 +105,11 @@ class WebdatasetReaderStage(BaseInterleavedReader):
             byte_offset = info.offset_data
             byte_size = info.size
         return InterleavedBatch.build_source_ref(
-            path=ctx.tar_path, member=content_key,
-            byte_offset=byte_offset, byte_size=byte_size, frame_index=frame_index,
+            path=ctx.tar_path,
+            member=content_key,
+            byte_offset=byte_offset,
+            byte_size=byte_size,
+            frame_index=frame_index,
         )
 
     # -- row builders (override in subclasses for custom formats) --
@@ -121,16 +128,24 @@ class WebdatasetReaderStage(BaseInterleavedReader):
         }
 
     def _metadata_row(self, ctx: _SampleContext) -> dict[str, Any]:
-        return {**self._build_row(ctx, {
-            "position": -1,
-            "modality": "metadata",
-            "content_type": "application/json",
-            "source_ref": self._build_source_ref(ctx, ctx.json_member_name),
-        }), **ctx.passthrough}
+        return {
+            **self._build_row(
+                ctx,
+                {
+                    "position": -1,
+                    "modality": "metadata",
+                    "content_type": "application/json",
+                    "source_ref": self._build_source_ref(ctx, ctx.json_member_name),
+                },
+            ),
+            **ctx.passthrough,
+        }
 
     @staticmethod
     def _apply_per_modality_fields(
-        row: dict[str, Any], passthrough: dict[str, list[Any]], index: int,
+        row: dict[str, Any],
+        passthrough: dict[str, list[Any]],
+        index: int,
     ) -> None:
         for field_name, values in passthrough.items():
             if index < len(values):
@@ -139,13 +154,21 @@ class WebdatasetReaderStage(BaseInterleavedReader):
 
     @staticmethod
     def _warn_per_modality_length_mismatch(
-        sample_id: str, passthrough: dict[str, list[Any]], actual_count: int, modality: str,
+        sample_id: str,
+        passthrough: dict[str, list[Any]],
+        actual_count: int,
+        modality: str,
     ) -> None:
         for field_name, values in passthrough.items():
             if actual_count != len(values):
                 logger.warning(
                     "sample_id={}: per_{}_field '{}' has {} values but {} non-None {}s",
-                    sample_id, modality, field_name, len(values), actual_count, modality,
+                    sample_id,
+                    modality,
+                    field_name,
+                    len(values),
+                    actual_count,
+                    modality,
                 )
 
     def _text_rows(self, ctx: _SampleContext) -> list[dict[str, Any]]:
@@ -158,13 +181,16 @@ class WebdatasetReaderStage(BaseInterleavedReader):
         for idx, text_value in enumerate(texts):
             if text_value is None:
                 continue
-            row = self._build_row(ctx, {
-                "position": idx,
-                "modality": "text",
-                "content_type": "text/plain",
-                "text_content": str(text_value),
-                "source_ref": source_ref,
-            })
+            row = self._build_row(
+                ctx,
+                {
+                    "position": idx,
+                    "modality": "text",
+                    "content_type": "text/plain",
+                    "text_content": str(text_value),
+                    "source_ref": source_ref,
+                },
+            )
             self._apply_per_modality_fields(row, ctx.per_text_passthrough, non_none_counter)
             non_none_counter += 1
             rows.append(row)
@@ -176,7 +202,10 @@ class WebdatasetReaderStage(BaseInterleavedReader):
         if not isinstance(images, list):
             return []
         image_member_name = self._resolve_default_image_member_name(
-            ctx.sample_id, ctx.sample, images, ctx.member_names,
+            ctx.sample_id,
+            ctx.sample,
+            images,
+            ctx.member_names,
         )
         rows: list[dict[str, Any]] = []
         frame_counters: dict[str, int] = {}
@@ -191,12 +220,15 @@ class WebdatasetReaderStage(BaseInterleavedReader):
             if content_key is not None and is_multiframe_candidate:
                 frame_index = frame_counters.get(content_key, 0)
                 frame_counters[content_key] = frame_index + 1
-            row = self._build_row(ctx, {
-                "position": idx,
-                "modality": "image",
-                "content_type": content_type or ("application/octet-stream" if image_member_name else None),
-                "source_ref": self._build_source_ref(ctx, content_key, frame_index=frame_index),
-            })
+            row = self._build_row(
+                ctx,
+                {
+                    "position": idx,
+                    "modality": "image",
+                    "content_type": content_type or ("application/octet-stream" if image_member_name else None),
+                    "source_ref": self._build_source_ref(ctx, content_key, frame_index=frame_index),
+                },
+            )
             self._apply_per_modality_fields(row, ctx.per_image_passthrough, non_none_counter)
             non_none_counter += 1
             rows.append(row)
@@ -234,7 +266,8 @@ class WebdatasetReaderStage(BaseInterleavedReader):
 
     @staticmethod
     def _extract_per_modality_fields(
-        sample: dict[str, Any], field_names: tuple[str, ...],
+        sample: dict[str, Any],
+        field_names: tuple[str, ...],
     ) -> dict[str, list[Any]]:
         result: dict[str, list[Any]] = {}
         for field_name in field_names:
@@ -245,10 +278,7 @@ class WebdatasetReaderStage(BaseInterleavedReader):
             if isinstance(value, list):
                 result[field_name] = value
             else:
-                msg = (
-                    f"per-modality field '{field_name}' must be a list, "
-                    f"got {type(value).__name__}"
-                )
+                msg = f"per-modality field '{field_name}' must be a list, got {type(value).__name__}"
                 raise TypeError(msg)
         return result
 

--- a/nemo_curator/tasks/interleaved.py
+++ b/nemo_curator/tasks/interleaved.py
@@ -182,7 +182,10 @@ class InterleavedBatch(Task[pa.Table | pd.DataFrame]):
     ) -> str:
         """Build a ``source_ref`` JSON locator string."""
         ref: dict[str, object] = {
-            "path": path, "member": member, "byte_offset": byte_offset, "byte_size": byte_size,
+            "path": path,
+            "member": member,
+            "byte_offset": byte_offset,
+            "byte_size": byte_size,
         }
         if frame_index is not None:
             ref["frame_index"] = frame_index

--- a/tests/stages/interleaved/test_interleaved_task.py
+++ b/tests/stages/interleaved/test_interleaved_task.py
@@ -158,7 +158,11 @@ def test_parse_source_ref_with_frame_index() -> None:
 )
 def test_build_source_ref_frame_index(frame_index: int | None, key_present: bool) -> None:
     ref_str = InterleavedBatch.build_source_ref(
-        path="/a.tar", member="m.jpg", byte_offset=10, byte_size=20, frame_index=frame_index,
+        path="/a.tar",
+        member="m.jpg",
+        byte_offset=10,
+        byte_size=20,
+        frame_index=frame_index,
     )
     parsed = json.loads(ref_str)
     assert ("frame_index" in parsed) is key_present

--- a/tests/stages/interleaved/test_materialization.py
+++ b/tests/stages/interleaved/test_materialization.py
@@ -58,7 +58,10 @@ def _image_row(
         "text_content": None,
         "binary_content": None,
         "source_ref": InterleavedBatch.build_source_ref(
-            path=path, member=member, byte_offset=byte_offset, byte_size=byte_size,
+            path=path,
+            member=member,
+            byte_offset=byte_offset,
+            byte_size=byte_size,
         ),
         "materialize_error": None,
     }
@@ -87,23 +90,27 @@ def test_get_frame_index_returns_none_for_missing_values(val: object, expected: 
     [pytest.param(float("nan"), id="nan_path"), pytest.param("", id="empty_path")],
 )
 def test_classify_rows_missing_path_variants(path_val: object) -> None:
-    df = pd.DataFrame({
-        "_src_path": [path_val],
-        "_src_member": [None],
-        "_src_byte_offset": [None],
-        "_src_byte_size": [None],
-    })
+    df = pd.DataFrame(
+        {
+            "_src_path": [path_val],
+            "_src_member": [None],
+            "_src_byte_offset": [None],
+            "_src_byte_size": [None],
+        }
+    )
     result = _classify_rows(df, pd.Series([True]))
     assert result.missing == [0]
 
 
 def test_classify_rows_range_with_zero_size() -> None:
-    df = pd.DataFrame({
-        "_src_path": ["/shard.tar"],
-        "_src_member": ["img.jpg"],
-        "_src_byte_offset": [100],
-        "_src_byte_size": [0],
-    })
+    df = pd.DataFrame(
+        {
+            "_src_path": ["/shard.tar"],
+            "_src_member": ["img.jpg"],
+            "_src_byte_offset": [100],
+            "_src_byte_size": [0],
+        }
+    )
     result = _classify_rows(df, pd.Series([True]))
     assert "/shard.tar" in result.tar_extract
     assert not result.range_read
@@ -322,18 +329,21 @@ def test_materialize_with_only_missing_binary_false(tmp_path: Path) -> None:
     img_path = tmp_path / "img.jpg"
     img_path.write_bytes(new_bytes)
 
-    rows = [{
-        "sample_id": "s1",
-        "position": 0,
-        "modality": "image",
-        "content_type": "image/jpeg",
-        "text_content": None,
-        "binary_content": b"old-bytes",
-        "source_ref": InterleavedBatch.build_source_ref(path=str(img_path), member=None),
-        "materialize_error": None,
-    }]
+    rows = [
+        {
+            "sample_id": "s1",
+            "position": 0,
+            "modality": "image",
+            "content_type": "image/jpeg",
+            "text_content": None,
+            "binary_content": b"old-bytes",
+            "source_ref": InterleavedBatch.build_source_ref(path=str(img_path), member=None),
+            "materialize_error": None,
+        }
+    ]
     task = InterleavedBatch(
-        task_id="re_mat", dataset_name="d",
+        task_id="re_mat",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     result = materialize_task_binary_content(task, only_missing_binary=False)

--- a/tests/stages/interleaved/test_multimodal_core.py
+++ b/tests/stages/interleaved/test_multimodal_core.py
@@ -239,9 +239,7 @@ def test_materialize_fills_binary_from_range_read(tmp_path: Path) -> None:
     raw_file = tmp_path / "data.bin"
     raw_file.write_bytes(b"HEADER" + payload + b"FOOTER")
 
-    task = _image_task(
-        [_image_row(path=str(raw_file), member="data.bin", byte_offset=6, byte_size=len(payload))]
-    )
+    task = _image_task([_image_row(path=str(raw_file), member="data.bin", byte_offset=6, byte_size=len(payload))])
     result = materialize_task_binary_content(task)
     df = result.to_pandas()
     assert df.loc[0, "binary_content"] == payload
@@ -249,9 +247,7 @@ def test_materialize_fills_binary_from_range_read(tmp_path: Path) -> None:
 
 
 def test_materialize_range_read_bad_path(tmp_path: Path) -> None:
-    task = _image_task(
-        [_image_row(path=str(tmp_path / "nonexistent.bin"), member="x", byte_offset=0, byte_size=10)]
-    )
+    task = _image_task([_image_row(path=str(tmp_path / "nonexistent.bin"), member="x", byte_offset=0, byte_size=10)])
     result = materialize_task_binary_content(task)
     df = result.to_pandas()
     assert isinstance(df.loc[0, "materialize_error"], str)
@@ -315,16 +311,18 @@ def test_materialize_empty_task() -> None:
     task = InterleavedBatch(
         task_id="empty",
         dataset_name="d",
-        data=pa.table({
-            "sample_id": pa.array([], type=pa.string()),
-            "position": pa.array([], type=pa.int32()),
-            "modality": pa.array([], type=pa.string()),
-            "content_type": pa.array([], type=pa.string()),
-            "text_content": pa.array([], type=pa.string()),
-            "binary_content": pa.array([], type=pa.large_binary()),
-            "source_ref": pa.array([], type=pa.string()),
-            "materialize_error": pa.array([], type=pa.string()),
-        }),
+        data=pa.table(
+            {
+                "sample_id": pa.array([], type=pa.string()),
+                "position": pa.array([], type=pa.int32()),
+                "modality": pa.array([], type=pa.string()),
+                "content_type": pa.array([], type=pa.string()),
+                "text_content": pa.array([], type=pa.string()),
+                "binary_content": pa.array([], type=pa.large_binary()),
+                "source_ref": pa.array([], type=pa.string()),
+                "materialize_error": pa.array([], type=pa.string()),
+            }
+        ),
     )
     result = materialize_task_binary_content(task)
     assert result.num_items == 0
@@ -409,21 +407,33 @@ def test_aspect_ratio_filter_works_on_png_images() -> None:
     df = pd.DataFrame(
         [
             {
-                "sample_id": "s1", "position": 0, "modality": "text",
-                "content_type": "text/plain", "text_content": "ok",
-                "binary_content": None, "source_ref": None,
+                "sample_id": "s1",
+                "position": 0,
+                "modality": "text",
+                "content_type": "text/plain",
+                "text_content": "ok",
+                "binary_content": None,
+                "source_ref": None,
                 "materialize_error": None,
             },
             {
-                "sample_id": "s1", "position": 1, "modality": "image",
-                "content_type": "image/png", "text_content": None,
-                "binary_content": valid_png, "source_ref": None,
+                "sample_id": "s1",
+                "position": 1,
+                "modality": "image",
+                "content_type": "image/png",
+                "text_content": None,
+                "binary_content": valid_png,
+                "source_ref": None,
                 "materialize_error": None,
             },
             {
-                "sample_id": "s1", "position": 2, "modality": "image",
-                "content_type": "image/png", "text_content": None,
-                "binary_content": narrow_png, "source_ref": None,
+                "sample_id": "s1",
+                "position": 2,
+                "modality": "image",
+                "content_type": "image/png",
+                "text_content": None,
+                "binary_content": narrow_png,
+                "source_ref": None,
                 "materialize_error": None,
             },
         ]
@@ -518,17 +528,32 @@ def test_filter_recomputes_positions_after_drop() -> None:
             return ~((df["modality"] != "metadata") & (pos % 2 == 1))
 
     rows = [
-        {"sample_id": "s1", "position": i, "modality": "text", "content_type": "text/plain",
-         "text_content": f"t{i}", "binary_content": None, "source_ref": None,
-         "materialize_error": None}
+        {
+            "sample_id": "s1",
+            "position": i,
+            "modality": "text",
+            "content_type": "text/plain",
+            "text_content": f"t{i}",
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        }
         for i in range(4)
     ] + [
-        {"sample_id": "s1", "position": -1, "modality": "metadata", "content_type": "application/json",
-         "text_content": None, "binary_content": None, "source_ref": None,
-         "materialize_error": None},
+        {
+            "sample_id": "s1",
+            "position": -1,
+            "modality": "metadata",
+            "content_type": "application/json",
+            "text_content": None,
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
     ]
     task = InterleavedBatch(
-        task_id="pos_test", dataset_name="d",
+        task_id="pos_test",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     stage = _DropOddPositions(drop_invalid_rows=False)
@@ -555,16 +580,27 @@ def test_filter_preserves_interleaved_ordering_across_modalities() -> None:
 
     def _row(sample_id: str, position: int, modality: str, text: str | None = None) -> dict:
         return {
-            "sample_id": sample_id, "position": position, "modality": modality,
+            "sample_id": sample_id,
+            "position": position,
+            "modality": modality,
             "content_type": "text/plain" if modality == "text" else "image/jpeg",
-            "text_content": text, "binary_content": None, "source_ref": None,
+            "text_content": text,
+            "binary_content": None,
+            "source_ref": None,
             "materialize_error": None,
         }
 
     rows = [
-        {"sample_id": "s1", "position": -1, "modality": "metadata", "content_type": "application/json",
-         "text_content": None, "binary_content": None, "source_ref": None,
-         "materialize_error": None},
+        {
+            "sample_id": "s1",
+            "position": -1,
+            "modality": "metadata",
+            "content_type": "application/json",
+            "text_content": None,
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
         _row("s1", 0, "text", "intro"),
         _row("s1", 1, "image"),
         _row("s1", 2, "text", "middle"),
@@ -572,7 +608,8 @@ def test_filter_preserves_interleaved_ordering_across_modalities() -> None:
         _row("s1", 4, "text", "end"),
     ]
     task = InterleavedBatch(
-        task_id="interleave_test", dataset_name="d",
+        task_id="interleave_test",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     stage = _DropSecondImage(drop_invalid_rows=False)
@@ -598,16 +635,27 @@ def test_filter_preserves_interleaved_ordering_with_noninterleaved_row_order() -
 
     def _row(sample_id: str, position: int, modality: str, text: str | None = None) -> dict:
         return {
-            "sample_id": sample_id, "position": position, "modality": modality,
+            "sample_id": sample_id,
+            "position": position,
+            "modality": modality,
             "content_type": "text/plain" if modality == "text" else "image/jpeg",
-            "text_content": text, "binary_content": None, "source_ref": None,
+            "text_content": text,
+            "binary_content": None,
+            "source_ref": None,
             "materialize_error": None,
         }
 
     rows = [
-        {"sample_id": "s1", "position": -1, "modality": "metadata", "content_type": "application/json",
-         "text_content": None, "binary_content": None, "source_ref": None,
-         "materialize_error": None},
+        {
+            "sample_id": "s1",
+            "position": -1,
+            "modality": "metadata",
+            "content_type": "application/json",
+            "text_content": None,
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
         _row("s1", 0, "text", "intro"),
         _row("s1", 2, "text", "middle"),
         _row("s1", 4, "text", "end"),
@@ -615,7 +663,8 @@ def test_filter_preserves_interleaved_ordering_with_noninterleaved_row_order() -
         _row("s1", 3, "image"),
     ]
     task = InterleavedBatch(
-        task_id="noninterleaved_row_order", dataset_name="d",
+        task_id="noninterleaved_row_order",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     stage = _KeepAll(drop_invalid_rows=False)
@@ -639,9 +688,13 @@ def test_filter_drops_orphaned_metadata_rows() -> None:
 
     def _row(sample_id: str, position: int, modality: str, text: str | None = None) -> dict:
         return {
-            "sample_id": sample_id, "position": position, "modality": modality,
+            "sample_id": sample_id,
+            "position": position,
+            "modality": modality,
             "content_type": "text/plain" if modality == "text" else "application/json",
-            "text_content": text, "binary_content": None, "source_ref": None,
+            "text_content": text,
+            "binary_content": None,
+            "source_ref": None,
             "materialize_error": None,
         }
 
@@ -654,7 +707,8 @@ def test_filter_drops_orphaned_metadata_rows() -> None:
         _row("s2", 1, "text", "dropped2"),
     ]
     task = InterleavedBatch(
-        task_id="orphan_test", dataset_name="d",
+        task_id="orphan_test",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     stage = _DropAllSample2Content(drop_invalid_rows=False)
@@ -673,15 +727,36 @@ def test_filter_drops_orphaned_metadata_rows() -> None:
 def test_count_and_num_items() -> None:
     table = pa.Table.from_pylist(
         [
-            {"sample_id": "s1", "position": 0, "modality": "text", "content_type": None,
-             "text_content": "a", "binary_content": None, "source_ref": None,
-             "materialize_error": None},
-            {"sample_id": "s1", "position": 1, "modality": "image", "content_type": None,
-             "text_content": None, "binary_content": None, "source_ref": None,
-             "materialize_error": None},
-            {"sample_id": "s2", "position": 0, "modality": "text", "content_type": None,
-             "text_content": "b", "binary_content": None, "source_ref": None,
-             "materialize_error": None},
+            {
+                "sample_id": "s1",
+                "position": 0,
+                "modality": "text",
+                "content_type": None,
+                "text_content": "a",
+                "binary_content": None,
+                "source_ref": None,
+                "materialize_error": None,
+            },
+            {
+                "sample_id": "s1",
+                "position": 1,
+                "modality": "image",
+                "content_type": None,
+                "text_content": None,
+                "binary_content": None,
+                "source_ref": None,
+                "materialize_error": None,
+            },
+            {
+                "sample_id": "s2",
+                "position": 0,
+                "modality": "text",
+                "content_type": None,
+                "text_content": "b",
+                "binary_content": None,
+                "source_ref": None,
+                "materialize_error": None,
+            },
         ],
         schema=INTERLEAVED_SCHEMA,
     )
@@ -696,12 +771,26 @@ def test_count_and_num_items() -> None:
 def test_count_with_pandas_data() -> None:
     table = pa.Table.from_pylist(
         [
-            {"sample_id": "s1", "position": 0, "modality": "text", "content_type": None,
-             "text_content": "a", "binary_content": None, "source_ref": None,
-             "materialize_error": None},
-            {"sample_id": "s1", "position": 1, "modality": "image", "content_type": None,
-             "text_content": None, "binary_content": None, "source_ref": None,
-             "materialize_error": None},
+            {
+                "sample_id": "s1",
+                "position": 0,
+                "modality": "text",
+                "content_type": None,
+                "text_content": "a",
+                "binary_content": None,
+                "source_ref": None,
+                "materialize_error": None,
+            },
+            {
+                "sample_id": "s1",
+                "position": 1,
+                "modality": "image",
+                "content_type": None,
+                "text_content": None,
+                "binary_content": None,
+                "source_ref": None,
+                "materialize_error": None,
+            },
         ],
         schema=INTERLEAVED_SCHEMA,
     )
@@ -729,7 +818,9 @@ def test_read_direct_file_handles_non_oserror_exceptions() -> None:
     """_read_direct_file must gracefully return None for non-OSError exceptions
     (e.g. RuntimeError from fsspec plugins) instead of crashing.
     """
-    with patch("nemo_curator.stages.interleaved.utils.materialization.fsspec.open", side_effect=RuntimeError("plugin error")):
+    with patch(
+        "nemo_curator.stages.interleaved.utils.materialization.fsspec.open", side_effect=RuntimeError("plugin error")
+    ):
         result = _read_direct_file("/some/path.jpg", {})
     assert result is None
 
@@ -761,34 +852,49 @@ def test_iter_materialized_bytes_only_yields_masked_rows(tmp_path: Path) -> None
 
     rows = [
         {
-            "sample_id": "s1", "position": -1, "modality": "metadata",
-            "content_type": "application/json", "text_content": None,
-            "binary_content": None, "source_ref": None,
+            "sample_id": "s1",
+            "position": -1,
+            "modality": "metadata",
+            "content_type": "application/json",
+            "text_content": None,
+            "binary_content": None,
+            "source_ref": None,
             "materialize_error": None,
         },
         {
-            "sample_id": "s1", "position": 0, "modality": "text",
-            "content_type": "text/plain", "text_content": "hello",
-            "binary_content": None, "source_ref": None,
+            "sample_id": "s1",
+            "position": 0,
+            "modality": "text",
+            "content_type": "text/plain",
+            "text_content": "hello",
+            "binary_content": None,
+            "source_ref": None,
             "materialize_error": None,
         },
         {
-            "sample_id": "s1", "position": 1, "modality": "image",
-            "content_type": "image/jpeg", "text_content": None,
+            "sample_id": "s1",
+            "position": 1,
+            "modality": "image",
+            "content_type": "image/jpeg",
+            "text_content": None,
             "binary_content": None,
             "source_ref": InterleavedBatch.build_source_ref(path=str(file_a), member=None),
             "materialize_error": None,
         },
         {
-            "sample_id": "s1", "position": 2, "modality": "image",
-            "content_type": "image/jpeg", "text_content": None,
+            "sample_id": "s1",
+            "position": 2,
+            "modality": "image",
+            "content_type": "image/jpeg",
+            "text_content": None,
             "binary_content": None,
             "source_ref": InterleavedBatch.build_source_ref(path=str(file_b), member=None),
             "materialize_error": None,
         },
     ]
     task = InterleavedBatch(
-        task_id="iter_test", dataset_name="d",
+        task_id="iter_test",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     df = task.to_pandas().copy()
@@ -815,8 +921,11 @@ def test_iter_materialized_bytes_preserves_original_indices(tmp_path: Path) -> N
 
     rows = [
         {
-            "sample_id": "s1", "position": 0, "modality": "image",
-            "content_type": "image/jpeg", "text_content": None,
+            "sample_id": "s1",
+            "position": 0,
+            "modality": "image",
+            "content_type": "image/jpeg",
+            "text_content": None,
             "binary_content": None,
             "source_ref": InterleavedBatch.build_source_ref(path=str(img_path), member=None),
             "materialize_error": None,
@@ -847,20 +956,25 @@ def test_materialize_extracts_individual_tiff_frames(tmp_path: Path) -> None:
 
     rows = []
     for i in range(n_frames):
-        rows.append({
-            "sample_id": "s1",
-            "position": i,
-            "modality": "image",
-            "content_type": "image/tiff",
-            "text_content": None,
-            "binary_content": None,
-            "source_ref": InterleavedBatch.build_source_ref(
-                path=tar_path, member="doc.tiff", frame_index=i,
-            ),
-            "materialize_error": None,
-        })
+        rows.append(
+            {
+                "sample_id": "s1",
+                "position": i,
+                "modality": "image",
+                "content_type": "image/tiff",
+                "text_content": None,
+                "binary_content": None,
+                "source_ref": InterleavedBatch.build_source_ref(
+                    path=tar_path,
+                    member="doc.tiff",
+                    frame_index=i,
+                ),
+                "materialize_error": None,
+            }
+        )
     task = InterleavedBatch(
-        task_id="tiff_mat", dataset_name="d",
+        task_id="tiff_mat",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     result = materialize_task_binary_content(task)
@@ -904,17 +1018,50 @@ def test_filter_drop_invalid_rows_true() -> None:
             return pd.Series(True, index=df.index, dtype=bool)
 
     rows = [
-        {"sample_id": "s1", "position": -1, "modality": "metadata", "content_type": "application/json",
-         "text_content": None, "binary_content": None, "source_ref": None, "materialize_error": None},
-        {"sample_id": "s1", "position": 0, "modality": "text", "content_type": "text/plain",
-         "text_content": "ok", "binary_content": None, "source_ref": None, "materialize_error": None},
-        {"sample_id": "s1", "position": 1, "modality": "video", "content_type": "video/mp4",
-         "text_content": None, "binary_content": None, "source_ref": None, "materialize_error": None},
-        {"sample_id": "s1", "position": -1, "modality": "text", "content_type": "text/plain",
-         "text_content": "bad", "binary_content": None, "source_ref": None, "materialize_error": None},
+        {
+            "sample_id": "s1",
+            "position": -1,
+            "modality": "metadata",
+            "content_type": "application/json",
+            "text_content": None,
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
+        {
+            "sample_id": "s1",
+            "position": 0,
+            "modality": "text",
+            "content_type": "text/plain",
+            "text_content": "ok",
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
+        {
+            "sample_id": "s1",
+            "position": 1,
+            "modality": "video",
+            "content_type": "video/mp4",
+            "text_content": None,
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
+        {
+            "sample_id": "s1",
+            "position": -1,
+            "modality": "text",
+            "content_type": "text/plain",
+            "text_content": "bad",
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
     ]
     task = InterleavedBatch(
-        task_id="drop_test", dataset_name="d",
+        task_id="drop_test",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     stage = _KeepAllContent(drop_invalid_rows=True)
@@ -926,11 +1073,20 @@ def test_filter_drop_invalid_rows_true() -> None:
 def test_iter_materialized_bytes_empty_mask() -> None:
     """iter_materialized_bytes yields nothing when row_mask selects no rows."""
     rows = [
-        {"sample_id": "s1", "position": 0, "modality": "text", "content_type": "text/plain",
-         "text_content": "hello", "binary_content": None, "source_ref": None, "materialize_error": None},
+        {
+            "sample_id": "s1",
+            "position": 0,
+            "modality": "text",
+            "content_type": "text/plain",
+            "text_content": "hello",
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
     ]
     task = InterleavedBatch(
-        task_id="empty_mask", dataset_name="d",
+        task_id="empty_mask",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     df = task.to_pandas()
@@ -949,13 +1105,30 @@ def test_annotate_metadata_only_rows() -> None:
             return pd.Series(True, index=df.index, dtype=bool)
 
     rows = [
-        {"sample_id": "s1", "position": -1, "modality": "metadata", "content_type": "application/json",
-         "text_content": None, "binary_content": None, "source_ref": None, "materialize_error": None},
-        {"sample_id": "s2", "position": -1, "modality": "metadata", "content_type": "application/json",
-         "text_content": None, "binary_content": None, "source_ref": None, "materialize_error": None},
+        {
+            "sample_id": "s1",
+            "position": -1,
+            "modality": "metadata",
+            "content_type": "application/json",
+            "text_content": None,
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
+        {
+            "sample_id": "s2",
+            "position": -1,
+            "modality": "metadata",
+            "content_type": "application/json",
+            "text_content": None,
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
     ]
     task = InterleavedBatch(
-        task_id="meta_only", dataset_name="d",
+        task_id="meta_only",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     stage = _KeepAllContent(drop_invalid_rows=False)
@@ -966,13 +1139,30 @@ def test_annotate_metadata_only_rows() -> None:
 def test_aspect_ratio_filter_no_image_rows() -> None:
     """Filter is a no-op when there are no image rows."""
     rows = [
-        {"sample_id": "s1", "position": -1, "modality": "metadata", "content_type": "application/json",
-         "text_content": None, "binary_content": None, "source_ref": None, "materialize_error": None},
-        {"sample_id": "s1", "position": 0, "modality": "text", "content_type": "text/plain",
-         "text_content": "hello", "binary_content": None, "source_ref": None, "materialize_error": None},
+        {
+            "sample_id": "s1",
+            "position": -1,
+            "modality": "metadata",
+            "content_type": "application/json",
+            "text_content": None,
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
+        {
+            "sample_id": "s1",
+            "position": 0,
+            "modality": "text",
+            "content_type": "text/plain",
+            "text_content": "hello",
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
     ]
     task = InterleavedBatch(
-        task_id="no_img", dataset_name="d",
+        task_id="no_img",
+        dataset_name="d",
         data=pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA),
     )
     stage = InterleavedAspectRatioFilterStage(drop_invalid_rows=False)

--- a/tests/stages/interleaved/test_multimodal_reader.py
+++ b/tests/stages/interleaved/test_multimodal_reader.py
@@ -180,7 +180,9 @@ def test_reader_image_tokens_with_frame_index(tmp_path: Path) -> None:
     _write_tar_sample(tar_path, payload, json_name="sample.json", image_name="doc.pdf.tiff", image_bytes=b"TIFF_DATA")
     task = _task_for_tar(tar_path, "sub_image_test")
     reader = WebdatasetReaderStage(
-        source_id_field="pdf_name", sample_id_field="pdf_name", image_extensions=(".tiff",),
+        source_id_field="pdf_name",
+        sample_id_field="pdf_name",
+        image_extensions=(".tiff",),
     )
     df = _as_df(reader.process(task))
 
@@ -608,7 +610,9 @@ def test_reader_empty_tar(tmp_path: Path) -> None:
         img_info.size = 3
         tf.addfile(img_info, BytesIO(b"abc"))
     task = FileGroupTask(
-        task_id="empty", dataset_name="d", data=[str(tar_path)],
+        task_id="empty",
+        dataset_name="d",
+        data=[str(tar_path)],
         _metadata={"source_files": [str(tar_path)]},
     )
     reader = WebdatasetReaderStage(source_id_field="pdf_name")
@@ -627,7 +631,8 @@ def test_reader_multi_tar(tmp_path: Path) -> None:
             {f"{sample_id}.json": json.dumps(payload).encode(), f"{sample_id}.jpg": b"img"},
         )
     task = FileGroupTask(
-        task_id="multi", dataset_name="d",
+        task_id="multi",
+        dataset_name="d",
         data=[str(tmp_path / "shard1.tar"), str(tmp_path / "shard2.tar")],
         _metadata={"source_files": ["shard1.tar", "shard2.tar"]},
     )
@@ -650,7 +655,8 @@ def test_reader_max_batch_bytes_splits(tmp_path: Path) -> None:
             {f"{sample_id}.json": json.dumps(payload).encode()},
         )
     task = FileGroupTask(
-        task_id="split", dataset_name="d",
+        task_id="split",
+        dataset_name="d",
         data=[str(tmp_path / "doc1.tar"), str(tmp_path / "doc2.tar")],
         _metadata={"source_files": ["doc1.tar", "doc2.tar"]},
     )
@@ -698,7 +704,10 @@ def test_reader_non_list_images_field(tmp_path: Path) -> None:
     ],
 )
 def test_resolve_image_content_key(
-    image_token: object, default_member: str | None, member_names: set[str], expected: str | None,
+    image_token: object,
+    default_member: str | None,
+    member_names: set[str],
+    expected: str | None,
 ) -> None:
     result = WebdatasetReaderStage._resolve_image_content_key(image_token, default_member, member_names)
     assert result == expected

--- a/tests/stages/interleaved/test_multimodal_writer.py
+++ b/tests/stages/interleaved/test_multimodal_writer.py
@@ -123,7 +123,9 @@ def test_writer_does_not_persist_dataframe_index(tmp_path: Path) -> None:
     )
     df.index = pd.Index([99])
     task = InterleavedBatch(task_id="idx_task", dataset_name="mint_test", data=df)
-    writer = InterleavedParquetWriterStage(path=str(tmp_path / "out_idx"), materialize_on_write=False, mode="overwrite")
+    writer = InterleavedParquetWriterStage(
+        path=str(tmp_path / "out_idx"), materialize_on_write=False, mode="overwrite"
+    )
     write_task = writer.process(task)
     written = pd.read_parquet(write_task.data[0])
     assert "__index_level_0__" not in written.columns
@@ -144,16 +146,27 @@ def test_interleaved_ordering_preserved_through_filter_and_write(tmp_path: Path)
 
     def _row(sample_id: str, position: int, modality: str, text: str | None = None) -> dict:
         return {
-            "sample_id": sample_id, "position": position, "modality": modality,
+            "sample_id": sample_id,
+            "position": position,
+            "modality": modality,
             "content_type": "text/plain" if modality == "text" else "image/png",
-            "text_content": text, "binary_content": None, "source_ref": None,
+            "text_content": text,
+            "binary_content": None,
+            "source_ref": None,
             "materialize_error": None,
         }
 
     rows = [
-        {"sample_id": "s1", "position": -1, "modality": "metadata", "content_type": "application/json",
-         "text_content": None, "binary_content": None, "source_ref": None,
-         "materialize_error": None},
+        {
+            "sample_id": "s1",
+            "position": -1,
+            "modality": "metadata",
+            "content_type": "application/json",
+            "text_content": None,
+            "binary_content": None,
+            "source_ref": None,
+            "materialize_error": None,
+        },
         _row("s1", 0, "text", "intro"),
         _row("s1", 1, "image"),
         _row("s1", 2, "text", "middle"),
@@ -258,7 +271,9 @@ def test_heterogeneous_passthrough_fields_combine_as_nullable(tmp_path: Path) ->
 
     out_dir = tmp_path / "combined_out"
     writer = InterleavedParquetWriterStage(
-        path=str(out_dir), materialize_on_write=False, mode="overwrite",
+        path=str(out_dir),
+        materialize_on_write=False,
+        mode="overwrite",
     )
     writer.process(batch_a)
     writer.process(batch_b)
@@ -296,15 +311,26 @@ def test_heterogeneous_passthrough_fields_combine_as_nullable(tmp_path: Path) ->
 
 def test_writer_uses_uuid_when_no_source_files(tmp_path: Path) -> None:
     """Writer falls back to UUID filename when task has no source_files metadata."""
-    df = pd.DataFrame([{
-        "sample_id": "s1", "position": 0, "modality": "text",
-        "content_type": "text/plain", "text_content": "hello",
-        "binary_content": None, "source_ref": None, "materialize_error": None,
-    }])
+    df = pd.DataFrame(
+        [
+            {
+                "sample_id": "s1",
+                "position": 0,
+                "modality": "text",
+                "content_type": "text/plain",
+                "text_content": "hello",
+                "binary_content": None,
+                "source_ref": None,
+                "materialize_error": None,
+            }
+        ]
+    )
     task = InterleavedBatch(task_id="no_source", dataset_name="test", data=df, _metadata={})
     out_dir = tmp_path / "uuid_out"
     writer = InterleavedParquetWriterStage(
-        path=str(out_dir), materialize_on_write=False, mode="overwrite",
+        path=str(out_dir),
+        materialize_on_write=False,
+        mode="overwrite",
     )
     write_task = writer.process(task)
     assert len(write_task.data) == 1
@@ -313,19 +339,31 @@ def test_writer_uses_uuid_when_no_source_files(tmp_path: Path) -> None:
 
 def test_writer_no_materialize_preserves_null_binary(tmp_path: Path) -> None:
     """materialize_on_write=False leaves binary_content null even for image rows."""
-    table = pa.Table.from_pylist([{
-        "sample_id": "s1", "position": 0, "modality": "image",
-        "content_type": "image/jpeg", "text_content": None,
-        "binary_content": None,
-        "source_ref": InterleavedBatch.build_source_ref(path="/fake/img.jpg", member=None),
-        "materialize_error": None,
-    }], schema=INTERLEAVED_SCHEMA)
+    table = pa.Table.from_pylist(
+        [
+            {
+                "sample_id": "s1",
+                "position": 0,
+                "modality": "image",
+                "content_type": "image/jpeg",
+                "text_content": None,
+                "binary_content": None,
+                "source_ref": InterleavedBatch.build_source_ref(path="/fake/img.jpg", member=None),
+                "materialize_error": None,
+            }
+        ],
+        schema=INTERLEAVED_SCHEMA,
+    )
     task = InterleavedBatch(
-        task_id="no_mat", dataset_name="test", data=table,
+        task_id="no_mat",
+        dataset_name="test",
+        data=table,
         _metadata={"source_files": ["/fake/img.jpg"]},
     )
     writer = InterleavedParquetWriterStage(
-        path=str(tmp_path / "no_mat_out"), materialize_on_write=False, mode="overwrite",
+        path=str(tmp_path / "no_mat_out"),
+        materialize_on_write=False,
+        mode="overwrite",
     )
     write_task = writer.process(task)
     written = pd.read_parquet(write_task.data[0])
@@ -338,18 +376,30 @@ def test_writer_no_materialize_preserves_null_binary(tmp_path: Path) -> None:
 )
 def test_writer_custom_compression(tmp_path: Path, compression: str) -> None:
     """Custom compression in write_kwargs is used in the written parquet."""
-    df = pd.DataFrame([{
-        "sample_id": "s1", "position": 0, "modality": "text",
-        "content_type": "text/plain", "text_content": "hello",
-        "binary_content": None, "source_ref": None, "materialize_error": None,
-    }])
+    df = pd.DataFrame(
+        [
+            {
+                "sample_id": "s1",
+                "position": 0,
+                "modality": "text",
+                "content_type": "text/plain",
+                "text_content": "hello",
+                "binary_content": None,
+                "source_ref": None,
+                "materialize_error": None,
+            }
+        ]
+    )
     task = InterleavedBatch(
-        task_id="comp", dataset_name="test", data=df,
+        task_id="comp",
+        dataset_name="test",
+        data=df,
         _metadata={"source_files": ["test.tar"]},
     )
     writer = InterleavedParquetWriterStage(
         path=str(tmp_path / f"{compression}_out"),
-        materialize_on_write=False, mode="overwrite",
+        materialize_on_write=False,
+        mode="overwrite",
         write_kwargs={"compression": compression},
     )
     write_task = writer.process(task)

--- a/tutorials/multimodal/mint1t_mvp_pipeline.py
+++ b/tutorials/multimodal/mint1t_mvp_pipeline.py
@@ -44,7 +44,9 @@ def build_pipeline(args: argparse.Namespace) -> Pipeline:
             per_text_fields=tuple(args.per_text_fields) if args.per_text_fields else (),
         )
     )
-    pipe.add_stage(InterleavedAspectRatioFilterStage(min_aspect_ratio=1.0, max_aspect_ratio=2.0, drop_invalid_rows=True))
+    pipe.add_stage(
+        InterleavedAspectRatioFilterStage(min_aspect_ratio=1.0, max_aspect_ratio=2.0, drop_invalid_rows=True)
+    )
     pipe.add_stage(
         InterleavedParquetWriterStage(
             path=args.output_path,


### PR DESCRIPTION
## Summary

- Apply `ruff format` auto-fixes from pre-commit hooks to 9 files introduced/modified in #1517
- No logic changes — purely formatting (line wrapping, trailing commas, string quoting)

## Files changed

- `benchmarking/scripts/multimodal_mint1t_benchmark.py`
- `nemo_curator/stages/interleaved/io/readers/webdataset.py`
- `nemo_curator/tasks/interleaved.py`
- `tests/stages/interleaved/test_interleaved_task.py`
- `tests/stages/interleaved/test_materialization.py`
- `tests/stages/interleaved/test_multimodal_core.py`
- `tests/stages/interleaved/test_multimodal_reader.py`
- `tests/stages/interleaved/test_multimodal_writer.py`
- `tutorials/multimodal/mint1t_mvp_pipeline.py`

## Test plan

- [x] All pre-commit hooks pass (`ruff`, `ruff format`, trailing whitespace, etc.)
- [ ] CI passes (no logic changes, formatting only)


Made with [Cursor](https://cursor.com)