### PR TITLE
[ci] fix: retry apt-get installs to handle mirror sync failures

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -81,8 +81,11 @@ runs:
     - name: Install GH CLI
       shell: bash
       run: |
-        apt-get update
-        apt-get install -y gh
+        for i in 1 2 3; do
+          apt-get update && apt-get install -y gh && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
 
     - name: Normalize repo name to lowercase
       shell: bash

--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -98,8 +98,11 @@ runs:
       shell: bash -x -e -u -o pipefail {0}
       if: ${{ contains(inputs.runner, 'aws') }}
       run: |
-        apt-get update
-        apt-get install -y uuid-runtime
+        for i in 1 2 3; do
+          apt-get update && apt-get install -y uuid-runtime && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
 
     - name: Start container
       shell: bash

--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -78,7 +78,11 @@ runs:
       if: ${{ inputs.has-azure-credentials == 'true' }}
       shell: bash
       run: |
-        curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+        for i in 1 2 3; do
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash && break
+          echo "Attempt $i failed, retrying in 10s..."
+          sleep 10
+        done
 
     - name: Azure Login
       if: ${{ inputs.has-azure-credentials == 'true' }}

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -213,7 +213,12 @@ jobs:
     name: "GPU Extras Individual - Install Only (${{ matrix.installer }}) - Py3.12"
     steps:
       - name: Install dependencies for setup-python
-        run: apt-get update && apt-get install -y --no-install-recommends git curl
+        run: |
+          for i in 1 2 3; do
+            apt-get update && apt-get install -y --no-install-recommends git curl && break
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
 
       - uses: actions/checkout@v6
         with:
@@ -426,7 +431,11 @@ jobs:
 
           cat > ${{ github.workspace }}/.run_install.sh << 'SCRIPT'
           set -e
-          apt-get update && apt-get install -y --no-install-recommends git curl
+          for i in 1 2 3; do
+            apt-get update && apt-get install -y --no-install-recommends git curl && break
+            echo "Attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
           curl -LsSf https://astral.sh/uv/install.sh | sh
           export PATH="/root/.local/bin:$PATH"
           uv sync --locked --link-mode copy --extra all --python 3.12 2>&1 | tee install.log


### PR DESCRIPTION
## Summary

- Wraps all `apt-get update && apt-get install` calls in a 3-attempt retry loop with a 10s back-off
- Wraps the Azure CLI install script (`InstallAzureCLIDeb`) in the same retry loop — the script runs its own `apt-get update` internally and is subject to the same mirror sync failures

## Affected files

- `.github/actions/build-container/action.yml` — Install GH CLI
- `.github/actions/test-template/action.yml` — Install uuidgen + Install Azure CLI
- `.github/workflows/install-test.yml` — Install git/curl (×2, including inside heredoc script)

## Test plan

- [ ] CI passes on the next run without manual retries