### PR TITLE
Add v26.04 index.html redirect to docs config

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -21,6 +21,8 @@ redirects:
     destination: "/home/welcome"
   - source: "/latest/:path*/index.html"
     destination: "/latest/:path*"
+  - source: "/v26.04/:path*/index.html"
+    destination: "/v26.04/:path*"
   - source: "/v26.02/:path*/index.html"
     destination: "/v26.02/:path*"
   - source: "/v25.09/:path*/index.html"


### PR DESCRIPTION
## Description

Adds the `v26.04` version-specific `index.html` redirect to `fern/docs.yml`. This ensures that legacy Sphinx-style URLs with `index.html` suffixes under the `/v26.04/` path are properly redirected to clean Fern canonical URLs, matching the pattern already in place for `latest`, `v26.02`, and `v25.09`.

## Checklist
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.