### PR TITLE
ci: Gpu test matrix ci_worklod check

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -144,6 +144,13 @@ jobs:
   cicd-gpu-test-matrix:
     needs: [pre-flight, cicd-wait-in-queue]
     runs-on: ubuntu-latest
+    if: |
+      (
+        success()
+        || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || needs.pre-flight.outputs.force_run_all == 'true'
+      )
+      && !cancelled()
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
## Description
- GPU test matrix job should run on main (ci_workload=true)

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
