### PR TITLE
ci: Update coverage download path

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -263,6 +263,7 @@ jobs:
       )
       && !cancelled()
     strategy:
+      fail-fast: false
       matrix:
         flag: [unit-test, e2e]
     steps:
@@ -273,6 +274,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           pattern: coverage-${{ matrix.flag }}-*
+          path: coverage-downloads
 
       - name: Get total coverage of current branch
         shell: bash -x -e -u -o pipefail {0}
@@ -280,10 +282,14 @@ jobs:
         run: |
           pip install coverage[toml]
           ls -al .
-          ls -al coverage-*/
-          coverage combine --keep $(ls coverage-*/.coverage)
+          if ! [ -d coverage-downloads ] || [ -z "$(ls -A coverage-downloads)" ]; then
+            echo "No coverage artifacts found for ${{ matrix.flag }}, skipping."
+            exit 0
+          fi
+          ls -al coverage-downloads/
+          coverage combine --keep $(find coverage-downloads -name '.coverage')
           coverage report -i
-          rm -rf coverage-*
+          rm -rf coverage-downloads
           ls -al
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

download-artifact@v7 changed extraction behavior: without a path: parameter, it now extracts artifact files directly into the workspace root rather than creating {artifact_name}/subdirectories.

Add path: coverage-downloads to the download step so the extraction location is explicit and predictable regardless of action version behavior.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
