### PR TITLE
Inital codeowners setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,12 +11,18 @@ tests/stages/deduplication/ @ayushdg @praateekmahajan
 # Documentation
 docs/ @NVIDIA-NeMo/docs_team
 
-# CI/CD
+# CI/CD and Build Configuration
 .github/ @NVIDIA-NeMo/automation
+codecov.yml @NVIDIA-NeMo/automation
+docker/ @NVIDIA-NeMo/automation
+pyproject.toml @NVIDIA-NeMo/automation
+uv.lock @NVIDIA-NeMo/automation
 
 # Text Embedders and Classifiers
 nemo_curator/stages/text/embedders/ @sarahyurick @praateekmahajan @VibhuJawa
+tests/stages/text/embedders/ @sarahyurick @praateekmahajan @VibhuJawa
 nemo_curator/stages/text/classifiers/ @sarahyurick @praateekmahajan @VibhuJawa
+tests/stages/text/classifiers/ @sarahyurick @praateekmahajan @VibhuJawa
 
 # Backends
 nemo_curator/backends/ @oyilmaz-nvidia @praateekmahajan @abhinavg4 @ayushdg


### PR DESCRIPTION
## Description
This PR sets up a couple of things:

1. Ping 1 person from the `curator_reviewers` team (automatically through load balancing) for PR reviews.
2. Additionally set up codeowners for specific parts of the codebase that "Must" require an approval from a code owner as well to merge the PR. 

## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [N/A] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
