### PR TITLE
[benchmarking] Update ndd_ray_serve timeout

### DIFF
--- a/benchmarking/nightly-benchmark.yaml
+++ b/benchmarking/nightly-benchmark.yaml
@@ -776,7 +776,7 @@ entries:
       --executor=ray_data
       --engine-kwargs='{"tensor_parallel_size": 1}'
       --autoscaling-config='{"min_replicas": 4, "max_replicas": 4}'
-    timeout_s: 3600
+    timeout_s: 700
     ray:
       num_cpus: 16
       num_gpus: 4


### PR DESCRIPTION
## Description
If Ray Serve is unable to load models into memory it gets stuck forever (see https://github.com/NVIDIA-NeMo/Curator/issues/1620)

However when there is memory available it should only run for ~600s

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
