### PR TITLE
Enable basepath-aware in Fern experimental config

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -126,3 +126,4 @@ libraries:
 experimental:
   mdx-components:
     - ./components
+  basepath-aware: true


### PR DESCRIPTION
## Description

Adds `basepath-aware: true` to the `experimental` block in `fern/docs.yml`. This enables Fern's basepath-aware feature so that components and links resolve correctly under the site's base path.

## Checklist
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.