### PR TITLE
docs: add release notes for cryptography bump and uv min version (PR #1682)

### DIFF
--- a/fern/versions/v26.04/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.04/pages/about/release-notes/index.mdx
@@ -66,6 +66,8 @@ Standardized return type for all deduplication workflows:
 
 - **Cosmos-Xenna**: Updated from 0.1.2 to 0.2.0 with simplified resource model
 - **Ray**: Updated to 2.54
+- **cryptography**: Bumped from >=46.0.5 to >=46.0.6 to address CVE GHSA-m959-cc7f-wv43 (PR #1682)
+- **uv**: Added minimum required version (>=0.7.0) to prevent lockfile revision drift
 
 ## Bug Fixes
 


### PR DESCRIPTION
## Description

Adds 26.04 release note line items for PR #1682, which bumped the `cryptography` constraint from >=46.0.5 to >=46.0.6 (CVE GHSA-m959-cc7f-wv43) and added a minimum uv version (>=0.7.0) to prevent lockfile revision drift.

## Usage
```python
# No usage changes — documentation only.
```

## Checklist

- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.