### PR TITLE
[benchmarking] Increases timeout for `math_preprocess_llm_cleanup` benchmark

### DIFF
--- a/benchmarking/nightly-benchmark.yaml
+++ b/benchmarking/nightly-benchmark.yaml
@@ -1145,7 +1145,7 @@ entries:
       --prompt=HTML_TO_TEXT_PROMPT
       --chunk-data
       --chunk-length=4096
-    timeout_s: 1200
+    timeout_s: 1800
     sink_data:
       - name: slack
         additional_metrics:


### PR DESCRIPTION
* Increases timeout from 20m to 30m for `math_preprocess_llm_cleanup` benchmark, due to several timeout failures when limited to 20m.

cc @ronjer30 , @sarahyurick 