### PR TITLE
fix: keep pipeline pytest temp files off /tmp

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -98,7 +98,12 @@ jobs:
           source .venv/bin/activate
           FOLDER="${{ matrix.folder }}"
           FOLDER="${FOLDER/stages-/stages/}"
-          coverage run --branch --source=nemo_curator -m pytest -v "tests/$FOLDER" -m "not gpu"
+          if [ "$FOLDER" = "pipelines" ]; then
+            mkdir -p "$GITHUB_WORKSPACE/pytest-tmp"
+            coverage run --branch --source=nemo_curator -m pytest -v "tests/$FOLDER" -m "not gpu" --basetemp="$GITHUB_WORKSPACE/pytest-tmp"
+          else
+            coverage run --branch --source=nemo_curator -m pytest -v "tests/$FOLDER" -m "not gpu"
+          fi
 
       - name: Generate report
         id: check


### PR DESCRIPTION
## Description
For the CPU pipelines test shard, send pytest temporary files to `$GITHUB_WORKSPACE/pytest-tmp` instead of the runner's default `/tmp`. This keeps the Ray `--temp-dir`/pytest temp tree off the smaller `/tmp` partition and matches the workaround described in the issue.

Closes #1775.

## Usage
```python
# CI-only change: the pipelines shard now runs roughly like
# pytest tests/pipelines -m "not gpu" --basetemp="$GITHUB_WORKSPACE/pytest-tmp"
```
## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
