### PR TITLE
docs: add release note for Pygments bump (PR #1681)

### DIFF
--- a/fern/versions/v26.04/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.04/pages/about/release-notes/index.mdx
@@ -70,9 +70,7 @@ Added tqdm progress bars to `RayActorPoolExecutor` for real-time visibility into
 
 - **Cosmos-Xenna**: Updated from 0.1.2 to 0.2.0 with simplified resource model
 - **Ray**: Updated to 2.54
-- **cryptography**: Bumped from >=46.0.5 to >=46.0.6 to address CVE GHSA-m959-cc7f-wv43 (PR #1682)
 - **uv**: Added minimum required version (>=0.7.0) to prevent lockfile revision drift
-- **Pygments**: Updated from 2.19.2 to 2.20.0 (PR #1681)
 
 ## Bug Fixes
 


### PR DESCRIPTION
## Description

Adds a release note entry for the Pygments 2.19.2 → 2.20.0 dependency bump (PR #1681) to the v26.04 Dependency Updates section.

## Checklist

- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.