### PR TITLE
fix: use compute instead of concurrency for ray data

### DIFF
--- a/nemo_curator/backends/experimental/ray_data/adapter.py
+++ b/nemo_curator/backends/experimental/ray_data/adapter.py
@@ -88,27 +88,27 @@ class RayDataStageAdapter(BaseStageAdapter):
 
         if is_actor_stage_:
             map_batches_fn = create_actor_from_stage(self.stage)
-            concurrency_kwargs = {
-                "concurrency": calculate_concurrency_for_actors_for_stage(
+            map_batches_kwargs = {
+                "compute": calculate_concurrency_for_actors_for_stage(
                     self.stage, ignore_head_node=ignore_head_node
                 ),
             }
         else:
             map_batches_fn = create_task_from_stage(self.stage)
-            concurrency_kwargs = {"concurrency": None}
+            map_batches_kwargs = {}
             max_calls = self.stage.ray_stage_spec().get(RayStageSpecKeys.MAX_CALLS_PER_WORKER, None)
             if max_calls is not None:
-                concurrency_kwargs["max_calls"] = max_calls
+                map_batches_kwargs["max_calls"] = max_calls
 
         if self.stage.resources.cpus > 0:
-            concurrency_kwargs["num_cpus"] = self.stage.resources.cpus  # type: ignore[reportArgumentType]
+            map_batches_kwargs["num_cpus"] = self.stage.resources.cpus  # type: ignore[reportArgumentType]
         if self.stage.resources.gpus > 0:
-            concurrency_kwargs["num_gpus"] = self.stage.resources.gpus  # type: ignore[reportArgumentType]
+            map_batches_kwargs["num_gpus"] = self.stage.resources.gpus  # type: ignore[reportArgumentType]
 
         # Calculate concurrency based on available resources
-        logger.info(f"{self.stage.__class__.__name__} {is_actor_stage_=} with {concurrency_kwargs=}")
+        logger.info(f"{self.stage.__class__.__name__} {is_actor_stage_=} with {map_batches_kwargs=}")
 
-        processed_dataset = dataset.map_batches(map_batches_fn, batch_size=self.batch_size, **concurrency_kwargs)  # type: ignore[reportArgumentType]
+        processed_dataset = dataset.map_batches(map_batches_fn, batch_size=self.batch_size, **map_batches_kwargs)  # type: ignore[reportArgumentType]
 
         if self.stage.ray_stage_spec().get(RayStageSpecKeys.IS_FANOUT_STAGE, False):
             processed_dataset = processed_dataset.repartition(target_num_rows_per_block=1)

--- a/tests/backends/experimental/ray_data/test_adapter.py
+++ b/tests/backends/experimental/ray_data/test_adapter.py
@@ -1,0 +1,43 @@
+from unittest.mock import Mock, patch
+
+from nemo_curator.backends.experimental.ray_data.adapter import RayDataStageAdapter
+from nemo_curator.stages.resources import Resources
+
+
+def _make_stage(ray_stage_spec=None):
+    stage = Mock()
+    stage.batch_size = 8
+    stage.resources = Resources(cpus=2.0, gpus=1.0)
+    stage.ray_stage_spec.return_value = ray_stage_spec or {}
+    stage.__class__.__name__ = "MockStage"
+    return stage
+
+
+@patch("nemo_curator.backends.experimental.ray_data.adapter.create_actor_from_stage", return_value=Mock())
+@patch("nemo_curator.backends.experimental.ray_data.adapter.calculate_concurrency_for_actors_for_stage", return_value=(1, 4))
+def test_process_dataset_uses_compute_for_actor_stages(mock_concurrency, mock_create_actor):
+    dataset = Mock()
+    dataset.map_batches.return_value = dataset
+    stage = _make_stage()
+
+    adapter = RayDataStageAdapter(stage)
+    adapter.process_dataset(dataset)
+
+    _, kwargs = dataset.map_batches.call_args
+    assert kwargs["compute"] == (1, 4)
+    assert "concurrency" not in kwargs
+
+
+@patch("nemo_curator.backends.experimental.ray_data.adapter.create_task_from_stage", return_value=Mock())
+@patch("nemo_curator.backends.experimental.ray_data.adapter.is_actor_stage", return_value=False)
+def test_process_dataset_omits_compute_for_task_stages(mock_is_actor_stage, mock_create_task):
+    dataset = Mock()
+    dataset.map_batches.return_value = dataset
+    stage = _make_stage()
+
+    adapter = RayDataStageAdapter(stage)
+    adapter.process_dataset(dataset)
+
+    _, kwargs = dataset.map_batches.call_args
+    assert "compute" not in kwargs
+    assert "concurrency" not in kwargs


### PR DESCRIPTION
## Description
closes #1520

Switch the Ray Data adapter from the deprecated `concurrency` argument to `compute` for actor-backed `map_batches()` calls, and add a focused adapter test to guard the forwarded kwargs.

## Usage
```python
# Existing Ray Data pipelines continue to work; the adapter now forwards `compute=`
# instead of the deprecated `concurrency=` when building actor-backed map_batches calls.
```
## Checklist
- [x] The title of the PR starts with fix or feat, if this applies to your PR.
- [x] Changes are manually tested and documented in the PR if automated coverage is not practical.
- [x] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.