### PR TITLE
docs: add release notes and docs for math benchmarking support (PR #1604)

### DIFF
--- a/fern/versions/v26.04/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.04/pages/about/release-notes/index.mdx
@@ -129,6 +129,16 @@ Standardized return type for all deduplication workflows:
 
 Added tqdm progress bars to `RayActorPoolExecutor` for real-time visibility into task completion during stage processing and shuffle inserts. Progress bars are enabled by default and can be configured with `show_progress` and `progress_interval` parameters. This is particularly useful for long-running deduplication jobs where progress is not otherwise apparent.
 
+### S3 Transport for CommonCrawlWARCReader (PR #1604)
+
+Added S3 as an alternative transport for `CommonCrawlWARCReader`, which fetches individual WARC records using byte-range requests:
+
+- **S3 transport via boto3**: Activate with `use_s3=True` or the `CC_USE_S3` environment variable. Addresses latency and throttling issues when fetching WARC records at scale over HTTPS.
+- **Environment variable configuration**: `CC_USE_S3`, `CC_S3_BUCKET`, and `CC_S3_KEY_PREFIX` environment variables provide runtime configuration without code changes.
+- **Thread-safe lazy initialization**: Both the `requests.Session` and boto3 S3 client use double-checked locking for safe concurrent use with `ThreadPoolExecutor`.
+
+Learn more in the [Common Crawl](/curate-text/load-data/common-crawl) documentation.
+
 ## Improvements
 
 ### Batched Shuffle Insertion for Exact Deduplication (PR #1369)
@@ -167,6 +177,7 @@ Resolved four HIGH-severity vulnerabilities affecting Curator dependencies:
 - **uv**: Added minimum required version (>=0.7.0) to prevent lockfile revision drift
 - **nemo-toolkit**: Bumped `nemo_toolkit[asr]` from `==2.4.0` to `>=2.7.2` to address deserialization CVEs. Only affects `audio_cpu` and `audio_cuda12` extras.
 - **xgrammar**: Moved from `constraint-dependencies` (`>=0.1.21`) to `override-dependencies` (`>=0.1.32`) to override vLLM's pinned version and address CVE-2026-25048.
+- **boto3**: Added `boto3>=1.35` to the `math_cpu` install extra for S3 range requests in `CommonCrawlWARCReader` (PR #1604)
 
 ## Enhancements
 
@@ -217,6 +228,14 @@ Fixed audio pipeline stage names not propagating in `StagePerfStats`, making ben
 ### Video vLLM Setup Race Condition (PR #1590)
 
 Fixed a race condition in `CaptionGenerationStage` and `CaptionEnhancementStage` where multiple workers simultaneously initializing vLLM would race on the shared `torch.compile` cache directory, causing `FileNotFoundError`. Model initialization now runs once per node in `setup_on_node()` instead of per-worker in `setup()`, matching the pattern used by text vLLM stages.
+
+### MathContentExtractor Serialization Crash (PR #1604)
+
+Fixed a `deepcopy`/pickle crash in `MathContentExtractor` caused by unpickleable `threading.Lock` and `magic.Magic` objects. Added `__getstate__`/`__setstate__` methods that strip these objects before serialization and reinitialize them on deserialization. This fixes failures triggered by `ProcessingStage.with_()` and Ray executors.
+
+### CommonCrawlWARCReader Serialization for Ray (PR #1604)
+
+Added `__getstate__`/`__setstate__` to `CommonCrawlWARCReader` for pickle compatibility with Ray executors. The `threading.Lock`, `requests.Session`, and boto3 S3 client are stripped during serialization and lazily reinitialized after deserialization.
 
 ## Breaking Changes
 

--- a/fern/versions/v26.04/pages/curate-text/load-data/common-crawl.mdx
+++ b/fern/versions/v26.04/pages/curate-text/load-data/common-crawl.mdx
@@ -25,6 +25,15 @@ Curator's Common Crawl processing pipeline consists of four sequential stages:
 
 The pipeline outputs structured data that you can write to JSONL or Parquet files for further processing.
 
+### WARC Record Reader
+
+For pipelines that already have WARC metadata (such as `warc_filename`, `warc_record_offset`, and `warc_record_length` columns from a CC Index lookup), use `CommonCrawlWARCReader` to fetch individual WARC records directly via byte-range requests — without downloading full WARC files.
+
+`CommonCrawlWARCReader` supports two transport modes:
+
+- **HTTPS** (default): Fetches records from `data.commoncrawl.org` using the `requests` library. No AWS credentials required.
+- **S3**: Fetches records from the `commoncrawl` S3 bucket using `boto3` range requests. Activate with `use_s3=True` or by setting the `CC_USE_S3=1` environment variable. Credentials are resolved through boto3's standard chain (environment variables, `~/.aws/config`, instance profiles).
+
 ## Before You Start
 
 Choose your download method and ensure you have the prerequisites:
@@ -204,6 +213,57 @@ cc_stage = CommonCrawlDownloadExtractStage(
     stop_lists=stop_lists
 )
 ```
+
+## WARC Record Reader Usage
+
+Use `CommonCrawlWARCReader` when your dataset already contains WARC metadata columns from a CC Index lookup:
+
+```python
+from nemo_curator.stages.text.download.common_crawl.download import CommonCrawlWARCReader
+
+# HTTPS transport (default)
+warc_reader = CommonCrawlWARCReader(
+    warc_filename_col="warc_filename",
+    warc_record_offset_col="warc_record_offset",
+    warc_record_length_col="warc_record_length",
+    max_workers=16,
+)
+
+# S3 transport
+warc_reader = CommonCrawlWARCReader(
+    warc_filename_col="warc_filename",
+    warc_record_offset_col="warc_record_offset",
+    warc_record_length_col="warc_record_length",
+    use_s3=True,
+    max_workers=16,
+)
+```
+
+### WARC Record Reader Parameters
+
+| Parameter | Type | Description | Default |
+| --- | --- | --- | --- |
+| `warc_filename_col` | str | Column name containing the WARC filename | `"warc_filename"` |
+| `warc_record_offset_col` | str | Column name containing the byte offset | `"warc_record_offset"` |
+| `warc_record_length_col` | str | Column name containing the record length | `"warc_record_length"` |
+| `binary_content_col` | str | Output column name for fetched content | `"binary_content"` |
+| `drop_failed` | bool | Drop rows where the fetch failed | `True` |
+| `max_workers` | int | Number of parallel threads for fetching | `16` |
+| `timeout` | int | Request timeout in seconds | `30` |
+| `max_retries` | int | Number of retries for failed requests | `3` |
+| `use_s3` | bool \| None | Use S3 transport instead of HTTPS. If `None`, reads the `CC_USE_S3` environment variable (accepted values: `1`, `true`, `yes`). | `None` |
+| `s3_bucket` | str \| None | S3 bucket name. Falls back to the `CC_S3_BUCKET` environment variable, then `"commoncrawl"`. | `None` |
+| `s3_key_prefix` | str \| None | Prefix to strip from `warc_filename` when building the S3 object key. Falls back to the `CC_S3_KEY_PREFIX` environment variable. | `None` |
+
+### Environment Variables
+
+You can configure `CommonCrawlWARCReader` S3 transport using environment variables instead of constructor parameters:
+
+| Variable | Description | Example |
+| --- | --- | --- |
+| `CC_USE_S3` | Enable S3 transport | `1`, `true`, `yes` |
+| `CC_S3_BUCKET` | Override the S3 bucket name | `commoncrawl` |
+| `CC_S3_KEY_PREFIX` | Prefix to strip from `warc_filename` for S3 key construction | `crawl-data/` |
 
 ## Advanced Usage
 


### PR DESCRIPTION
## Description

Adds fern documentation for PR #1604 (math modality benchmarking support). Updates the Common Crawl page with `CommonCrawlWARCReader` usage, S3 transport parameters, and environment variable reference. Adds release note entries for S3 transport, serialization bug fixes for `MathContentExtractor` and `CommonCrawlWARCReader`, and the `boto3` dependency addition.

## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.