### PR TITLE
[benchmarking] Adds gpustat data for processes running on each GPU

### DIFF
--- a/benchmarking/runner/utils.py
+++ b/benchmarking/runner/utils.py
@@ -191,10 +191,21 @@ def get_gpu_stats() -> dict:
     Returns:
         dict: Keys are GPU indices; values are dicts with "memory_total" and "memory_used".
     """
+    # utils.py is also imported in scripts that run before the Curator
+    # environment is set up, so import gpustat lazily.
     import gpustat
 
     query = gpustat.new_query()
-    return {gpu.index: {"memory_total": gpu.memory_total, "memory_used": gpu.memory_used} for gpu in query}
+    query_data = {}
+    for gpu in query:
+        # Only include certain fields from the process data.
+        process_data = [{k: p[k] for k in ["username", "command", "gpu_memory_usage", "pid"]} for p in gpu.processes]
+        query_data[gpu.index] = {
+            "memory_total": gpu.memory_total,
+            "memory_used": gpu.memory_used,
+            "processes": process_data,
+        }
+    return query_data
 
 
 def log_gpu_stats(gpu_stats: dict, warn_if_in_use: bool = False) -> None:

--- a/benchmarking/runner/utils.py
+++ b/benchmarking/runner/utils.py
@@ -199,7 +199,9 @@ def get_gpu_stats() -> dict:
     query_data = {}
     for gpu in query:
         # Only include certain fields from the process data.
-        process_data = [{k: p[k] for k in ["username", "command", "gpu_memory_usage", "pid"]} for p in gpu.processes]
+        process_data = [
+            {k: p.get(k) for k in ["username", "command", "gpu_memory_usage", "pid"]} for p in gpu.processes
+        ]
         query_data[gpu.index] = {
             "memory_total": gpu.memory_total,
             "memory_used": gpu.memory_used,

--- a/benchmarking/runner/utils.py
+++ b/benchmarking/runner/utils.py
@@ -186,10 +186,15 @@ def human_readable_bytes_repr(size: int) -> str:
 
 
 def get_gpu_stats() -> dict:
-    """Query GPU stats using gpustat and return memory info for each available GPU.
+    """
+    Query GPU stats using gpustat and return memory information and process info for each available GPU.
 
     Returns:
-        dict: Keys are GPU indices; values are dicts with "memory_total" and "memory_used".
+        dict: Keys are GPU indices; values are dicts containing:
+            - "memory_total" (int): Total GPU memory in MiB.
+            - "memory_used" (int): Used GPU memory in MiB.
+            - "processes" (list[dict]): List of processes using the GPU, each with keys:
+                "username", "command", "gpu_memory_usage", "pid".
     """
     # utils.py is also imported in scripts that run before the Curator
     # environment is set up, so import gpustat lazily.


### PR DESCRIPTION
* Adds specific data on each process running on each GPU to the results dict.
  * This dict is dumped in `results.json`, which can be inspected manually or by downstream tooling.
  * This data can be used to assist in debugging failures due to unexpected resource usage.

Question: do we also want to expose this additional data to the console and/or Slack report?  This is currently only available to users via `results.json`.  The concern is being too verbose, especially in the Slack report which is already quite busy.
