### PR TITLE
[QA test fix] Adjust image dedup example

### DIFF
--- a/tutorials/image/getting-started/image_dedup_example.py
+++ b/tutorials/image/getting-started/image_dedup_example.py
@@ -99,7 +99,7 @@ def create_image_deduplication_pipeline(args: argparse.Namespace) -> Pipeline:
     pipeline.add_stage(ImageReaderStage(
         dali_batch_size=args.batch_size,
         verbose=args.verbose,
-        num_threads=16,  # More threads for I/O
+        num_threads=4,
         num_gpus_per_worker=0.25,
     ))
 
@@ -175,6 +175,12 @@ def main(args: argparse.Namespace) -> None:
     pipeline = create_embedding_deduplication_workflow(args)
     print("\n" + "=" * 50 + "\n")
     pipeline.run()
+
+    # Restart Ray between steps 2.2 and 2.3 to evict idle CLIP embedding actors
+    # (~17 GB each) left over from step 2.1.
+    ray_client.stop()
+    ray_client = RayClient()
+    ray_client.start()
 
     # Step 2.3: Create image deduplication pipeline
     print("Step 2.3: Running image deduplication pipeline...")

--- a/tutorials/image/getting-started/image_dedup_example.py
+++ b/tutorials/image/getting-started/image_dedup_example.py
@@ -120,6 +120,27 @@ def create_image_deduplication_pipeline(args: argparse.Namespace) -> Pipeline:
     return pipeline
 
 
+def _download_step(args: argparse.Namespace) -> None:
+    """Step 1: Download and prepare webdataset from parquet file."""
+    if not args.skip_download:
+        print("Step 1: Downloading webdataset from parquet file...")
+        download_start = time.time()
+        os.makedirs(args.input_wds_dataset_dir, exist_ok=True)
+        download_webdataset(
+            parquet_path=args.input_parquet,
+            output_dir=args.input_wds_dataset_dir,
+            num_processes=args.download_processes,
+            entries_per_tar=args.entries_per_tar,
+        )
+        download_time = time.time() - download_start
+        print(f"✓ Dataset download completed in {download_time:.2f} seconds")
+        print(f"✓ Webdataset saved to: {args.input_wds_dataset_dir}")
+    else:
+        print("Step 1: Skipping download (using existing dataset)")
+        print(f"Using existing dataset at: {args.input_wds_dataset_dir}")
+    print("\n" + "=" * 50 + "\n")
+
+
 def main(args: argparse.Namespace) -> None:
     """Main execution function for image curation pipeline."""
 
@@ -135,30 +156,7 @@ def main(args: argparse.Namespace) -> None:
     print(f"Task batch size: {args.batch_size}")
     print("\n" + "=" * 50 + "\n")
 
-    # Step 1: Download and prepare webdataset from parquet file
-    if not args.skip_download:
-        print("Step 1: Downloading webdataset from parquet file...")
-        download_start = time.time()
-
-        # Create output directory if it doesn't exist
-        os.makedirs(args.input_wds_dataset_dir, exist_ok=True)
-
-        # Download webdataset using helper function
-        download_webdataset(
-            parquet_path=args.input_parquet,
-            output_dir=args.input_wds_dataset_dir,
-            num_processes=args.download_processes,
-            entries_per_tar=args.entries_per_tar,
-        )
-
-        download_time = time.time() - download_start
-        print(f"✓ Dataset download completed in {download_time:.2f} seconds")
-        print(f"✓ Webdataset saved to: {args.input_wds_dataset_dir}")
-        print("\n" + "=" * 50 + "\n")
-    else:
-        print("Step 1: Skipping download (using existing dataset)")
-        print(f"Using existing dataset at: {args.input_wds_dataset_dir}")
-        print("\n" + "=" * 50 + "\n")
+    _download_step(args)
 
     # Step 2: Create and run curation pipelines
     # Step 2.1: Create image embedding pipeline


### PR DESCRIPTION
## Description
Fix QA issue: https://nvbugspro.nvidia.com/bug/6054589
  - Extract download logic into _download_step() to fix PLR0915 lint                                                                                                                                                                                                                                                                  
  - Restart Ray between steps 2.2 and 2.3 to evict idle CLIP actors and prevent OOM (Bug 1)
  - Reduce ImageReaderStage num_threads 16→4 in the dedup pipeline to prevent SIGSEGV from DALI GC pressure (Bug 2)     

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
