### PR TITLE
docs: document InferenceServer for Ray Serve support (PR #1541)

### DIFF
--- a/fern/versions/v26.04.yml
+++ b/fern/versions/v26.04.yml
@@ -249,6 +249,9 @@ navigation:
               - page: LLM Client Setup
                 path: ./v26.04/pages/curate-text/synthetic/llm-client.mdx
                 slug: llm-client
+              - page: Inference Server
+                path: ./v26.04/pages/curate-text/synthetic/inference-server.mdx
+                slug: inference-server
               - page: Multilingual Q&A
                 path: ./v26.04/pages/curate-text/synthetic/multilingual-qa.mdx
                 slug: multilingual-qa

--- a/fern/versions/v26.04/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.04/pages/about/release-notes/index.mdx
@@ -12,6 +12,18 @@ modality: "universal"
 
 ## What's New in 26.04
 
+### Inference Server (Ray Serve)
+
+Built-in LLM serving alongside curation pipelines using Ray Serve and vLLM:
+
+- **`InferenceServer` and `InferenceModelConfig`**: New APIs to deploy one or more LLMs as OpenAI-compatible endpoints directly within a Ray cluster, eliminating the need for separate inference infrastructure.
+- **Context manager support**: `InferenceServer` works as a context manager for automatic startup and cleanup of served models.
+- **GPU contention detection**: `Pipeline.run()` automatically detects when an InferenceServer is active and enforces `RayDataExecutor` usage for GPU pipeline stages to prevent resource conflicts.
+- **`GenerationConfig.extra_kwargs`**: New field for passing arbitrary parameters through to the OpenAI API `create()` call.
+- **New install extras**: `inference_server` (Ray Serve + vLLM dependencies) and `sdg_cuda12` (SDG with local inference support).
+
+Learn more in the [Inference Server](/curate-text/synthetic/inference-server) documentation.
+
 ### vLLM Default for Semantic Deduplication Embeddings
 
 The default embedding backend for `TextSemanticDeduplicationWorkflow` switched from SentenceTransformers to vLLM:

--- a/fern/versions/v26.04/pages/admin/installation.mdx
+++ b/fern/versions/v26.04/pages/admin/installation.mdx
@@ -186,6 +186,9 @@ NeMo Curator provides several installation extras to install only the components
 | **image_cuda12** | `uv pip install nemo-curator[image_cuda12]` | GPU-accelerated image processing with NVIDIA DALI |
 | **video_cpu** | `uv pip install nemo-curator[video_cpu]` | CPU-only video processing |
 | **video_cuda12** | `uv pip install --no-build-isolation nemo-curator[video_cuda12]` | GPU-accelerated video processing with CUDA libraries. Requires FFmpeg and additional build dependencies when using `uv`. |
+| **inference_server** | `uv pip install nemo-curator[inference_server]` | Ray Serve + vLLM for serving LLMs alongside curation pipelines |
+| **sdg_cpu** | `uv pip install nemo-curator[sdg_cpu]` | CPU-only synthetic data generation with Data Designer |
+| **sdg_cuda12** | `uv pip install nemo-curator[sdg_cuda12]` | GPU-accelerated synthetic data generation with local inference server support |
 
 <Note>
 **Development Dependencies**: For development tools (pre-commit, ruff, pytest), use `uv sync --group dev --group linting --group test` instead of pip extras. Development dependencies are managed as dependency groups, not optional dependencies.

--- a/fern/versions/v26.04/pages/curate-text/synthetic/index.mdx
+++ b/fern/versions/v26.04/pages/curate-text/synthetic/index.mdx
@@ -10,7 +10,7 @@ modality: "text-only"
 
 # Synthetic Data Generation
 
-NeMo Curator provides synthetic data generation (SDG) capabilities for creating and augmenting training data using Large Language Models (LLMs). These pipelines integrate with OpenAI-compatible APIs, enabling you to use NVIDIA NIM endpoints, local vLLM servers, or other inference providers.
+NeMo Curator provides synthetic data generation (SDG) capabilities for creating and augmenting training data using Large Language Models (LLMs). These pipelines integrate with OpenAI-compatible APIs, enabling you to use NVIDIA NIM endpoints, NeMo Curator's built-in [Inference Server](/curate-text/synthetic/inference-server) (Ray Serve + vLLM), or other inference providers.
 
 ## Use Cases
 
@@ -48,7 +48,7 @@ flowchart LR
     C --> D["Postprocessing<br/>(Cleanup, Filtering)"]
     D --> E["Output Dataset<br/>(Parquet/JSONL)"]
     
-    F["LLM Client<br/>(NVIDIA API,<br/>vLLM, TGI)"] -.->|"API Calls"| C
+    F["LLM Client<br/>(NVIDIA API,<br/>InferenceServer,<br/>vLLM, TGI)"] -.->|"API Calls"| C
     
     classDef stage fill:#e3f2fd,stroke:#1976d2,stroke-width:2px,color:#000
     classDef infra fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px,color:#000
@@ -73,9 +73,17 @@ Before using synthetic data generation, ensure you have:
    uv pip install --extra-index-url https://pypi.nvidia.com nemo-curator[text_cuda12]
    ```
 
-   <Note>
-   Nemotron-CC pipelines use the `transformers` library for tokenization, which is included in NeMo Curator's core dependencies.
-   </Note>
+3. **Local inference** (optional) — to serve models alongside your pipeline:
+
+   ```bash
+   uv pip install nemo-curator[inference_server]
+   ```
+
+   Refer to the [Inference Server](/curate-text/synthetic/inference-server) guide for setup details.
+
+<Note>
+Nemotron-CC pipelines use the `transformers` library for tokenization, which is included in NeMo Curator core dependencies.
+</Note>
 
 ## Available SDG Stages
 
@@ -98,6 +106,12 @@ Before using synthetic data generation, ensure you have:
 Configure OpenAI-compatible clients for NVIDIA APIs and custom endpoints
 configuration
 performance
+</Card>
+
+<Card title="Inference Server" href="/curate-text/synthetic/inference-server">
+Serve LLMs locally via Ray Serve and vLLM alongside curation pipelines
+ray-serve
+local-inference
 </Card>
 
 <Card title="Multilingual Q&A Generation" href="/curate-text/synthetic/multilingual-qa">

--- a/fern/versions/v26.04/pages/curate-text/synthetic/inference-server.mdx
+++ b/fern/versions/v26.04/pages/curate-text/synthetic/inference-server.mdx
@@ -1,0 +1,197 @@
+---
+description: "Serve LLMs locally via Ray Serve and vLLM alongside NeMo Curator pipelines using InferenceServer"
+categories: ["how-to-guides"]
+tags: ["inference-server", "ray-serve", "vllm", "llm", "serving", "local-inference"]
+personas: ["data-scientist-focused", "mle-focused"]
+difficulty: "intermediate"
+content_type: "how-to"
+modality: "text-only"
+---
+
+# Inference Server
+
+NeMo Curator can serve LLMs locally using Ray Serve and vLLM, providing an OpenAI-compatible endpoint without external inference infrastructure. This is useful for synthetic data generation workflows where you co-locate model serving with your curation pipeline on the same GPU cluster.
+
+## Prerequisites
+
+Install the inference server dependencies:
+
+```bash
+uv pip install nemo-curator[inference_server]
+```
+
+This installs Ray Serve, vLLM, and supporting libraries. You need an NVIDIA GPU with sufficient VRAM for the model you intend to serve.
+
+## Quick Start
+
+```python
+from openai import OpenAI
+from nemo_curator.core.client import RayClient
+from nemo_curator.core.serve import InferenceModelConfig, InferenceServer
+
+# 1. Start Ray cluster
+client = RayClient()
+client.start()
+
+# 2. Configure and serve a model
+config = InferenceModelConfig(
+    model_identifier="google/gemma-3-27b-it",
+    engine_kwargs={"tensor_parallel_size": 4},
+    deployment_config={
+        "autoscaling_config": {
+            "min_replicas": 1,
+            "max_replicas": 1,
+        },
+    },
+)
+
+with InferenceServer(models=[config]) as server:
+    # 3. Query via OpenAI SDK
+    oai = OpenAI(base_url=server.endpoint, api_key="unused")
+    response = oai.chat.completions.create(
+        model="google/gemma-3-27b-it",
+        messages=[{"role": "user", "content": "Hello!"}],
+    )
+    print(response.choices[0].message.content)
+```
+
+The `InferenceServer` deploys models onto the Ray cluster and exposes an OpenAI-compatible API at `http://localhost:<port>/v1`. When used as a context manager, it automatically starts and stops the server.
+
+## InferenceModelConfig
+
+Each model you want to serve is described by an `InferenceModelConfig`:
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `model_identifier` | str | Required | HuggingFace model ID or local path |
+| `model_name` | str | None | API-facing model name clients use in requests. Defaults to `model_identifier` |
+| `deployment_config` | dict | `{}` | Ray Serve deployment configuration (autoscaling, replicas) |
+| `engine_kwargs` | dict | `{}` | vLLM engine keyword arguments (`tensor_parallel_size`, etc.) |
+| `runtime_env` | dict | `{}` | Ray runtime environment (pip packages, env vars, working directory) |
+
+### Common Engine Arguments
+
+```python
+config = InferenceModelConfig(
+    model_identifier="meta-llama/Llama-3-8B-Instruct",
+    engine_kwargs={
+        "tensor_parallel_size": 2,  # Split model across 2 GPUs
+    },
+)
+```
+
+### Autoscaling
+
+Use `deployment_config` to control replica count and autoscaling:
+
+```python
+config = InferenceModelConfig(
+    model_identifier="meta-llama/Llama-3-8B-Instruct",
+    deployment_config={
+        "autoscaling_config": {
+            "min_replicas": 1,
+            "max_replicas": 4,
+        },
+    },
+)
+```
+
+## InferenceServer
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `models` | list[InferenceModelConfig] | Required | Models to deploy |
+| `name` | str | `"default"` | Ray Serve application name |
+| `port` | int | 8000 | HTTP port for the OpenAI-compatible endpoint |
+| `health_check_timeout_s` | int | 300 | Seconds to wait for models to become healthy |
+| `verbose` | bool | False | If True, keep Ray Serve and vLLM logging at default levels |
+
+### Start and Stop
+
+You can use `InferenceServer` as a context manager or call `start()` and `stop()` manually:
+
+```python
+# Context manager (recommended)
+with InferenceServer(models=[config]) as server:
+    # server.endpoint is available here
+    pass  # Server stops automatically
+
+# Manual lifecycle
+server = InferenceServer(models=[config])
+server.start()
+# ... use server.endpoint ...
+server.stop()
+```
+
+### Multi-Model Serving
+
+Deploy multiple models in a single server. Clients select a model by name in the API request:
+
+```python
+models = [
+    InferenceModelConfig(
+        model_identifier="meta-llama/Llama-3-8B-Instruct",
+        model_name="llama-8b",
+        engine_kwargs={"tensor_parallel_size": 1},
+    ),
+    InferenceModelConfig(
+        model_identifier="google/gemma-3-27b-it",
+        model_name="gemma-27b",
+        engine_kwargs={"tensor_parallel_size": 4},
+    ),
+]
+
+with InferenceServer(models=models) as server:
+    oai = OpenAI(base_url=server.endpoint, api_key="unused")
+    # Select model by name
+    response = oai.chat.completions.create(
+        model="llama-8b",
+        messages=[{"role": "user", "content": "Hello!"}],
+    )
+```
+
+The `/v1/models` endpoint lists all available models.
+
+## Use with NeMo Curator Pipelines
+
+### With AsyncOpenAIClient
+
+Point NeMo Curator's `AsyncOpenAIClient` at the inference server endpoint:
+
+```python
+from nemo_curator.models.client.openai_client import AsyncOpenAIClient
+from nemo_curator.core.serve import InferenceModelConfig, InferenceServer
+
+config = InferenceModelConfig(
+    model_identifier="meta-llama/Llama-3-8B-Instruct",
+    engine_kwargs={"tensor_parallel_size": 2},
+)
+
+with InferenceServer(models=[config]) as server:
+    client = AsyncOpenAIClient(
+        base_url=server.endpoint,
+        api_key="unused",
+        max_concurrent_requests=10,
+    )
+    # Use client in SDG pipeline stages
+```
+
+### GPU Contention
+
+When an `InferenceServer` is active, `Pipeline.run()` automatically detects potential GPU contention:
+
+- **RayDataExecutor**: Allowed. Ray's resource scheduler coordinates GPU allocation between served models and pipeline stages.
+- **XennaExecutor**: Raises `RuntimeError` if the pipeline has GPU stages. Xenna manages GPU assignment independently and would conflict with served models.
+
+If your pipeline has only CPU stages, either executor works.
+
+## Logging
+
+By default (`verbose=False`), `InferenceServer` suppresses per-request logs from vLLM and Ray Serve access logs to reduce noise. Ray Serve logs still go to files under the Ray session log directory. Set `verbose=True` to restore full logging output for debugging.
+
+---
+
+## Next Steps
+
+- [LLM Client Setup](/curate-text/synthetic/llm-client): Configure client parameters and generation settings
+- [Synthetic Data Generation](/curate-text/synthetic): Overview of SDG capabilities

--- a/fern/versions/v26.04/pages/curate-text/synthetic/llm-client.mdx
+++ b/fern/versions/v26.04/pages/curate-text/synthetic/llm-client.mdx
@@ -79,6 +79,7 @@ config = GenerationConfig(
 | `stop` | str/list | None | Stop sequences to end generation |
 | `stream` | bool | False | Enable streaming (not recommended for batch processing) |
 | `n` | int | 1 | Number of completions to generate per request |
+| `extra_kwargs` | dict | None | Additional keyword arguments passed through to the OpenAI `create()` call |
 
 ## Performance Tuning
 
@@ -133,6 +134,28 @@ client = AsyncOpenAIClient(
     api_key="your-api-key",
     max_concurrent_requests=5,
 )
+```
+
+### Local Inference with InferenceServer
+
+To serve models locally and connect them to `AsyncOpenAIClient`, use NeMo Curator's built-in [Inference Server](/curate-text/synthetic/inference-server) (Ray Serve + vLLM):
+
+```python
+from nemo_curator.core.serve import InferenceModelConfig, InferenceServer
+from nemo_curator.models.client.openai_client import AsyncOpenAIClient
+
+config = InferenceModelConfig(
+    model_identifier="meta-llama/Llama-3-8B-Instruct",
+    engine_kwargs={"tensor_parallel_size": 2},
+)
+
+with InferenceServer(models=[config]) as server:
+    client = AsyncOpenAIClient(
+        base_url=server.endpoint,
+        api_key="unused",
+        max_concurrent_requests=10,
+    )
+    # Use client in pipeline stages
 ```
 
 ## Complete Example


### PR DESCRIPTION
## Description

Documents the `InferenceServer` and `InferenceModelConfig` APIs introduced in #1541 for the v26.04 fern docs. Adds a new how-to page for serving LLMs locally via Ray Serve + vLLM alongside curation pipelines. Updates the LLM client guide with `extra_kwargs` and a local inference example, adds `inference_server`/`sdg_cpu`/`sdg_cuda12` install extras to the installation guide, updates the SDG overview with InferenceServer references, and replaces the 26.02 release notes with a 26.04 skeleton containing the Inference Server entry.

## Usage
```python
from nemo_curator.core.serve import InferenceModelConfig, InferenceServer

config = InferenceModelConfig(
    model_identifier="google/gemma-3-27b-it",
    engine_kwargs={"tensor_parallel_size": 4},
    deployment_config={
        "autoscaling_config": {"min_replicas": 1, "max_replicas": 1},
    },
)

with InferenceServer(models=[config]) as server:
    print(server.endpoint)  # http://localhost:8000/v1
```

## Checklist
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.