### PR TITLE
docs: add release notes for audio stage name fix (PR #1470)

### DIFF
--- a/docs/about/release-notes/index.md
+++ b/docs/about/release-notes/index.md
@@ -133,7 +133,6 @@ New API for tracking and analyzing pipeline execution:
 
 ## Bug Fixes
 
-- Fixed audio pipeline stage names not being propagated in `StagePerfStats`, making benchmark results unable to identify per-stage timing (PR #1470)
 - Fixed fasttext predict call compatibility with numpy>2
 - Fixed broken NeMo Framework documentation links
 - Fixed MegatronTokenizerWriter to download only necessary tokenizer files


### PR DESCRIPTION
## Description

Adds a bug fix entry to the Fern 26.04 release notes for PR #1470, which fixed audio pipeline stage names not propagating in `StagePerfStats`. This made benchmark output unable to identify per-stage timing. The fix ensures all audio stages correctly report their names and preserve stage performance history.

## Usage

N/A — documentation-only change.

## Checklist

- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.