### PR TITLE
docs: add AEGIS classifier GPU utilization note and release notes (Issue #878)

### DIFF
--- a/fern/versions/v26.04/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.04/pages/about/release-notes/index.mdx
@@ -29,7 +29,7 @@ Upgraded Cosmos-Xenna from 0.1.2 to 0.2.0 with a simplified resource model and i
 
 ### AEGIS Classifier GPU Utilization (Issue #878)
 
-Confirmed full GPU utilization for the AEGIS safety classifier when running on multi-GPU setups. The AEGIS classifier, which uses the LlamaGuard-7b generative model, now properly distributes inference across all available GPUs. Added a performance note to the [classifier documentation](/curate-text/process-data/quality-assessment/distributed-classifier) to set expectations for processing times relative to encoder-based classifiers.
+Confirmed full GPU utilization for the AEGIS safety classifier when running on multi-GPU setups. The AEGIS classifier, which uses the LlamaGuard-7b generative model, properly distributes inference across all available GPUs. Added a performance note to the [classifier documentation](/curate-text/process-data/quality-assessment/distributed-classifier) to set expectations for processing times relative to encoder-based classifiers.
 
 ## Bug Fixes
 

--- a/fern/versions/v26.04/pages/curate-text/process-data/quality-assessment/distributed-classifier.mdx
+++ b/fern/versions/v26.04/pages/curate-text/process-data/quality-assessment/distributed-classifier.mdx
@@ -170,7 +170,7 @@ results = pipeline.run()  # Uses XennaExecutor by default
 The classifier adds a column with labels: "safe," "O1" through "O13" (each representing specific safety risks), or "unknown."
 
 <Note>
-The AEGIS classifier relies on the [LlamaGuard-7b](https://huggingface.co/meta-llama/LlamaGuard-7b) base model, which is a generative LLM. This makes it significantly slower than the other classifiers in NeMo Curator that use encoder-based models (such as DeBERTa). Full GPU utilization is confirmed when running AEGIS on multi-GPU setups, but expect longer processing times compared to non-generative classifiers due to the autoregressive nature of the underlying model.
+The AEGIS classifier relies on the [LlamaGuard-7b](https://huggingface.co/nvidia/Aegis-AI-Content-Safety-LlamaGuard-Defensive-1.0) base model, which is a generative LLM. This makes it significantly slower than the other classifiers in NeMo Curator that use encoder-based models (such as DeBERTa). Full GPU utilization is confirmed when running AEGIS on multi-GPU setups, but expect longer processing times compared to non-generative classifiers due to the autoregressive nature of the underlying model.
 </Note>
 
 For raw LLM output, use:


### PR DESCRIPTION
## Description

Adds documentation for confirmed full GPU utilization of the AEGIS safety classifier on multi-GPU setups (closes #878). Includes a performance note in the distributed classifier docs explaining that AEGIS uses the LlamaGuard-7b generative model, which is slower than encoder-based classifiers. Also adds a release notes entry under a new "Improvements" section for 26.04.

## Checklist

- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.