### PR TITLE
docs: add release notes and docs for batched shuffle insertion (PR #1369)

### DIFF
--- a/fern/versions/v26.04/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.04/pages/about/release-notes/index.mdx
@@ -66,6 +66,15 @@ Standardized return type for all deduplication workflows:
 
 Added tqdm progress bars to `RayActorPoolExecutor` for real-time visibility into task completion during stage processing and shuffle inserts. Progress bars are enabled by default and can be configured with `show_progress` and `progress_interval` parameters. This is particularly useful for long-running deduplication jobs where progress is not otherwise apparent.
 
+## Improvements
+
+### Batched Shuffle Insertion for Exact Deduplication (PR #1369)
+
+The exact deduplication identification stage now supports batched insertion into the shuffler, improving throughput by processing multiple file groups in a single call. This reduces actor call overhead and enables larger, more efficient GPU operations during the shuffle phase.
+
+- **New `identification_batchsize` parameter** on `ExactDeduplicationWorkflow`: Controls how many input blocks are concatenated and inserted together. For example, an `input_blocksize` of `256MiB` with `identification_batchsize=4` processes ~1 GB of data per insertion call.
+- **Batch-aware shuffle adapter**: The Ray actor pool shuffle adapter now automatically uses `read_and_insert_batch` when a stage provides it, falling back to single-task processing otherwise.
+
 ## Dependency Updates
 
 - **Cosmos-Xenna**: Updated from 0.1.2 to 0.2.0 with simplified resource model

--- a/fern/versions/v26.04/pages/curate-text/process-data/deduplication/exact.mdx
+++ b/fern/versions/v26.04/pages/curate-text/process-data/deduplication/exact.mdx
@@ -82,6 +82,7 @@ Configure exact deduplication using these key parameters:
 | `id_field` | str \| None | None | Existing ID field name (if assign_id=False) |
 | `input_filetype` | str | "parquet" | Input file format ("parquet" or "jsonl") |
 | `input_blocksize` | str \| int | "2GiB" | Size of input blocks for processing |
+| `identification_batchsize` | int | 1 | Number of input blocks to concatenate and insert into the shuffler per call. Higher values increase GPU throughput at the cost of memory. For example, `input_blocksize="256MiB"` with `identification_batchsize=4` processes ~1 GB per call. |
 | `perform_removal` | bool | False | Reserved; must remain `False`. Exact removal is performed with `TextDuplicatesRemovalWorkflow`. |
 
 ## Removing Duplicates
@@ -160,7 +161,7 @@ The workflow produces these output files:
 
 **Best practices**:
 
-- Use `input_blocksize="2GiB"` for optimal performance
+- Use smaller `input_blocksize` values (`256MiB` to `512MiB`) with a larger `identification_batchsize` to target 2-6 GB of overall batches as memory allows. For example, `input_blocksize="256MiB"` with `identification_batchsize=8` processes ~2 GB per insertion call. This improves both shuffle throughput and removal performance compared to the `2GiB` default.
 - Clear output directory between runs
 - Use `assign_id=True` for consistent ID tracking
 </Accordion>


### PR DESCRIPTION
## Description

Adds 26.04 release notes and documentation for the batched shuffle insertion feature introduced in PR #1369. The release notes describe the new `identification_batchsize` parameter and batch-aware shuffle adapter. The exact dedup configuration table and performance best practices are updated accordingly.

## Usage
```python
exact_workflow = ExactDeduplicationWorkflow(
    input_path="input_data/",
    output_path="./results",
    text_field="text",
    input_blocksize="256MiB",
    identification_batchsize=4,  # Process ~1 GB per insertion call
    input_filetype="parquet"
)
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.