### PR TITLE
docs: add known issue for Xenna 0.1.2 + Ray nightly incompatibility

### DIFF
--- a/fern/versions/v26.04/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.04/pages/about/release-notes/index.mdx
@@ -140,14 +140,16 @@ RuntimeError: Worker is a GPU worker, but no GPUs are available. This likely mea
 that the ray cluster was not started with 'RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0'.
 ```
 
-Xenna 0.1.2 relies on `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0` being set before the Ray cluster starts because it bypasses Ray's built-in GPU allocation. Newer Ray releases changed the internal GPU visibility behavior, breaking this workaround.
+Xenna 0.1.2 relies on `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1` being set before the Ray cluster starts so that Ray does not override `CUDA_VISIBLE_DEVICES` per worker, letting Xenna manage GPU visibility directly. Newer Ray releases changed the internal GPU visibility behavior, breaking this workaround.
+
+<Note>The error message text references `=0`, but the correct value is `=1`. Setting the variable to `1` tells Ray **not** to set `CUDA_VISIBLE_DEVICES`, which is what Xenna requires.</Note>
 
 **Resolution**: Upgrade to NeMo Curator 26.04, which ships Cosmos-Xenna 0.2.0. Xenna 0.2.0 manages CUDA device visibility directly and no longer depends on `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES`.
 
 If you must remain on 26.02, pin Ray to `<=2.43` and ensure the environment variable is set before starting the Ray cluster:
 
 ```bash
-export RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0
+export RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
 ray start --head
 ```
 

--- a/fern/versions/v26.04/pages/api-reference/executors/xenna-executor.mdx
+++ b/fern/versions/v26.04/pages/api-reference/executors/xenna-executor.mdx
@@ -175,9 +175,18 @@ RuntimeError: Worker is a GPU worker, but no GPUs are available. This likely mea
 that the ray cluster was not started with 'RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0'.
 ```
 
-This occurs when Cosmos-Xenna 0.1.2 (shipped in NeMo Curator 26.02) is used with Ray nightly builds or Ray versions newer than 2.43. Xenna 0.1.2 bypasses Ray's GPU allocation and requires `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0` to be set before the Ray cluster starts, but newer Ray releases changed the internal GPU visibility behavior.
+This occurs when Cosmos-Xenna 0.1.2 (shipped in NeMo Curator 26.02) is used with Ray nightly builds or Ray versions newer than 2.43. Xenna 0.1.2 bypasses Ray's GPU allocation and requires `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1` to be set before the Ray cluster starts, but newer Ray releases changed the internal GPU visibility behavior.
+
+<Note>The error message text references `=0`, but the correct value is `=1`. Setting the variable to `1` tells Ray **not** to set `CUDA_VISIBLE_DEVICES`, which is what Xenna requires.</Note>
 
 **Resolution**: Upgrade to NeMo Curator 26.04, which ships Cosmos-Xenna 0.2.0. Xenna 0.2.0 manages CUDA device visibility directly and does not require this environment variable.
+
+If you must remain on 26.02, pin Ray to `<=2.43` and set the variable before starting the cluster:
+
+```bash
+export RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
+ray start --head
+```
 
 ## Source Code
 


### PR DESCRIPTION
## Description

Documents the known issue where Cosmos-Xenna 0.1.2 (shipped in 26.02) fails to start GPU workers when paired with Ray nightly builds or Ray versions newer than 2.43, due to changed GPU visibility behavior breaking the `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES` workaround. Adds a Known Issues section to the 26.04 release notes and a Troubleshooting section to the XennaExecutor API reference with the resolution (upgrade to 26.04 / Xenna 0.2.0).

## Checklist
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.