### PR TITLE
Init resumability

### DIFF
--- a/nemo_curator/backends/base.py
+++ b/nemo_curator/backends/base.py
@@ -17,6 +17,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from loguru import logger
+
 from nemo_curator.tasks import Task
 from nemo_curator.utils.performance_utils import StageTimer
 
@@ -57,6 +59,31 @@ class BaseExecutor(ABC):
     @abstractmethod
     def execute(self, stages: list["ProcessingStage"], initial_tasks: list[Task] | None = None) -> None:
         """Execute the pipeline."""
+
+    def _mark_pipeline_checkpoint(self, stages: list["ProcessingStage"]) -> None:
+        """Mark the last ResumableStage as the pipeline checkpoint.
+
+        This stage writes completion records to ``{checkpoint_dir}/pipeline_complete/``,
+        which input stages (FilePartitioningStage) read to skip already-completed inputs.
+        Must be called before any stage is serialized to workers.
+        """
+        from nemo_curator.stages.resumable import ResumableStage
+
+        last_resumable = None
+        for stage in stages:
+            if (
+                isinstance(stage, ResumableStage)
+                and getattr(stage, "resume", False)
+                and getattr(stage, "checkpoint_dir", None)
+            ):
+                last_resumable = stage
+
+        if last_resumable is not None:
+            last_resumable._is_pipeline_checkpoint = True
+            logger.info(
+                f"Pipeline checkpoint: '{last_resumable.name}' will write to "
+                f"{last_resumable.checkpoint_dir}/pipeline_complete/"
+            )
 
 
 class BaseStageAdapter:

--- a/nemo_curator/backends/experimental/ray_actor_pool/executor.py
+++ b/nemo_curator/backends/experimental/ray_actor_pool/executor.py
@@ -92,6 +92,8 @@ class RayActorPoolExecutor(BaseExecutor):
         if not stages:
             return []
 
+        self._mark_pipeline_checkpoint(stages)
+
         session_id = uuid.uuid4().bytes
 
         try:
@@ -156,7 +158,7 @@ class RayActorPoolExecutor(BaseExecutor):
             raise
         else:
             # Return final results directly - no need for ray.get()
-            final_results = current_tasks if current_tasks else []
+            final_results = current_tasks or []
             logger.info(f"\nPipeline completed. Final results: {len(final_results)} tasks")
 
             return final_results

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -55,11 +55,13 @@ class RayDataExecutor(BaseExecutor):
         if not stages:
             return []
 
+        self._mark_pipeline_checkpoint(stages)
+
         register_loguru_serializer()
         # This prevents verbose logging from Ray Data about serialization of the dataclass
         DataContext.get_current().enable_fallback_to_arrow_object_ext_type = True
         # Initialize with initial tasks if provided, otherwise start with EmptyTask
-        tasks: list[Task] = initial_tasks if initial_tasks else [EmptyTask]
+        tasks: list[Task] = initial_tasks or [EmptyTask]
         output_tasks: list[Task] = []
         try:
             # Initialize ray and explicitly set NOSET to empty

--- a/nemo_curator/backends/xenna/executor.py
+++ b/nemo_curator/backends/xenna/executor.py
@@ -43,6 +43,9 @@ class XennaExecutor(BaseExecutor):
                 - execution_mode: 'streaming' or 'batch' (default: 'streaming')
                 - cpu_allocation_percentage: CPU allocation ratio (default: 0.95)
                 - autoscale_interval_s: Auto-scaling interval (default: 180)
+                - return_last_stage_outputs: Collect and return last stage outputs to the driver (default: True).
+                  Set to False for write-and-forget pipelines to avoid output reference count validation errors
+                  when some tasks fail mid-pipeline (e.g. due to OOM or disk spilling).
             ignore_head_node (bool, optional): Whether to ignore the head node (default: False)
                 Not supported by XennaExecutor. Raises an error if set to True.
         """
@@ -57,6 +60,7 @@ class XennaExecutor(BaseExecutor):
             "execution_mode": "streaming",
             "cpu_allocation_percentage": 0.95,
             "autoscale_interval_s": 180,
+            "return_last_stage_outputs": True,
         }
 
     def execute(self, stages: list[ProcessingStage], initial_tasks: list[Task] | None = None) -> list[Task]:
@@ -122,7 +126,7 @@ class XennaExecutor(BaseExecutor):
             execution_mode=exec_mode,
             logging_interval_s=self._get_pipeline_config("logging_interval"),
             log_worker_allocation_layout=True,
-            return_last_stage_outputs=True,
+            return_last_stage_outputs=self._get_pipeline_config("return_last_stage_outputs"),
             ignore_failures=self._get_pipeline_config("ignore_failures"),
             cpu_allocation_percentage=self._get_pipeline_config("cpu_allocation_percentage"),
             mode_specific=streaming_config,

--- a/nemo_curator/backends/xenna/executor.py
+++ b/nemo_curator/backends/xenna/executor.py
@@ -69,11 +69,13 @@ class XennaExecutor(BaseExecutor):
         Returns:
             list[Task]: List of output tasks from the pipeline
         """
+        self._mark_pipeline_checkpoint(stages)
+
         # Convert stages to Xenna stage specs
         stage_specs = []
 
         # Initialize with initial tasks if provided, otherwise start with EmptyTask
-        initial_tasks = initial_tasks if initial_tasks else [EmptyTask]
+        initial_tasks = initial_tasks or [EmptyTask]
 
         for stage in stages:
             # Get stage configuration
@@ -155,7 +157,7 @@ class XennaExecutor(BaseExecutor):
         finally:
             # This ensures we unset all the env vars set above during initialize and kill the pending actors.
             ray.shutdown()
-        return results if results else []
+        return results or []
 
     def _get_pipeline_config(self, key: str) -> Any:  # noqa: ANN401
         """Get configuration value with fallback to defaults."""

--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -174,6 +174,35 @@ class Pipeline:
 
         return "\n".join(lines)
 
+    def enable_resumability(self, checkpoint_dir: str) -> "Pipeline":
+        """Enable resumability on all applicable stages in the pipeline.
+
+        For input stages (FilePartitioningStage, ClientPartitioningStage): sets ``resume=True``
+        and ``checkpoint_dir`` so they read the completion manifest and skip already-finished
+        partitions on re-runs.
+
+        For writer stages (BaseWriter, InterleavedBaseWriter): sets ``resume=True`` and
+        ``checkpoint_dir`` so they write a completion record after each successful write.
+
+        The executor automatically marks the last writer as the pipeline checkpoint, routing
+        its completion records to ``{checkpoint_dir}/pipeline_complete/`` — the same directory
+        that input stages read from.
+
+        Args:
+            checkpoint_dir (str): Path (local or remote, e.g. ``s3://...``) to the directory
+                where completion records are stored.
+
+        Returns:
+            Pipeline: Self for method chaining.
+        """
+        from nemo_curator.stages.resumable import ResumableInputStage, ResumableStage
+
+        for stage in self.stages:
+            if isinstance(stage, (ResumableStage, ResumableInputStage)):
+                stage.resume = True
+                stage.checkpoint_dir = checkpoint_dir
+        return self
+
     def run(self, executor: BaseExecutor | None = None, initial_tasks: list[Task] | None = None) -> list[Task] | None:
         """Run the pipeline.
 

--- a/nemo_curator/stages/__init__.py
+++ b/nemo_curator/stages/__init__.py
@@ -1,0 +1,3 @@
+from nemo_curator.stages.resumable import ResumableInputStage, ResumableStage
+
+__all__ = ["ResumableInputStage", "ResumableStage"]

--- a/nemo_curator/stages/client_partitioning.py
+++ b/nemo_curator/stages/client_partitioning.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import fsspec
 from fsspec.core import url_to_fs
+from loguru import logger
 
 from nemo_curator.backends.base import WorkerMetadata
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
@@ -67,14 +68,26 @@ class ClientPartitioningStage(FilePartitioningStage):
         else:
             partitions = [[p] for p in rel_paths]
 
+        # Resumability: load completed task ids and skip them on resume
+        completed_ids: set[str] = set()
+        if self.resume and self.checkpoint_dir:
+            completed_ids = self.load_completed_task_ids()
+            if completed_ids:
+                logger.info(f"Resume: {len(completed_ids)} partitions already complete, will skip")
+
         # Create FileGroupTasks for each partition
         tasks = []
         total = len(partitions)
         dataset_name = self._get_dataset_name(self.file_paths)
+        skipped = 0
         for i, group in enumerate(partitions):
+            task_id = f"file_group_{i}"
+            if task_id in completed_ids:
+                skipped += 1
+                continue
             tasks.append(
                 FileGroupTask(
-                    task_id=f"file_group_{i}",
+                    task_id=task_id,
                     dataset_name=dataset_name,
                     data=group,
                     _metadata={
@@ -82,10 +95,14 @@ class ClientPartitioningStage(FilePartitioningStage):
                         "total_partitions": total,
                         "storage_options": self.storage_options,
                         "source_files": group,  # always a list for deterministic downstream naming
+                        "original_task_id": task_id,  # preserved through reader transforms (e.g. "_processed" suffix)
                     },
                     reader_config={},
                 )
             )
+
+        if skipped:
+            logger.info(f"Resume: skipped {skipped}, emitting {len(tasks)} partitions for processing")
 
         return tasks
 

--- a/nemo_curator/stages/file_partitioning.py
+++ b/nemo_curator/stages/file_partitioning.py
@@ -20,6 +20,7 @@ from loguru import logger
 from nemo_curator.backends.experimental.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
+from nemo_curator.stages.resumable import ResumableInputStage
 from nemo_curator.tasks import FileGroupTask, _EmptyTask
 from nemo_curator.utils.file_utils import (
     _split_files_as_per_blocksize,
@@ -30,7 +31,7 @@ from nemo_curator.utils.file_utils import (
 
 
 @dataclass
-class FilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
+class FilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask], ResumableInputStage):
     """Stage that partitions input file paths into FileGroupTasks.
 
     This stage runs as a dedicated processing stage (not on the driver)
@@ -61,6 +62,8 @@ class FilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
     storage_options: dict[str, Any] | None = None
     limit: int | None = None
     name: str = "file_partitioning"
+    resume: bool = False
+    checkpoint_dir: str | None = None
 
     def __post_init__(self):
         """Initialize default values."""
@@ -117,9 +120,17 @@ class FilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
             logger.info("No partitions specified, defaulting to one file per partition")
             partitions = self._partition_by_count(files, 1)
 
+        # Resumability: load completed task ids and skip them on resume
+        completed_ids: set[str] = set()
+        if self.resume and self.checkpoint_dir:
+            completed_ids = self.load_completed_task_ids()
+            if completed_ids:
+                logger.info(f"Resume: {len(completed_ids)} partitions already complete, will skip")
+
         # Create FileGroupTask for each partition
         tasks = []
         dataset_name = self._get_dataset_name(files)
+        skipped = 0
 
         for i, file_group in enumerate(partitions):
             if self.limit is not None and len(tasks) >= self.limit:
@@ -127,19 +138,26 @@ class FilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
                 # https://github.com/NVIDIA-NeMo/Curator/issues/948
                 logger.info(f"Reached limit of {self.limit} file groups")
                 break
+            task_id = f"file_group_{i}"
+            if task_id in completed_ids:
+                skipped += 1
+                continue
             file_task = FileGroupTask(
-                task_id=f"file_group_{i}",
+                task_id=task_id,
                 dataset_name=dataset_name,
                 data=file_group,
                 _metadata={
                     "partition_index": i,
                     "total_partitions": len(partitions),
                     "source_files": file_group,  # Add source files for deterministic naming during write stage
+                    "original_task_id": task_id,  # Preserved through reader transforms (e.g. "_processed" suffix)
                 },
                 reader_config={},  # Empty - will be populated by reader stage
             )
             tasks.append(file_task)
 
+        if skipped:
+            logger.info(f"Resume: skipped {skipped}, emitting {len(tasks)} partitions for processing")
         logger.info(f"Created {len(tasks)} file groups from {len(files)} files")
         return tasks
 

--- a/nemo_curator/stages/image/io/image_reader.py
+++ b/nemo_curator/stages/image/io/image_reader.py
@@ -135,13 +135,16 @@ class ImageReaderStage(ProcessingStage[FileGroupTask, ImageBatch]):
             if image_objects:
                 yield image_objects
 
-    def _stream_batches(self, tar_files: list[pathlib.Path]) -> Generator[ImageBatch, None, None]:
+    def _stream_batches(
+        self, tar_files: list[pathlib.Path], metadata: dict | None = None
+    ) -> Generator[ImageBatch, None, None]:
         """Emit one ImageBatch per DALI run across all provided tar files."""
         for batch_id, image_objects in enumerate(self._read_tars_with_dali(tar_files)):
             yield ImageBatch(
                 task_id=f"image_batch_{batch_id}",
                 dataset_name="tar_files",
                 data=image_objects,
+                _metadata=metadata or {},
             )
 
     def process(self, task: FileGroupTask) -> list[ImageBatch]:
@@ -153,4 +156,7 @@ class ImageReaderStage(ProcessingStage[FileGroupTask, ImageBatch]):
 
         tar_files = [pathlib.Path(p) for p in tar_file_paths]
 
-        return list(self._stream_batches(tar_files))
+        # Propagate original_task_id so downstream resumable writers (e.g. ImageWriterStage)
+        # can record completions under the same key that FilePartitioningStage checks.
+        metadata = {"original_task_id": task._metadata.get("original_task_id", task.task_id)}
+        return list(self._stream_batches(tar_files, metadata))

--- a/nemo_curator/stages/image/io/image_writer.py
+++ b/nemo_curator/stages/image/io/image_writer.py
@@ -26,12 +26,13 @@ import pyarrow.parquet as pq
 from loguru import logger
 
 from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.stages.resumable import ResumableStage
 from nemo_curator.tasks.file_group import FileGroupTask
 from nemo_curator.tasks.image import ImageBatch
 
 
 @dataclass
-class ImageWriterStage(ProcessingStage[ImageBatch, FileGroupTask]):
+class ImageWriterStage(ProcessingStage[ImageBatch, FileGroupTask], ResumableStage):
     """Write images to tar files and corresponding metadata to a Parquet file.
 
     - Images are packed into tar archives with at most ``images_per_tar`` entries each.
@@ -45,6 +46,8 @@ class ImageWriterStage(ProcessingStage[ImageBatch, FileGroupTask]):
     deterministic_name: bool = True
     remove_image_data: bool = False
     name: str = "image_writer"
+    resume: bool = False
+    checkpoint_dir: str | None = None
 
     def __post_init__(self) -> None:
         os.makedirs(self.output_dir, exist_ok=True)
@@ -201,7 +204,7 @@ class ImageWriterStage(ProcessingStage[ImageBatch, FileGroupTask]):
                 parquet_paths.append(parquet_path)
 
         # Return FileGroupTask with produced files
-        return FileGroupTask(
+        output_task = FileGroupTask(
             task_id=task.task_id,
             dataset_name=task.dataset_name,
             data=[*tar_paths, *parquet_paths],
@@ -213,3 +216,8 @@ class ImageWriterStage(ProcessingStage[ImageBatch, FileGroupTask]):
             },
             _stage_perf=task._stage_perf,
         )
+
+        if self.resume and self.checkpoint_dir:
+            self.record_completion(task, output_task)
+
+        return output_task

--- a/nemo_curator/stages/interleaved/io/writers/base.py
+++ b/nemo_curator/stages/interleaved/io/writers/base.py
@@ -25,6 +25,7 @@ from loguru import logger
 import nemo_curator.stages.text.io.writer.utils as writer_utils
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.interleaved.utils import materialize_task_binary_content
+from nemo_curator.stages.resumable import ResumableStage
 from nemo_curator.tasks import FileGroupTask, InterleavedBatch
 from nemo_curator.utils.client_utils import is_remote_url
 from nemo_curator.utils.file_utils import check_output_mode
@@ -34,7 +35,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class BaseInterleavedWriter(ProcessingStage[InterleavedBatch, FileGroupTask], ABC):
+class BaseInterleavedWriter(ProcessingStage[InterleavedBatch, FileGroupTask], ResumableStage, ABC):
     """Base class for interleaved writers.
 
     Handles filesystem setup, deterministic file naming, optional binary
@@ -49,6 +50,8 @@ class BaseInterleavedWriter(ProcessingStage[InterleavedBatch, FileGroupTask], AB
     name: str = "base_interleaved_writer"
     mode: Literal["ignore", "overwrite", "append", "error"] = "ignore"
     append_mode_implemented: bool = False
+    resume: bool = False
+    checkpoint_dir: str | None = None
 
     def __post_init__(self) -> None:
         self.storage_options = (self.write_kwargs or {}).get("storage_options", {})
@@ -106,10 +109,15 @@ class BaseInterleavedWriter(ProcessingStage[InterleavedBatch, FileGroupTask], AB
         file_path_with_protocol = self.fs.unstrip_protocol(file_path) if is_remote_url(self.path) else file_path
 
         self.write_data(task, file_path_with_protocol)
-        return FileGroupTask(
+        output_task = FileGroupTask(
             task_id=task.task_id,
             dataset_name=task.dataset_name,
             data=[file_path_with_protocol],
             _metadata={**task._metadata, "format": self.file_extension},
             _stage_perf=task._stage_perf,
         )
+
+        if self.resume and self.checkpoint_dir:
+            self.record_completion(task, output_task)
+
+        return output_task

--- a/nemo_curator/stages/resumable.py
+++ b/nemo_curator/stages/resumable.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from fsspec.core import url_to_fs
+from loguru import logger
+
+if TYPE_CHECKING:
+    from nemo_curator.tasks import Task
+
+
+def _is_json_serializable(value: object) -> bool:
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return False
+    else:
+        return True
+
+
+class ResumableStage:
+    """Mixin for stages that can record per-task completion to a checkpoint directory.
+
+    The last ResumableStage in the pipeline (marked _is_pipeline_checkpoint=True by the
+    executor) writes to {checkpoint_dir}/pipeline_complete/{task_id}.json.
+    All other ResumableStages write to {checkpoint_dir}/{stage_name}/{task_id}.json.
+
+    Concrete classes must expose ``checkpoint_dir`` and ``resume`` instance attributes
+    (typically as dataclass fields) and a ``name`` attribute (inherited from ProcessingStage).
+    """
+
+    # Defaults — concrete subclasses override via dataclass fields.
+    checkpoint_dir: str | None = None
+    resume: bool = False
+    # Set to True by the executor on the last ResumableStage before serializing to workers.
+    _is_pipeline_checkpoint: bool = False
+
+    @property
+    def _completed_dir(self) -> str:
+        base = self.checkpoint_dir.rstrip("/")  # type: ignore[union-attr]
+        if self._is_pipeline_checkpoint:
+            return f"{base}/pipeline_complete"
+        return f"{base}/{self.name}"  # type: ignore[attr-defined]
+
+    def record_completion(self, input_task: Task, output_task: Task) -> None:
+        """Write a JSON completion record to ``_completed_dir/{checkpoint_key}.json``.
+
+        Called from inside ``process()`` after the output is committed to storage.
+        Safe to call concurrently from multiple actors — each task gets its own file.
+
+        The checkpoint key is taken from ``input_task._metadata["original_task_id"]`` when
+        present (set by FilePartitioningStage before readers transform the task_id).
+        This ensures the filename matches what ResumableInputStage looks for on resume.
+        """
+        from nemo_curator.tasks import FileGroupTask
+
+        fs, path = url_to_fs(self._completed_dir)
+        fs.makedirs(path, exist_ok=True)
+        record = {
+            "task_id": input_task.task_id,
+            "dataset_name": input_task.dataset_name,
+            "output_paths": output_task.data if isinstance(output_task, FileGroupTask) else [],
+            "metadata": {k: v for k, v in input_task._metadata.items() if _is_json_serializable(v)},
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        checkpoint_key = input_task._metadata.get("original_task_id", input_task.task_id)
+        record_path = f"{path}/{checkpoint_key}.json"
+        with fs.open(record_path, "w") as f:
+            json.dump(record, f)
+        logger.debug(f"Recorded completion for task '{checkpoint_key}' to {record_path}")
+
+
+class ResumableInputStage(ResumableStage):
+    """Mixin for input/reader stages that self-filter already-completed inputs.
+
+    These stages read from ``{checkpoint_dir}/pipeline_complete/`` to know which
+    task_ids have already been fully processed through the entire pipeline and
+    only emit tasks for incomplete inputs.
+    """
+
+    def load_completed_task_ids(self) -> set[str]:
+        """Return the set of task_ids that completed the full pipeline.
+
+        Performs a single ``fs.ls()`` on ``pipeline_complete/`` and returns the
+        filenames (without ``.json`` extension) as a set of completed task ids.
+        Returns an empty set when ``checkpoint_dir`` is not set or the directory
+        does not exist yet.
+        """
+        if not self.checkpoint_dir:
+            return set()
+        pipeline_complete_dir = f"{self.checkpoint_dir.rstrip('/')}/pipeline_complete"
+        fs, path = url_to_fs(pipeline_complete_dir)
+        if not fs.exists(path):
+            return set()
+        return {os.path.splitext(os.path.basename(f))[0] for f in fs.ls(path, detail=False) if f.endswith(".json")}

--- a/nemo_curator/stages/text/download/common_crawl/warc_iterator.py
+++ b/nemo_curator/stages/text/download/common_crawl/warc_iterator.py
@@ -29,7 +29,7 @@ class CommonCrawlWarcIterator(DocumentIterator):
 
     def iterate(self, file_path: str) -> Iterator[dict[str, Any]]:
         """Process a task containing WARC files and extract their contents."""
-        filename = file_path.name if isinstance(file_path, Path) else file_path.split("/")[-1]
+        filename = file_path.name if isinstance(file_path, Path) else file_path.rsplit("/", maxsplit=1)[-1]
 
         num_records = 0
         # TODO: Support cloud storage https://github.com/NVIDIA-NeMo/Curator/issues/779

--- a/nemo_curator/stages/text/download/wikipedia/stage.py
+++ b/nemo_curator/stages/text/download/wikipedia/stage.py
@@ -106,5 +106,5 @@ class WikipediaDownloadExtractStage(DocumentDownloadExtractStage):
 
     def get_description(self) -> str:
         """Get a description of this composite stage."""
-        date_str = self.dump_date if self.dump_date else "latest"
+        date_str = self.dump_date or "latest"
         return f"Wikipedia {self.language} pipeline for dump {date_str}"

--- a/nemo_curator/stages/text/filters/histogram/histogram.py
+++ b/nemo_curator/stages/text/filters/histogram/histogram.py
@@ -48,7 +48,7 @@ class HistogramFilter(DocumentFilter):
         super().__init__()
         self._lang = lang
         self._threshold = threshold
-        self._cache_dir = cache_dir if cache_dir else user_cache_dir()
+        self._cache_dir = cache_dir or user_cache_dir()
         self._threshold_char = threshold_char
         self._name = "histogram"
 

--- a/nemo_curator/stages/text/io/writer/base.py
+++ b/nemo_curator/stages/text/io/writer/base.py
@@ -22,13 +22,14 @@ from loguru import logger
 
 import nemo_curator.stages.text.io.writer.utils as writer_utils
 from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.stages.resumable import ResumableStage
 from nemo_curator.tasks import DocumentBatch, FileGroupTask
 from nemo_curator.utils.client_utils import is_remote_url
 from nemo_curator.utils.file_utils import check_output_mode
 
 
 @dataclass
-class BaseWriter(ProcessingStage[DocumentBatch, FileGroupTask], ABC):
+class BaseWriter(ProcessingStage[DocumentBatch, FileGroupTask], ResumableStage, ABC):
     """Base class for all writer stages.
 
     This abstract base class provides common functionality for writing DocumentBatch
@@ -42,6 +43,8 @@ class BaseWriter(ProcessingStage[DocumentBatch, FileGroupTask], ABC):
     name: str = "BaseWriter"
     mode: Literal["ignore", "overwrite", "append", "error"] = "ignore"
     append_mode_implemented: bool = False
+    resume: bool = False
+    checkpoint_dir: str | None = None
 
     def __post_init__(self):
         # Use fsspec's url_to_fs to get both filesystem and normalized path
@@ -93,7 +96,7 @@ class BaseWriter(ProcessingStage[DocumentBatch, FileGroupTask], ABC):
         logger.debug(f"Written {task.num_items} records to {file_path_with_protocol}")
 
         # Create FileGroupTask with written files using the full protocol-prefixed path
-        return FileGroupTask(
+        output_task = FileGroupTask(
             task_id=task.task_id,
             dataset_name=task.dataset_name,
             data=[file_path_with_protocol],
@@ -103,3 +106,8 @@ class BaseWriter(ProcessingStage[DocumentBatch, FileGroupTask], ABC):
             },
             _stage_perf=task._stage_perf,
         )
+
+        if self.resume and self.checkpoint_dir:
+            self.record_completion(task, output_task)
+
+        return output_task

--- a/nemo_curator/stages/text/models/utils.py
+++ b/nemo_curator/stages/text/models/utils.py
@@ -25,7 +25,7 @@ TOKEN_LENGTH_FIELD = "_curator_token_length"  # noqa: S105
 
 
 def format_name_with_suffix(model_identifier: str, suffix: str = "_classifier") -> str:
-    return model_identifier.split("/")[-1].replace("-", "_").lower() + suffix
+    return model_identifier.rsplit("/", maxsplit=1)[-1].replace("-", "_").lower() + suffix
 
 
 def clip_tokens(token_o: dict, padding_side: Literal["left", "right"] = "right") -> dict[str, torch.Tensor]:

--- a/nemo_curator/stages/text/modifiers/string/quotation_remover.py
+++ b/nemo_curator/stages/text/modifiers/string/quotation_remover.py
@@ -31,6 +31,6 @@ class QuotationRemover(DocumentModifier):
 
     def modify_document(self, text: str) -> str:
         if len(text.strip()) > 2 and text[0] == '"' and text[-1] == '"':  # noqa: SIM102, PLR2004
-            if "\n" not in text.strip() or text.split("\n")[0][-1] != '"':
+            if "\n" not in text.strip() or text.split("\n", maxsplit=1)[0][-1] != '"':
                 text = text[1:-1]
         return text

--- a/nemo_curator/stages/text/utils/text_utils.py
+++ b/nemo_curator/stages/text/utils/text_utils.py
@@ -176,7 +176,7 @@ def get_docstrings(source: str, module: str = "<string>") -> list[str]:
     results = []
     for _, group in grouped:
         for _, name, docstring in group:
-            name = name if name else module  # noqa: PLW2901
+            name = name or module  # noqa: PLW2901
             if docstring:
                 results.append(docstring)
     return results

--- a/nemo_curator/stages/video/filtering/motion_vector_backend.py
+++ b/nemo_curator/stages/video/filtering/motion_vector_backend.py
@@ -196,7 +196,7 @@ def decode_for_motion(  # noqa: C901
             source_fps = float(stream.average_rate)
         else:
             # Use nominal base rate if average not available
-            source_fps = float(stream.base_rate if stream.base_rate else 30)
+            source_fps = float(stream.base_rate or 30)
 
         # Get duration in seconds
         duration_seconds = 0

--- a/tests/stages/text/download/base/test_download.py
+++ b/tests/stages/text/download/base/test_download.py
@@ -30,7 +30,7 @@ class MockDocumentDownloader(DocumentDownloader):
 
     def _get_output_filename(self, url: str) -> str:
         """Simple filename generation for testing."""
-        return url.split("/")[-1].replace(":", "-")
+        return url.rsplit("/", maxsplit=1)[-1].replace(":", "-")
 
     def _download_to_path(self, url: str, path: str) -> tuple[bool, str | None]:
         """Mock download implementation - will be patched in tests."""
@@ -242,7 +242,7 @@ class TestDocumentDownloadStage:
         def side_effect(url: str) -> str | None:
             if "file2" in url:
                 return None  # Simulate failure
-            return str(tmp_path / url.split("/")[-1])
+            return str(tmp_path / url.rsplit("/", maxsplit=1)[-1])
 
         mock_download.side_effect = side_effect
 

--- a/tutorials/image/getting-started/image_curation_example.py
+++ b/tutorials/image/getting-started/image_curation_example.py
@@ -137,8 +137,9 @@ def main(args: argparse.Namespace) -> None:
     print(pipeline.describe())
     print("\n" + "=" * 50 + "\n")
 
-    # Create executor
-    executor = XennaExecutor()
+    # Create executor.
+    # return_last_stage_outputs=False: outputs are written to disk; no need to collect them on the driver.
+    executor = XennaExecutor(config={"return_last_stage_outputs": False})
 
     # Execute pipeline
     pipeline.run(executor)

--- a/tutorials/image/getting-started/image_curation_example.py
+++ b/tutorials/image/getting-started/image_curation_example.py
@@ -29,7 +29,7 @@ from nemo_curator.stages.image.io.image_reader import ImageReaderStage
 from nemo_curator.stages.image.io.image_writer import ImageWriterStage
 
 
-def create_image_curation_pipeline(args: argparse.Namespace) -> Pipeline:
+def create_image_curation_pipeline(args: argparse.Namespace, checkpoint_dir: str | None = None) -> Pipeline:
     """Create image curation pipeline with file partitioning, image reading, embedding, aesthetic scoring, and NSFW detection stages."""
 
     # Define pipeline
@@ -85,6 +85,9 @@ def create_image_curation_pipeline(args: argparse.Namespace) -> Pipeline:
         verbose=args.verbose,
     ))
 
+    if checkpoint_dir is not None:
+        pipeline.enable_resumability(checkpoint_dir)
+
     return pipeline
 
 
@@ -101,6 +104,8 @@ def main(args: argparse.Namespace) -> None:
     print(f"Model directory: {args.model_dir}")
     print(f"Tar files per partition: {args.tar_files_per_partition}")
     print(f"Task batch size: {args.batch_size}")
+    if args.resume:
+        print(f"Checkpoint directory: {args.checkpoint_dir}")
     print("\n" + "=" * 50 + "\n")
 
     # Step 1: Download and prepare webdataset from parquet file
@@ -131,7 +136,8 @@ def main(args: argparse.Namespace) -> None:
     # Step 2: Create and run curation pipeline
     print("Step 2: Running image curation pipeline...")
     start_time = time.time()
-    pipeline = create_image_curation_pipeline(args)
+    checkpoint_dir = args.checkpoint_dir if args.resume else None
+    pipeline = create_image_curation_pipeline(args, checkpoint_dir=checkpoint_dir)
 
     # Print pipeline description
     print(pipeline.describe())
@@ -293,5 +299,25 @@ if __name__ == "__main__":
         help="Number of images per tar file in output dataset"
     )
 
+    # Resumability arguments
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        default=False,
+        help="Enable pipeline resumability. Completed partitions are skipped on restart.",
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory for resumability checkpoints. "
+            "Defaults to a 'checkpoints' folder inside --output-dataset-dir."
+        ),
+    )
+
     args = parser.parse_args()
+
+    if args.resume and args.checkpoint_dir is None:
+        args.checkpoint_dir = os.path.join(args.output_dataset_dir, "checkpoints")
     main(args)

--- a/tutorials/image/getting-started/image_dedup_example.py
+++ b/tutorials/image/getting-started/image_dedup_example.py
@@ -37,37 +37,49 @@ def create_image_embedding_pipeline(args: argparse.Namespace) -> Pipeline:
     pipeline = Pipeline(name="image_curation", description="Curate images with embeddings and quality scoring")
 
     # Stage 0: Partition tar files for parallel processing
-    pipeline.add_stage(FilePartitioningStage(
-        file_paths=args.input_wds_dataset_dir,
-        files_per_partition=args.tar_files_per_partition,
-        file_extensions=[".tar"],
-    ))
+    pipeline.add_stage(
+        FilePartitioningStage(
+            file_paths=args.input_wds_dataset_dir,
+            files_per_partition=args.tar_files_per_partition,
+            file_extensions=[".tar"],
+        )
+    )
 
     # Stage 1: Read images from webdataset tar files (now runs in parallel)
-    pipeline.add_stage(ImageReaderStage(
-        dali_batch_size=args.batch_size,
-        verbose=args.verbose,
-        num_threads=16,  # More threads for I/O
-        num_gpus_per_worker=0.25,
-    ))
+    pipeline.add_stage(
+        ImageReaderStage(
+            dali_batch_size=args.batch_size,
+            verbose=args.verbose,
+            num_threads=16,  # More threads for I/O
+            num_gpus_per_worker=0.25,
+        )
+    )
 
     # Stage 2: Generate CLIP embeddings for images
-    pipeline.add_stage(ImageEmbeddingStage(
-        model_dir=args.model_dir,
-        num_gpus_per_worker=args.embedding_gpus_per_worker,
-        model_inference_batch_size=args.embedding_batch_size,
-        verbose=args.verbose,
-    ))
+    pipeline.add_stage(
+        ImageEmbeddingStage(
+            model_dir=args.model_dir,
+            num_gpus_per_worker=args.embedding_gpus_per_worker,
+            model_inference_batch_size=args.embedding_batch_size,
+            verbose=args.verbose,
+        )
+    )
 
     # Stage 3: Convert embeddings to document batch
     pipeline.add_stage(ConvertImageBatchToDocumentBatchStage(fields=["image_id", "embedding"]))
 
     # Stage 4: Save embeddings to parquet file
-    pipeline.add_stage(ParquetWriter(
-        path=args.embeddings_dir,
-    ))
+    pipeline.add_stage(
+        ParquetWriter(
+            path=args.embeddings_dir,
+        )
+    )
+
+    if args.checkpoint_dir:
+        pipeline.enable_resumability(checkpoint_dir=os.path.join(args.checkpoint_dir, "image_embedding"))
 
     return pipeline
+
 
 def create_embedding_deduplication_workflow(args: argparse.Namespace) -> Pipeline:
     """Create image deduplication pipeline with embedding deduplication."""
@@ -83,39 +95,51 @@ def create_embedding_deduplication_workflow(args: argparse.Namespace) -> Pipelin
         verbose=args.verbose,
     )
 
+
 def create_image_deduplication_pipeline(args: argparse.Namespace) -> Pipeline:
     """Create image deduplication pipeline with image deduplication."""
     # Define pipeline
     pipeline = Pipeline(name="image_deduplication", description="Deduplicate images with image deduplication")
 
     # Stage 0: Partition tar files for parallel processing
-    pipeline.add_stage(FilePartitioningStage(
-        file_paths=args.input_wds_dataset_dir,
-        files_per_partition=args.tar_files_per_partition,
-        file_extensions=[".tar"],
-    ))
+    pipeline.add_stage(
+        FilePartitioningStage(
+            file_paths=args.input_wds_dataset_dir,
+            files_per_partition=args.tar_files_per_partition,
+            file_extensions=[".tar"],
+        )
+    )
 
     # Stage 1: Read images from webdataset tar files (now runs in parallel)
-    pipeline.add_stage(ImageReaderStage(
-        dali_batch_size=args.batch_size,
-        verbose=args.verbose,
-        num_threads=16,  # More threads for I/O
-        num_gpus_per_worker=0.25,
-    ))
+    pipeline.add_stage(
+        ImageReaderStage(
+            dali_batch_size=args.batch_size,
+            verbose=args.verbose,
+            num_threads=16,  # More threads for I/O
+            num_gpus_per_worker=0.25,
+        )
+    )
 
     # Stage 2: Read removal list from parquet file and filter images
-    pipeline.add_stage(ImageDuplicatesRemovalStage(
-        removal_parquets_dir=args.removal_parquets_dir + "/duplicates",
-        duplicate_id_field="id",
-        verbose=args.verbose,
-    ))
+    pipeline.add_stage(
+        ImageDuplicatesRemovalStage(
+            removal_parquets_dir=args.removal_parquets_dir + "/duplicates",
+            duplicate_id_field="id",
+            verbose=args.verbose,
+        )
+    )
 
     # Stage 3: Write filtered images to disk
-    pipeline.add_stage(ImageWriterStage(
-        output_dir=args.output_dataset_dir,
-        remove_image_data=True,
-        verbose=args.verbose,
-    ))
+    pipeline.add_stage(
+        ImageWriterStage(
+            output_dir=args.output_dataset_dir,
+            remove_image_data=True,
+            verbose=args.verbose,
+        )
+    )
+
+    if args.checkpoint_dir:
+        pipeline.enable_resumability(checkpoint_dir=os.path.join(args.checkpoint_dir, "image_deduplication"))
 
     return pipeline
 
@@ -133,6 +157,8 @@ def main(args: argparse.Namespace) -> None:
     print(f"Model directory: {args.model_dir}")
     print(f"Tar files per partition: {args.tar_files_per_partition}")
     print(f"Task batch size: {args.batch_size}")
+    if args.checkpoint_dir:
+        print(f"Checkpoint directory: {args.checkpoint_dir} (resumability enabled)")
     print("\n" + "=" * 50 + "\n")
 
     # Step 1: Download and prepare webdataset from parquet file
@@ -171,14 +197,12 @@ def main(args: argparse.Namespace) -> None:
 
     # Step 2.2: Create image deduplication pipeline (pairwise executor is XennaExecutor by default)
     print("Step 2.2: Running image deduplication pipeline...")
-    start_time = time.time()
     pipeline = create_embedding_deduplication_workflow(args)
     print("\n" + "=" * 50 + "\n")
     pipeline.run()
 
     # Step 2.3: Create image deduplication pipeline
     print("Step 2.3: Running image deduplication pipeline...")
-    start_time = time.time()
     pipeline = create_image_deduplication_pipeline(args)
     print(pipeline.describe())
     print("\n" + "=" * 50 + "\n")
@@ -210,49 +234,37 @@ if __name__ == "__main__":
         type=str,
         required=False,
         default=None,
-        help="Path to input parquet file containing image URLs and metadata"
+        help="Path to input parquet file containing image URLs and metadata",
     )
     parser.add_argument(
-        "--input-wds-dataset-dir",
+        "--input-wds-dataset-dir", type=str, required=True, help="Directory to save the downloaded webdataset"
+    )
+    parser.add_argument(
+        "--output-dataset-dir", type=str, required=True, help="Directory to save the resulting webdataset"
+    )
+    parser.add_argument("--embeddings-dir", type=str, required=True, help="Directory to save the embeddings")
+    parser.add_argument(
+        "--removal-parquets-dir", type=str, required=True, help="Directory to save the remove parquets"
+    )
+    parser.add_argument(
+        "--download-processes", type=int, default=8, help="Number of parallel processes for downloading images"
+    )
+    parser.add_argument(
+        "--entries-per-tar", type=int, default=1000, help="Number of entries per tar shard during download"
+    )
+    parser.add_argument(
+        "--skip-download", action="store_true", default=False, help="Skip dataset download and use existing webdataset"
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
         type=str,
-        required=True,
-        help="Directory to save the downloaded webdataset"
-    )
-    parser.add_argument(
-        "--output-dataset-dir",
-        type=str,
-        required=True,
-        help="Directory to save the resulting webdataset"
-    )
-    parser.add_argument(
-        "--embeddings-dir",
-        type=str,
-        required=True,
-        help="Directory to save the embeddings"
-    )
-    parser.add_argument(
-        "--removal-parquets-dir",
-        type=str,
-        required=True,
-        help="Directory to save the remove parquets"
-    )
-    parser.add_argument(
-        "--download-processes",
-        type=int,
-        default=8,
-        help="Number of parallel processes for downloading images"
-    )
-    parser.add_argument(
-        "--entries-per-tar",
-        type=int,
-        default=1000,
-        help="Number of entries per tar shard during download"
-    )
-    parser.add_argument(
-        "--skip-download",
-        action="store_true",
-        default=False,
-        help="Skip dataset download and use existing webdataset"
+        default=None,
+        help=(
+            "Directory to store pipeline resumability checkpoints. "
+            "When set, completed partitions are recorded so interrupted pipelines "
+            "can resume without reprocessing already-finished work. "
+            "Each pipeline writes to its own subdirectory under this path."
+        ),
     )
 
     # Image reader arguments
@@ -260,41 +272,25 @@ if __name__ == "__main__":
         "--tar-files-per-partition",
         type=int,
         default=1,
-        help="Number of tar files to process per partition (controls parallelism) for FilePartitioningStage"
+        help="Number of tar files to process per partition (controls parallelism) for FilePartitioningStage",
     )
     parser.add_argument(
-        "--batch-size",
-        type=int,
-        default=100,
-        help="Number of images per ImageBatch for the reader stage"
+        "--batch-size", type=int, default=100, help="Number of images per ImageBatch for the reader stage"
     )
 
     # General arguments
     parser.add_argument(
-        "--model-dir",
-        type=str,
-        required=True,
-        help="Path to model directory containing all model weights"
+        "--model-dir", type=str, required=True, help="Path to model directory containing all model weights"
     )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        default=False,
-        help="Enable verbose logging for all stages"
-    )
+    parser.add_argument("--verbose", action="store_true", default=False, help="Enable verbose logging for all stages")
 
     # Embedding stage arguments
-    parser.add_argument(
-        "--embedding-batch-size",
-        type=int,
-        default=32,
-        help="Batch size for embedding generation"
-    )
+    parser.add_argument("--embedding-batch-size", type=int, default=32, help="Batch size for embedding generation")
     parser.add_argument(
         "--embedding-gpus-per-worker",
         type=float,
         default=0.25,
-        help="GPU allocation per worker for embedding generation"
+        help="GPU allocation per worker for embedding generation",
     )
 
     args = parser.parse_args()

--- a/tutorials/synthetic/synthetic_data_generation_example.py
+++ b/tutorials/synthetic/synthetic_data_generation_example.py
@@ -170,9 +170,7 @@ def main() -> None:
 
     # Define a prompt for synthetic data generation
     prompt = (
-        args.prompt
-        if args.prompt
-        else """
+        args.prompt or """
     Generate a short question and a short answer in the general science domain in the language {language}.
     Begin with the language name using the 2-letter code, which is in square brackets, e.g. [EN] for English, [FR] for French, [DE] for German, [ES] for Spanish, [IT] for Italian.
     """

--- a/tutorials/text/tinystories/resumable_main.py
+++ b/tutorials/text/tinystories/resumable_main.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TinyStories curation pipeline with resumability.
+
+This tutorial demonstrates pipeline resumability using the TinyStories dataset.
+The pipeline can be interrupted (e.g. Ctrl+C) and restarted with --resume to
+skip already-completed partitions.
+
+Usage:
+    # First run (or full run)
+    python resumable_main.py --resume
+
+    # Interrupt with Ctrl+C, then restart — completed partitions are skipped
+    python resumable_main.py --resume
+"""
+
+import argparse
+import os
+import time
+
+import pandas as pd
+import requests
+
+from stages import (
+    IncompleteStoryFilter,
+    QuotationUnifier,
+)
+
+from nemo_curator.backends.ray_data import RayDataExecutor
+from nemo_curator.core.client import RayClient
+from nemo_curator.pipeline import Pipeline
+from nemo_curator.stages.file_partitioning import FilePartitioningStage
+from nemo_curator.stages.text.filters import ScoreFilter
+from nemo_curator.stages.text.io.reader.jsonl import JsonlReaderStage
+from nemo_curator.stages.text.io.writer import JsonlWriter
+from nemo_curator.stages.text.modifiers import Modify
+
+
+TINYSTORIES_URLS = {
+    "train": "https://huggingface.co/datasets/roneneldan/TinyStories/resolve/main/TinyStories-train.txt",
+    "valid": "https://huggingface.co/datasets/roneneldan/TinyStories/resolve/main/TinyStories-valid.txt",
+}
+
+RECORD_SEPARATOR = "<|endoftext|>"
+
+
+def download_and_partition(url: str, raw_dir: str, stories_per_file: int) -> None:
+    """Download a TinyStories .txt file and split it into multiple JSONL partition files.
+
+    Skips download and splitting if the files already exist.
+
+    Args:
+        url: URL of the TinyStories .txt file.
+        raw_dir: Directory to write JSONL files into.
+        stories_per_file: Number of stories per output JSONL file.
+    """
+    os.makedirs(raw_dir, exist_ok=True)
+
+    txt_path = os.path.join(raw_dir, os.path.basename(url))
+    if not os.path.exists(txt_path):
+        print(f"Downloading {url}...")
+        response = requests.get(url, timeout=120)  # noqa: S113
+        response.raise_for_status()
+        with open(txt_path, "wb") as f:
+            f.write(response.content)
+        print(f"Saved to {txt_path}")
+
+    existing = [f for f in os.listdir(raw_dir) if f.endswith(".jsonl")]
+    if existing:
+        print(f"Found {len(existing)} existing JSONL partition files in {raw_dir}, skipping split.")
+        return
+
+    # Parse stories separated by <|endoftext|>
+    stories = []
+    current: list[str] = []
+    with open(txt_path) as f:
+        for line in f:
+            if line.strip() == RECORD_SEPARATOR:
+                if current:
+                    stories.append(" ".join(current))
+                    current = []
+            else:
+                stripped = line.strip()
+                if stripped:
+                    current.append(stripped)
+    if current:
+        stories.append(" ".join(current))
+
+    num_files = 0
+    for i, start in enumerate(range(0, len(stories), stories_per_file)):
+        chunk = stories[start : start + stories_per_file]
+        jsonl_path = os.path.join(raw_dir, f"tinystories_{i:04d}.jsonl")
+        pd.DataFrame({"text": chunk}).to_json(jsonl_path, lines=True, orient="records")
+        num_files += 1
+
+    print(f"Split {len(stories)} stories into {num_files} JSONL files ({stories_per_file} stories each)")
+
+
+def main(args: argparse.Namespace) -> None:
+    ray_client = RayClient()
+    ray_client.start()
+
+    raw_dir = os.path.join(args.data_root, "raw", args.split)
+    curated_dir = os.path.join(args.data_root, "curated", args.split)
+    checkpoint_dir = os.path.join(args.data_root, "checkpoints", args.split)
+    os.makedirs(curated_dir, exist_ok=True)
+
+    print("Running the TinyStories curation pipeline")
+    print(f"    Raw JSONL partitions : {raw_dir}")
+    print(f"    Curated output       : {curated_dir}")
+    if args.resume:
+        print(f"    Checkpoint directory : {checkpoint_dir}")
+
+    # Step 1: Download and split into JSONL partition files (no-op if already done)
+    download_and_partition(TINYSTORIES_URLS[args.split], raw_dir, args.stories_per_file)
+
+    # Step 2: Build the curation pipeline
+    #
+    # FilePartitioningStage  →  one FileGroupTask per JSONL file (resumable input)
+    # JsonlReaderStage        →  reads the file group into a DocumentBatch
+    # ScoreFilter             →  drops stories that don't end with punctuation
+    # Modify                  →  normalises quotation marks
+    # JsonlWriter             →  writes curated output and records completion (resumable output)
+    pipeline = Pipeline(
+        name="tinystories_curation",
+        description="Curation pipeline for the TinyStories dataset with resumability.",
+        stages=[
+            FilePartitioningStage(
+                file_paths=raw_dir,
+                files_per_partition=1,
+                file_extensions=[".jsonl"],
+            ),
+            JsonlReaderStage(),
+            ScoreFilter(filter_obj=IncompleteStoryFilter()),
+            Modify(modifier_fn=QuotationUnifier()),
+            JsonlWriter(curated_dir),
+        ],
+    )
+
+    # enable_resumability configures FilePartitioningStage (input) and JsonlWriter (output):
+    #   - FilePartitioningStage skips partitions that already have a completion record
+    #   - JsonlWriter writes a per-partition JSON record to checkpoint_dir/pipeline_complete/
+    #     after each successful write, so restarts pick up from where they left off
+    if args.resume:
+        pipeline.enable_resumability(checkpoint_dir)
+        print("Resumability enabled — completed partitions will be skipped on restart.")
+
+    print("\nStarting the curation pipeline")
+    start_time = time.time()
+    pipeline.run(RayDataExecutor())
+    print(f"\nCuration pipeline finished in {time.time() - start_time:.2f} seconds")
+    print(f"Curated data written to '{curated_dir}'")
+
+    ray_client.stop()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="TinyStories curation pipeline with resumability.")
+    parser.add_argument(
+        "--data_root",
+        type=str,
+        default=os.path.dirname(os.path.abspath(__file__)) + "/data",
+        help="Root directory for raw, curated, and checkpoint data.",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        choices=["train", "valid"],
+        default="valid",
+        help="Dataset split to process ('valid' ~20 MB, 'train' ~2 GB).",
+    )
+    parser.add_argument(
+        "--stories-per-file",
+        type=int,
+        default=2000,
+        help="Stories per JSONL partition file. Controls the number of resumable partitions.",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        default=False,
+        help="Enable resumability. Completed partitions are skipped when the pipeline is restarted.",
+    )
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION

# Plan: Curator-Wide Pipeline Resumability

## Context

NeMo Curator pipelines can run for hours or days (e.g., 83K PDFs × 32 GPUs = 2+ hours). Any interruption loses all in-memory progress and forces a full restart.

**The design:** Each stage owns its own resumability logic via an abstract mixin. Input stages (readers/partitioners) read a completion manifest and only emit tasks for incomplete inputs — the filtering happens inside the stage, not in the executor. Output stages (writers) write completion records after each successful write. The executor's only job is to mark which writer is the "final" pipeline checkpoint.

---

## Design

### Shared manifest convention

```
{checkpoint_dir}/pipeline_complete/{task_id}.json   ← written by final writer, read by input stage
{checkpoint_dir}/{stage_name}/{task_id}.json         ← written by intermediate writers (for future multi-checkpoint support)
```

All stages in a pipeline share the same `checkpoint_dir`. The executor determines which writer is "final" (last ResumableStage in stage list) and sets its `_is_pipeline_checkpoint = True`. That writer writes to `pipeline_complete/`. All input stages (FilePartitioningStage, ClientPartitioningStage) read from `pipeline_complete/` to know which inputs to skip.

**Per-task JSON files** (not a single appended file) avoid concurrent write conflicts when multiple actors run in parallel. Presence of `{task_id}.json` = completion. Content = output file paths for reconstruction.

### task_id tracing: why `original_task_id` is needed

Text readers transform `task_id` by appending `_processed` (e.g., `file_group_0` → `file_group_0_processed`). This means the `DocumentBatch` that arrives at the writer has a different `task_id` than the `FileGroupTask` that `FilePartitioningStage` created.

**Solution:** `FilePartitioningStage` stores `_metadata["original_task_id"] = task_id` on every `FileGroupTask` it creates. All reader stages pass `_metadata` through unchanged (verified in codebase). The writer's `record_completion()` uses `input_task._metadata.get("original_task_id", input_task.task_id)` as the checkpoint filename. `FilePartitioningStage` checks `f"file_group_{i}"` (which equals `original_task_id`) against the completed set — they match.

**Interleaved fanout:** When one `FileGroupTask` fans out into multiple `InterleavedBatch` tasks, all share the same `original_task_id`. Each may write to the same checkpoint file concurrently — this is safe (small JSON atomic overwrite on S3/GCS/local). On resume, the whole input group is skipped; any partial fan-out outputs will be overwritten.

---

## New: `ResumableStage` and `ResumableInputStage`

**New file:** `nemo_curator/stages/resumable.py`

```python
class ResumableStage(ABC):
    """Mixin for stages that can record per-task completion to a checkpoint directory.

    The last ResumableStage in the pipeline (marked _is_pipeline_checkpoint=True by the
    executor) writes to {checkpoint_dir}/pipeline_complete/{task_id}.json.
    All other ResumableStages write to {checkpoint_dir}/{stage_name}/{task_id}.json.
    """
    checkpoint_dir: str | None = None
    _is_pipeline_checkpoint: bool = False  # set by executor on last ResumableStage

    @property
    def _completed_dir(self) -> str:
        base = self.checkpoint_dir.rstrip("/")
        if self._is_pipeline_checkpoint:
            return f"{base}/pipeline_complete"
        return f"{base}/{self.name}"

    def record_completion(self, input_task: Task, output_task: Task) -> None:
        """Write a JSON completion record to _completed_dir/{task_id}.json.

        Called from inside process() after the output is committed to storage.
        Must be safe to call concurrently from multiple actors (per-task file = no conflict).
        """
        fs, path = url_to_fs(self._completed_dir)
        fs.makedirs(path, exist_ok=True)
        record = {
            "task_id": input_task.task_id,
            "dataset_name": input_task.dataset_name,
            "output_paths": output_task.data if isinstance(output_task, FileGroupTask) else [],
            "metadata": {k: v for k, v in input_task._metadata.items() if _is_json_serializable(v)},
            "completed_at": datetime.utcnow().isoformat(),
        }
        # Use original_task_id if present (set by FilePartitioningStage before any reader
        # transforms it, e.g. text readers append "_processed"). This ensures the checkpoint
        # filename matches what FilePartitioningStage looks for on resume.
        checkpoint_key = input_task._metadata.get("original_task_id", input_task.task_id)
        record_path = f"{path}/{checkpoint_key}.json"
        with fs.open(record_path, "w") as f:
            json.dump(record, f)


class ResumableInputStage(ResumableStage, ABC):
    """Mixin for input/reader stages that self-filter already-completed inputs.

    These stages read from {checkpoint_dir}/pipeline_complete/ to know which
    task_ids have already been fully processed through the entire pipeline.
    They only emit FileGroupTasks for incomplete inputs.
    """

    def load_completed_task_ids(self) -> set[str]:
        """Single fs.ls() call on pipeline_complete/ → set of completed task_ids."""
        if not self.checkpoint_dir:
            return set()
        pipeline_complete_dir = f"{self.checkpoint_dir.rstrip('/')}/pipeline_complete"
        fs, path = url_to_fs(pipeline_complete_dir)
        if not fs.exists(path):
            return set()
        return {
            os.path.splitext(os.path.basename(f))[0]
            for f in fs.ls(path, detail=False)
            if f.endswith(".json")
        }
```

---

## `FilePartitioningStage` → implements `ResumableInputStage`

**File:** `nemo_curator/stages/file_partitioning.py`

Add `checkpoint_dir: str | None = None` and `resume: bool = False` fields.

Modify `process()` to filter before emitting tasks:

```python
def process(self, _: _EmptyTask) -> list[FileGroupTask]:
    files = ...
    partitions = ...

    # --- Resumability: skip already-completed inputs ---
    completed_ids: set[str] = set()
    if self.resume and self.checkpoint_dir:
        completed_ids = self.load_completed_task_ids()
        if completed_ids:
            logger.info(f"Resume: {len(completed_ids)} partitions already complete, will skip")

    tasks = []
    dataset_name = self._get_dataset_name(files)
    skipped = 0

    for i, file_group in enumerate(partitions):
        if self.limit is not None and len(tasks) >= self.limit:
            break
        task_id = f"file_group_{i}"
        if task_id in completed_ids:
            skipped += 1
            continue  # ← skip: already processed through full pipeline
        tasks.append(FileGroupTask(
            task_id=task_id,
            dataset_name=dataset_name,
            data=file_group,
            _metadata={
                "partition_index": i,
                "total_partitions": len(partitions),
                "source_files": file_group,
                "original_task_id": task_id,  # preserved through reader transforms (e.g. "_processed" suffix)
            },
            reader_config={},
        ))

    logger.info(f"Resume: skipped {skipped}, emitting {len(tasks)} partitions for processing")
    return tasks
```

**`ClientPartitioningStage`** (`nemo_curator/stages/client_partitioning.py`): same changes — it also sets `source_files` in `_metadata` and uses deterministic `task_id` per partition.

---

## `BaseWriter` → implements `ResumableStage`

**File:** `nemo_curator/stages/text/io/writer/base.py`

Add `resume: bool = False` and `checkpoint_dir: str | None = None`.

Call `record_completion()` inside `process()` after `write_data()` returns:

```python
def process(self, task: DocumentBatch) -> FileGroupTask:
    # ... existing: compute filename, write_data(), build output FileGroupTask ...
    output_task = FileGroupTask(task_id=task.task_id, data=[file_path_with_protocol], ...)

    # Record completion AFTER successful write
    if self.resume and self.checkpoint_dir:
        self.record_completion(task, output_task)

    return output_task
```

`record_completion()` runs inside the Ray actor on a remote node. It writes a small JSON file to `checkpoint_dir` via fsspec. For S3/GCS `checkpoint_dir`: works from any node. For local `checkpoint_dir`: requires shared filesystem (NFS) across nodes in distributed mode.

**`InterleavedBaseWriter`** (`nemo_curator/stages/interleaved/io/writers/base.py`): same changes — identical `source_files` + deterministic hash pattern.

---

## Executor: mark the pipeline checkpoint (all three executors)

The self-filtering design means **all three executors** work with zero filtering logic in the executor — `FilePartitioningStage.process()` handles it internally. The only executor change needed is marking the last `ResumableStage` as the pipeline checkpoint BEFORE stages are serialized to workers.

This works for all executors because:
- **`RayActorPoolExecutor`**: sets `_is_pipeline_checkpoint = True` on stage object before `remote(stage)` serializes it to the actor
- **`RayDataExecutor`**: sets it before `RayDataStageAdapter(stage)` is created and serialized into `map_batches`
- **`XennaExecutor`**: sets it before `create_named_xenna_stage_adapter(stage=stage)` is called — Xenna pickles the adapter (including the stage) when sending to workers

**Common utility method on `BaseExecutor`** (`nemo_curator/backends/base.py`):

```python
def _mark_pipeline_checkpoint(self, stages: list[ProcessingStage]) -> None:
    """Mark the last ResumableStage as the pipeline checkpoint.

    This stage writes completion records to {checkpoint_dir}/pipeline_complete/,
    which input stages (FilePartitioningStage) read to skip already-completed inputs.
    Must be called before any stage is serialized to workers.
    """
    from nemo_curator.stages.resumable import ResumableStage

    last_resumable = None
    for stage in stages:
        if (
            isinstance(stage, ResumableStage)
            and getattr(stage, "resume", False)
            and getattr(stage, "checkpoint_dir", None)
        ):
            last_resumable = stage

    if last_resumable is not None:
        last_resumable._is_pipeline_checkpoint = True
        logger.info(
            f"Pipeline checkpoint: '{last_resumable.name}' will write to "
            f"{last_resumable.checkpoint_dir}/pipeline_complete/"
        )
```

**All three executors** call `self._mark_pipeline_checkpoint(stages)` at the top of their `execute()` method, before creating any adapters or actor pools:

- `nemo_curator/backends/experimental/ray_actor_pool/executor.py` — add call before stage loop
- `nemo_curator/backends/ray_data/executor.py` — add call before stage loop
- `nemo_curator/backends/xenna/executor.py` — add call before the `for stage in stages` adapter loop

No other executor changes needed.

---

## Pipeline convenience method

**File:** `nemo_curator/pipeline/pipeline.py`

```python
def enable_resumability(self, checkpoint_dir: str) -> "Pipeline":
    """Enable resumability on all applicable stages.

    For input stages (FilePartitioningStage, ClientPartitioningStage): sets resume=True
    and checkpoint_dir so they can read the completion manifest.

    For writer stages (BaseWriter, InterleavedBaseWriter): sets resume=True and
    checkpoint_dir so they write completion records.

    The executor automatically marks the last writer as the pipeline checkpoint.
    """
    from nemo_curator.stages.resumable import ResumableStage, ResumableInputStage
    for stage in self.stages:
        if isinstance(stage, (ResumableStage, ResumableInputStage)):
            stage.resume = True
            stage.checkpoint_dir = checkpoint_dir
    return self
```

---

## Critical Files

| File | Change |
|------|--------|
| `nemo_curator/stages/resumable.py` | **New** — `ResumableStage`, `ResumableInputStage` |
| `nemo_curator/stages/file_partitioning.py` | Inherit `ResumableInputStage`; add `resume`, `checkpoint_dir`; filter in `process()` |
| `nemo_curator/stages/client_partitioning.py` | Same changes — same `source_files` pattern |
| `nemo_curator/stages/text/io/writer/base.py` | Inherit `ResumableStage`; add `resume`, `checkpoint_dir`; call `record_completion()` in `process()` |
| `nemo_curator/stages/interleaved/io/writers/base.py` | Same as above |
| `nemo_curator/backends/base.py` | Add `_mark_pipeline_checkpoint()` utility method to `BaseExecutor` |
| `nemo_curator/backends/experimental/ray_actor_pool/executor.py` | Call `_mark_pipeline_checkpoint(stages)` at start of `execute()` |
| `nemo_curator/backends/ray_data/executor.py` | Call `_mark_pipeline_checkpoint(stages)` at start of `execute()` |
| `nemo_curator/backends/xenna/executor.py` | Call `_mark_pipeline_checkpoint(stages)` at start of `execute()` |
| `nemo_curator/stages/__init__.py` | Export `ResumableStage`, `ResumableInputStage` |
| `nemo_curator/pipeline/pipeline.py` | Add `enable_resumability(checkpoint_dir)` |

---

## User API

```python
pipeline = (
    Pipeline("pdf-pipeline")
    .add_stage(FilePartitioningStage(file_paths="s3://raw/"))
    .add_stage(PDFReaderStage())
    .add_stage(GpuScoringStage())
    .add_stage(JsonlWriter(path="s3://output/"))
    .enable_resumability(checkpoint_dir="s3://checkpoints/pdf-pipeline/")
)

results = pipeline.run(executor=RayDataExecutor())
# First run: processes all 83K tasks; writer records each completion to pipeline_complete/
# Crash after 50K tasks
# Resume run:
#   - FilePartitioningStage: reads pipeline_complete/ → 50K done → emits only 33K tasks
#   - Executor marks JsonlWriter as _is_pipeline_checkpoint (writes to pipeline_complete/)
#   - Only 33K tasks flow through PDFReader + GpuScorer + JsonlWriter
```

---

## Out of Scope (this iteration)

- Multi-checkpoint pipelines (intermediate writer as partial checkpoint, then final writer) — requires per-stage filtering in the executor and reader stages after intermediate writers
- Intermediate `DocumentBatch` serialization (too large to checkpoint)
- Dataset fingerprint validation (detect input changes between runs)
- Deduplication shuffle stage resumability (global state coordination required)

---

## Verification

### Unit tests (`tests/unit_tests/test_resumable_stage.py`)
- `test_record_completion_writes_json_file()` — mock fsspec, verify record written to `pipeline_complete/{task_id}.json`
- `test_load_completed_task_ids_returns_set()` — create mock records, verify returned set
- `test_file_partitioning_skips_completed_inputs()` — pre-populate manifest, assert stage only emits incomplete tasks
- `test_file_partitioning_resume_false_emits_all()` — `resume=False` baseline, all tasks emitted
- `test_writer_records_completion_after_write()` — mock `write_data()`, assert `record_completion()` called
- `test_record_completion_uses_original_task_id()` — verify checkpoint filename is `original_task_id` (not `task_id_processed`) when `_metadata["original_task_id"]` is present

### Integration test (`tests/unit_tests/test_executor_resumability.py`)
- Build pipeline: `FilePartitioningStage(resume=True, checkpoint_dir=tmp_dir)` → mock scorer → `JsonlWriter(resume=True, checkpoint_dir=tmp_dir)`
- Verify executor marks `JsonlWriter` as `_is_pipeline_checkpoint = True`
- First run: 5/5 tasks processed, 5 JSON files in `tmp_dir/pipeline_complete/`
- Delete 2 completion records from `pipeline_complete/`
- Second run: verify `FilePartitioningStage` emits only 2 tasks, scorer runs only 2×

### Manual smoke test
```bash
# Run pipeline
python my_pipeline.py --checkpoint-dir s3://checkpoints/run1
# After crash (50K of 83K complete):

# Resume
python my_pipeline.py --checkpoint-dir s3://checkpoints/run1
# Expected log from FilePartitioningStage:
#   "Resume: 50000 partitions already complete, will skip"
#   "Resume: skipped 50000, emitting 33000 partitions for processing"
# Only 33K tasks flow through GPU scoring
```
