### PR TITLE
Build: drop rc0 pre-release tag and add dynamic git versioning

### DIFF
--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -27,11 +27,12 @@ defaults:
 
 jobs:
   build-test-publish-wheel:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.22.3
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.88.1
     with:
       dry-run: true
       python-package: nemo_curator
       python-version: "3.10"
+      packaging: uv
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/nemo_curator/package_info.py
+++ b/nemo_curator/package_info.py
@@ -31,18 +31,18 @@ if VERSION[3] != "":
 if VERSION[4] != "":
     __version__ = __version__ + "." + ".".join(VERSION[4:])
 
-import os as _os  # noqa: I001
-import subprocess as _subprocess
+import os as _os  # noqa: E402, I001
+import subprocess as _subprocess  # noqa: E402
 
 
 if not int(_os.getenv("NO_VCS_VERSION", "0")):
     try:
         _git = _subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
+            ["git", "rev-parse", "--short", "HEAD"],  # noqa: S607
             capture_output=True,
             cwd=_os.path.dirname(_os.path.abspath(__file__)),
             check=True,
-            universal_newlines=True,
+            text=True,
         )
     except (_subprocess.CalledProcessError, OSError):
         pass

--- a/nemo_curator/package_info.py
+++ b/nemo_curator/package_info.py
@@ -16,8 +16,8 @@
 MAJOR = 1
 MINOR = 1
 PATCH = 0
-PRE_RELEASE = "rc0"
-DEV = "dev0"
+PRE_RELEASE = ""
+DEV = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE, DEV)
@@ -30,6 +30,24 @@ if VERSION[3] != "":
 
 if VERSION[4] != "":
     __version__ = __version__ + "." + ".".join(VERSION[4:])
+
+import os as _os  # noqa: I001
+import subprocess as _subprocess
+
+
+if not int(_os.getenv("NO_VCS_VERSION", "0")):
+    try:
+        _git = _subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            cwd=_os.path.dirname(_os.path.abspath(__file__)),
+            check=True,
+            universal_newlines=True,
+        )
+    except (_subprocess.CalledProcessError, OSError):
+        pass
+    else:
+        __version__ += f"+{_git.stdout.strip()}"
 
 __package_name__ = "nemo_curator"
 __contact_names__ = "NVIDIA"


### PR DESCRIPTION
## Description

Drops the rc0 pre-release tag — version is now X.Y.Z (clean semver)
Appends +<short-sha> to __version__ at import/build time via git rev-parse --short HEAD
Gracefully falls back to the base version if git is unavailable or the code is not in a git repo
Set NO_VCS_VERSION=1 to opt out (e.g. for release builds)
Bump FW-CI-templates to v0.88.1

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
