### PR TITLE
fix: tighten URL regex character class

### DIFF
--- a/nemo_curator/stages/text/filters/heuristic/string.py
+++ b/nemo_curator/stages/text/filters/heuristic/string.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from typing import Literal
 
 from nemo_curator.stages.text.filters.doc_filter import DocumentFilter
@@ -113,13 +114,14 @@ class UrlsFilter(DocumentFilter):
     If more than 20% of the document is comprised of URLs, then discard.
     """
 
-    def __init__(self, max_url_to_text_ratio: float = 0.2):
+    def __init__(self, max_url_to_text_ratio: float = 0.2, regex_url_pattern: re.Pattern[str] = regex_url):
         super().__init__()
         self._cutoff = max_url_to_text_ratio
+        self._regex_url = regex_url_pattern
         self._name = "urls_ratio"
 
     def score_document(self, text: str) -> float:
-        all_urls = regex_url.findall(text)
+        all_urls = self._regex_url.findall(text)
         url_chars = sum([len(url) for url in all_urls])
         nchar = len(text)
         # Remove if the document is empty
@@ -433,11 +435,12 @@ class PornographicUrlsFilter(DocumentFilter):
     Check if any of the URLs within the document point to pornography.
     """
 
-    def __init__(self):
+    def __init__(self, regex_url_pattern: re.Pattern[str] = regex_url):
         super().__init__()
+        self._regex_url = regex_url_pattern
 
     def score_document(self, text: str) -> int:
-        all_urls = regex_url.findall(text)
+        all_urls = self._regex_url.findall(text)
         for url in all_urls:
             if "porn" in url:
                 return 1

--- a/nemo_curator/stages/text/utils/constants.py
+++ b/nemo_curator/stages/text/utils/constants.py
@@ -72,6 +72,6 @@ bullet_list = {
 regex_alpha = regex.compile("[[:alpha:]]")
 regex_digit = regex.compile("[[:digit:]]")
 regex_alphanum = re.compile("[a-zA-Z0-9\n?!,.]")
-regex_url = re.compile("http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
+regex_url = re.compile("http[s]?://(?:[a-zA-Z]|[0-9]|[$\-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
 regex_paren = re.compile(r"{|}|⟨|⟩|\[|\]|\(|\)")
 regex_hash = re.compile("#+")

--- a/nemo_curator/stages/text/utils/constants.py
+++ b/nemo_curator/stages/text/utils/constants.py
@@ -72,6 +72,6 @@ bullet_list = {
 regex_alpha = regex.compile("[[:alpha:]]")
 regex_digit = regex.compile("[[:digit:]]")
 regex_alphanum = re.compile("[a-zA-Z0-9\n?!,.]")
-regex_url = re.compile("http[s]?://(?:[a-zA-Z]|[0-9]|[$\-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
+regex_url = re.compile("http[s]?://(?:[a-zA-Z]|[0-9]|[$_@.&+-]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
 regex_paren = re.compile(r"{|}|⟨|⟩|\[|\]|\(|\)")
 regex_hash = re.compile("#+")

--- a/nemo_curator/stages/text/utils/constants.py
+++ b/nemo_curator/stages/text/utils/constants.py
@@ -72,6 +72,6 @@ bullet_list = {
 regex_alpha = regex.compile("[[:alpha:]]")
 regex_digit = regex.compile("[[:digit:]]")
 regex_alphanum = re.compile("[a-zA-Z0-9\n?!,.]")
-regex_url = re.compile("http[s]?://(?:[a-zA-Z]|[0-9]|[$_@.&+-]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
+regex_url = re.compile("http[s]?://(?:[a-zA-Z]|[0-9]|[$\-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
 regex_paren = re.compile(r"{|}|⟨|⟩|\[|\]|\(|\)")
 regex_hash = re.compile("#+")

--- a/tests/stages/text/modules/test_filters.py
+++ b/tests/stages/text/modules/test_filters.py
@@ -558,7 +558,7 @@ class TestHeuristicFilters:
 
     def test_urls_accepts_custom_regex(self) -> None:
         dataset = list_to_dataset(["visit https://docs.nvidia.com", "plain text"])
-        filters = ScoreFilter(UrlsFilter(regex_url_pattern=re.compile(r"https://docs\\.nvidia\\.com")))
+        filters = ScoreFilter(UrlsFilter(regex_url_pattern=re.compile(r"https://docs\.nvidia\.com")))
 
         filtered_data = filters.process(dataset)
 

--- a/tests/stages/text/modules/test_filters.py
+++ b/tests/stages/text/modules/test_filters.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import re
 
 import numpy as np
 import pandas as pd
@@ -555,6 +556,19 @@ class TestHeuristicFilters:
         )
         assert all_equal(expected_data, filtered_data), f"Expected {expected_data} but got {filtered_data}"
 
+    def test_urls_accepts_custom_regex(self) -> None:
+        dataset = list_to_dataset(["visit https://docs.nvidia.com", "plain text"])
+        filters = ScoreFilter(UrlsFilter(regex_url_pattern=re.compile(r"https://docs\\.nvidia\\.com")))
+
+        filtered_data = filters.process(dataset)
+
+        expected_data = DocumentBatch(
+            data=pd.DataFrame({"text": ["plain text"]}),
+            task_id="batch_1_urls_ratio",
+            dataset_name="test_1",
+        )
+        assert all_equal(expected_data, filtered_data), f"Expected {expected_data} but got {filtered_data}"
+
     def test_bullets(self) -> None:
         dataset = list_to_dataset(
             [
@@ -881,6 +895,19 @@ class TestHeuristicFilters:
 
         expected_data = DocumentBatch(
             data=pd.DataFrame({"text": ["no url", "fine url https://www.nvidia.com/en-us/"]}),
+            task_id="batch_1_PornographicUrlsFilter",
+            dataset_name="test_1",
+        )
+        assert all_equal(expected_data, filtered_data), f"Expected {expected_data} but got {filtered_data}"
+
+    def test_pornographicurls_accepts_custom_regex(self) -> None:
+        dataset = list_to_dataset(["bad url https://www.pornhub.com/", "bad word but no matching url"])
+        filters = ScoreFilter(PornographicUrlsFilter(regex_url_pattern=re.compile(r"https://www\\.pornhub\\.com/")))
+
+        filtered_data = filters.process(dataset)
+
+        expected_data = DocumentBatch(
+            data=pd.DataFrame({"text": ["bad word but no matching url"]}),
             task_id="batch_1_PornographicUrlsFilter",
             dataset_name="test_1",
         )

--- a/tests/stages/text/utils/test_constants.py
+++ b/tests/stages/text/utils/test_constants.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from nemo_curator.stages.text.utils.constants import regex_url
 
 

--- a/tests/stages/text/utils/test_constants.py
+++ b/tests/stages/text/utils/test_constants.py
@@ -1,0 +1,7 @@
+from nemo_curator.stages.text.utils.constants import regex_url
+
+
+def test_regex_url_does_not_treat_caret_as_valid_url_character() -> None:
+    text = "Visit http://exa^mple.com for details"
+
+    assert regex_url.findall(text) == ["http://exa"]


### PR DESCRIPTION
Fixes #1601

## Summary
- escape `-` in the URL regex character class so it is treated literally
- add a focused regression test for a caret in the hostname

## Testing
- python sanity check for the updated regex behavior