### PR TITLE
docs: add image reader Ray Data support docs (PR #1610)

### DIFF
--- a/fern/versions/v26.04/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.04/pages/about/release-notes/index.mdx
@@ -62,6 +62,10 @@ Standardized return type for all deduplication workflows:
 - **Structured metadata**: Access per-stage timing (`total_time`, `identification_time`, and others), duplicate counts (`num_duplicates`, `num_duplicates_removed`), and output paths through `result.metadata`
 - **`TaskPerfUtils` compatibility**: `collect_stage_metrics()` and `aggregate_task_metrics()` now accept `WorkflowRunResult` directly
 
+### Image Reader Ray Data Support (PR #1610)
+
+`ImageReaderStage` now works with `RayDataExecutor` in addition to `XennaExecutor`. The stage declares itself as a fanout stage, enabling Ray Data to repartition the multiple `ImageBatch` objects produced from each tar file across downstream workers for parallel processing.
+
 ### Actor Pool Progress Bars (PR #1457)
 
 Added tqdm progress bars to `RayActorPoolExecutor` for real-time visibility into task completion during stage processing and shuffle inserts. Progress bars are enabled by default and can be configured with `show_progress` and `progress_interval` parameters. This is particularly useful for long-running deduplication jobs where progress is not otherwise apparent.

--- a/fern/versions/v26.04/pages/curate-images/load-data/tar-archives.mdx
+++ b/fern/versions/v26.04/pages/curate-images/load-data/tar-archives.mdx
@@ -67,9 +67,13 @@ pipeline.add_stage(ImageReaderStage(
     num_gpus_per_worker=0.25,
 ))
 
-# Run the pipeline (uses XennaExecutor by default)
+# Run the pipeline
 results = pipeline.run()
 ```
+
+<Note>
+`ImageReaderStage` is compatible with both `XennaExecutor` and `RayDataExecutor`. When using `RayDataExecutor`, the stage automatically signals that it fans out (one tar file can produce multiple `ImageBatch` objects), which enables Ray Data to repartition batches across downstream workers for parallel processing.
+</Note>
 
 **Parameters:**
 


### PR DESCRIPTION
## Description

Documents `ImageReaderStage` compatibility with `RayDataExecutor` added in PR #1610. Adds a note to the tar archives loading guide explaining fanout behavior (one tar → multiple `ImageBatch` objects repartitioned across workers), and adds a release note entry under "What's New."

## Checklist
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.