### PR TITLE
docs: add citation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ Data curation modules measurably improve model performance. In ablation studies 
 
 ---
 
+## Citation
+
+If you find NeMo Curator useful in your work, please cite:
+
+> Jennings, Joseph, et al. "NeMo-Curator: a toolkit for data curation."
+
+For the full author list and citation metadata, see [CITATION.cff](CITATION.cff).
+
+---
+
 ## Contribute
 
 We welcome community contributions! Please refer to [CONTRIBUTING.md](https://github.com/NVIDIA/NeMo/blob/stable/CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
## Summary
- add a citation section near the bottom of the README
- surface the existing citation metadata in CITATION.cff
- make the software citation easier to find from the main repo landing page

Fixes #1551.

## Verification
- ran git diff --check
- README-only change; no code or test files changed