### PR TITLE
fix: ignore docs, tests, and tutorials in Ray uploads

### DIFF
--- a/.rayignore
+++ b/.rayignore
@@ -1,0 +1,3 @@
+docs/
+tests/
+tutorials/


### PR DESCRIPTION
## Description
closes #1337

Add a `.rayignore` file so Ray uploads skip the docs, tests, and tutorials directories that do not need to be shipped with pipeline code.

## Usage
```python
# No code changes required. Ray now respects .rayignore when packaging the working directory.
```
## Checklist
- [x] The title of the PR starts with fix or feat, if this applies to your PR.
- [x] Changes are manually tested and documented in the PR if automated coverage is not practical.
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.