### PR TITLE
fix(deps): Address container scan vulnerabilities in nemo_toolkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,6 +268,7 @@ override-dependencies = [
     "huggingface-hub>=0.34,<1.0", # Override huggingface-hub, transformers and data-designer require two different versions of hugging-face hub
     "kaldiio;  sys_platform == 'never'",
     "levenshtein;  sys_platform == 'never'",
+    "nemo_toolkit>=2.7.2", # Address GHSA-hvjw-vp7g-39h5 and GHSA-9379-mwvr-7wxx
     "numpy>=2.0.0,<=2.2.0", # Override nemo-toolkits constraint of <2.0.0, upperbounds for Numba compatibility
     "protobuf>=5.29.5",  # Override nemo-toolkits constraint of ~=5.29.5
     "setuptools>=80.10.1", # Override setuptools range in other dependencies to address CVE GHSA-58pv-8j8x-9vj2


### PR DESCRIPTION
## Summary

This commit resolves security vulnerabilities found in the Curator container scan. It addresses two high-severity issues in `nemo_toolkit` (GHSA-hvjw-vp7g-39h5, GHSA-9379-mwvr-7wxx) by adding a dependency override to `pyproject.toml`, ensuring a secure version of the package is installed.

## Changes

- **pyproject.toml**: Added an override for `nemo_toolkit>=2.7.2` in `[tool.uv.override-dependencies]` to explicitly enforce the use of a non-vulnerable version, addressing GHSA-hvjw-vp7g-39h5 and GHSA-9379-mwvr-7wxx.

## Related Issue

Closes #1642

