### PR TITLE
[benchmarking] increases hard timeout for fuzzy_dedup_id, add max runtime requirement to catch regressions

### DIFF
--- a/benchmarking/nightly-benchmark.yaml
+++ b/benchmarking/nightly-benchmark.yaml
@@ -242,7 +242,7 @@ entries:
       --bands-per-iteration=20
       --text-field=text
       --input-blocksize=1.5GiB
-    timeout_s: 700
+    timeout_s: 800
     sink_data:
       - name: slack
         additional_metrics:
@@ -259,7 +259,8 @@ entries:
         # 59,226,133 is expected, ensure +/- 1%
         min_value: 58633871
         max_value: 59818394
-
+      - metric: exec_time_s
+        max_value: 750  # benchmark should finish in under 750s, 800s hard timeout to prevent hangs
   - name: semdedup_identification_xenna
     enabled: true
     script: semdedup_identification_benchmark.py


### PR DESCRIPTION
* Increases hard timeout for fuzzy_dedup_identification to 800s
* Adds max runtime requirement of 750s to catch regressions

This approach should allow us to see if we exceed a max runtime while still allowing the process to complete (in 800s or less) to allow for possible additional debugging. 
