### PR TITLE
Onur/add qwen3

### DIFF
--- a/nemo_curator/backends/base.py
+++ b/nemo_curator/backends/base.py
@@ -64,6 +64,8 @@ class BaseStageAdapter:
 
     def __init__(self, stage: "ProcessingStage"):
         self.stage = stage
+        # Lazily initialised in setup() if stage._checkpoint_path is set.
+        self._write_checkpoint_mgr: Any = None
 
     def process_batch(self, tasks: list[Task]) -> list[Task]:
         """Process a batch of tasks.
@@ -78,6 +80,16 @@ class BaseStageAdapter:
         if not hasattr(self, "_timer") or self._timer is None:
             self._timer = StageTimer(self.stage)
 
+        # If the stage has deterministic cached output (file-writing fan-in), use it.
+        cached = self.stage.get_cached_output(tasks)
+        if cached is not None:
+            from loguru import logger as _logger
+            _logger.info(
+                f"Stage '{self.stage.name}': skipping — cached output found "
+                f"({len(cached)} tasks)"
+            )
+            return cached
+
         # Calculate input data size for timer
         input_size = sum(task.num_items for task in tasks)
         # Initialize performance timer for this batch
@@ -86,6 +98,40 @@ class BaseStageAdapter:
         with self._timer.time_process(input_size):
             # Use the batch processing logic
             results = self.stage.process_batch(tasks)
+
+        # ------------------------------------------------------------------
+        # source_files propagation (safety net)
+        # ------------------------------------------------------------------
+        # Guarantee every output task carries source_files, handling:
+        #   - 1:1 transforms that forgot to copy _metadata
+        #   - Fan-out (e.g. ImageReaderStage) — each child inherits parent's source_files
+        #   - Fan-in (N→M) — output gets the union of all inputs' source_files
+        input_source_files: set[str] = set()
+        for task in tasks:
+            input_source_files.update(task._metadata.get("source_files", []))
+
+        if input_source_files:
+            for result in results:
+                existing = set(result._metadata.get("source_files", []))
+                result._metadata["source_files"] = sorted(existing | input_source_files)
+
+        # ------------------------------------------------------------------
+        # Fan-out detection: write expected-count increment for checkpointing
+        # ------------------------------------------------------------------
+        # When a single input task (already tracking source_files) produces N > 1
+        # outputs, this is a secondary fan-out. We write one increment file per
+        # triggering input task so CheckpointManager can compute the total expected
+        # leaf count for that source partition (handles chained fan-outs correctly).
+        if self._write_checkpoint_mgr is not None and len(results) > 1:
+            for input_task in tasks:
+                src: list[str] = input_task._metadata.get("source_files", [])
+                if src:
+                    source_key = "|".join(sorted(src))
+                    self._write_checkpoint_mgr.write_expected_increment(
+                        source_key=source_key,
+                        triggering_task_id=input_task.task_id,
+                        increment=len(results) - 1,
+                    )
 
         # Log performance stats and add to result tasks
         _, stage_perf_stats = self._timer.log_stats()
@@ -116,6 +162,16 @@ class BaseStageAdapter:
             worker_metadata (WorkerMetadata, optional): Information about the worker
         """
         self.stage.setup(worker_metadata)
+        # If the pipeline was started with checkpoint_path, initialise a write-only
+        # CheckpointManager for fan-out increment tracking.
+        checkpoint_path: str | None = getattr(self.stage, "_checkpoint_path", None)
+        if checkpoint_path:
+            from nemo_curator.utils.checkpoint import CheckpointManager
+
+            storage_options: dict[str, Any] = getattr(
+                self.stage, "_checkpoint_storage_options", {}
+            ) or {}
+            self._write_checkpoint_mgr = CheckpointManager(checkpoint_path, storage_options)
 
     def teardown(self) -> None:
         """Teardown the stage once per actor."""

--- a/nemo_curator/models/prompt_formatter.py
+++ b/nemo_curator/models/prompt_formatter.py
@@ -19,10 +19,11 @@ import torch
 from transformers import AutoProcessor
 
 from nemo_curator.models.nemotron_h_vl import _NEMOTRON_VARIANTS_INFO
+from nemo_curator.models.qwen_vl import _QWEN_VARIANTS_INFO
 
 # Mapping of variants to their HuggingFace model IDs
 VARIANT_MAPPING: dict[str, str] = {
-    "qwen": "Qwen/Qwen2.5-VL-7B-Instruct",
+    **_QWEN_VARIANTS_INFO,
     **_NEMOTRON_VARIANTS_INFO,
 }
 
@@ -73,7 +74,7 @@ class PromptFormatter:
                 - "multi_modal_data": Dictionary containing processed "video" inputs
 
         """
-        if self.prompt_variant == "qwen":
+        if self.prompt_variant in ("qwen2.5", "qwen3"):
             return self._generate_qwen_inputs(prompt, video_inputs, override_text_prompt)
 
         if self.prompt_variant.startswith("nemotron"):

--- a/nemo_curator/models/qwen_lm.py
+++ b/nemo_curator/models/qwen_lm.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from loguru import logger
 from transformers import AutoTokenizer
@@ -40,18 +40,33 @@ from nemo_curator.models.base import ModelInterface
 _QWEN_LM_MODEL_ID = "Qwen/Qwen2.5-14B-Instruct"
 _QWEN_LM_MODEL_REVISION = "cf98f3b"
 
+_QWEN_LM_VARIANTS_INFO = {
+    "qwen2.5": _QWEN_LM_MODEL_ID,
+    "qwen3": _QWEN_LM_MODEL_ID,
+}
+
+QwenLMVariant = Literal["qwen2.5", "qwen3"]
+
 
 class QwenLM(ModelInterface):
     """Qwen language model."""
 
     def model_id_names(self) -> list[str]:
-        return [_QWEN_LM_MODEL_ID]
+        return [_QWEN_LM_VARIANTS_INFO[self.model_variant]]
 
-    def __init__(self, model_dir: str, caption_batch_size: int, fp8: bool, max_output_tokens: int):
+    def __init__(
+        self,
+        model_dir: str,
+        caption_batch_size: int,
+        fp8: bool,
+        max_output_tokens: int,
+        model_variant: str = "qwen2.5",
+    ):
         self.model_dir = model_dir
         self.caption_batch_size = caption_batch_size
         self.fp8 = fp8
         self.max_output_tokens = max_output_tokens
+        self.model_variant = model_variant
 
     def setup(self) -> None:
         if not VLLM_AVAILABLE:

--- a/nemo_curator/models/qwen_vl.py
+++ b/nemo_curator/models/qwen_vl.py
@@ -15,7 +15,7 @@
 import pathlib
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from loguru import logger
 
@@ -42,8 +42,38 @@ from nemo_curator.utils import grouping
 _QWEN2_5_VL_MODEL_ID = "Qwen/Qwen2.5-VL-7B-Instruct"
 _QWEN2_5_VL_MODEL_REVISION = "cc59489"
 
+_QWEN3_VL_MODEL_ID = "Qwen/Qwen3-VL-8B-Instruct"
+_QWEN3_VL_MODEL_REVISION = "0c351dd"
+
 _QWEN_VARIANTS_INFO = {
-    "qwen": _QWEN2_5_VL_MODEL_ID,
+    "qwen2.5": _QWEN2_5_VL_MODEL_ID,
+    "qwen3": _QWEN3_VL_MODEL_ID,
+}
+
+_QWEN_REVISIONS_INFO = {
+    "qwen2.5": _QWEN2_5_VL_MODEL_REVISION,
+    "qwen3": _QWEN3_VL_MODEL_REVISION,
+}
+
+QwenVariant = Literal["qwen2.5", "qwen3"]
+
+QWEN_VL_PIXEL_PARAMS: dict[str, dict] = {
+    "qwen2.5": {
+        "image_factor": 28,
+        "min_pixels": 4 * 28 * 28,
+        "max_pixels": 16384 * 28 * 28,
+        "video_min_pixels": 128 * 28 * 28,
+        "video_max_pixels": 768 * 28 * 28,
+        "video_total_pixels": 24576 * 28 * 28,
+    },
+    "qwen3": {
+        "image_factor": 32,
+        "min_pixels": 4 * 32 * 32,
+        "max_pixels": 16384 * 32 * 32,
+        "video_min_pixels": 128 * 32 * 32,
+        "video_max_pixels": 768 * 32 * 32,
+        "video_total_pixels": 24576 * 32 * 32,
+    },
 }
 
 
@@ -67,7 +97,7 @@ class QwenVL(ModelInterface):
         self.max_output_tokens = max_output_tokens
         self.model_does_preprocess = model_does_preprocess
         self.disable_mmcache = disable_mmcache
-        self.stage2_prompt = stage2_prompt_text if stage2_prompt_text else "Please refine this caption: "
+        self.stage2_prompt = stage2_prompt_text or "Please refine this caption: "
         self.verbose = verbose
         self.weight_file = str(pathlib.Path(model_dir) / _QWEN_VARIANTS_INFO[model_variant])
         # Default pattern for stage2 caption generation - matches (.*)(user_prompt)(.*)
@@ -143,15 +173,16 @@ class QwenVL(ModelInterface):
         return generated_text
 
     @classmethod
-    def download_weights_on_node(cls, model_dir: str) -> None:
+    def download_weights_on_node(cls, model_dir: str, variant: str = "qwen2.5") -> None:
         """Download the weights for the QwenVL model on the node."""
-        model_dir_path = Path(model_dir) / _QWEN2_5_VL_MODEL_ID
+        model_id = _QWEN_VARIANTS_INFO[variant]
+        model_dir_path = Path(model_dir) / model_id
         model_dir_path.mkdir(parents=True, exist_ok=True)
         if model_dir_path.exists() and any(model_dir_path.glob("*.safetensors")):
             return
         download_model_from_hf(
-            model_id=_QWEN2_5_VL_MODEL_ID,
+            model_id=model_id,
             local_dir=model_dir_path,
-            revision=_QWEN2_5_VL_MODEL_REVISION,
+            revision=_QWEN_REVISIONS_INFO[variant],
         )
         logger.info(f"QwenVL weights downloaded to: {model_dir_path}")

--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -174,12 +174,23 @@ class Pipeline:
 
         return "\n".join(lines)
 
-    def run(self, executor: BaseExecutor | None = None, initial_tasks: list[Task] | None = None) -> list[Task] | None:
+    def run(
+        self,
+        executor: BaseExecutor | None = None,
+        initial_tasks: list[Task] | None = None,
+        checkpoint_path: str | None = None,
+        checkpoint_storage_options: dict[str, Any] | None = None,
+    ) -> list[Task] | None:
         """Run the pipeline.
 
         Args:
             executor (BaseExecutor): Executor to use
             initial_tasks (list[Task], optional): Initial tasks to start the pipeline with. Defaults to None.
+            checkpoint_path (str, optional): Path to checkpoint directory for resumability.
+                When provided, completed source partitions are skipped on restart.
+                Must be on a shared filesystem (NFS or object storage) for multi-node clusters.
+            checkpoint_storage_options (dict, optional): fsspec storage options for the checkpoint path
+                (e.g. S3 credentials). Defaults to None.
 
         Returns:
             list[Task] | None: List of tasks
@@ -212,4 +223,52 @@ class Pipeline:
                     "The executor will schedule GPU stages on GPUs not held by Serve."
                 )
 
-        return executor.execute(self.stages, initial_tasks)
+        stages = (
+            self._with_checkpoint_stages(self.stages, checkpoint_path, checkpoint_storage_options)
+            if checkpoint_path
+            else self.stages
+        )
+        return executor.execute(stages, initial_tasks)
+
+    def _with_checkpoint_stages(
+        self,
+        stages: list[ProcessingStage],
+        checkpoint_path: str,
+        storage_options: dict[str, Any] | None = None,
+    ) -> list[ProcessingStage]:
+        """Return a new stages list with checkpoint filter/recorder injected.
+
+        - A ``_CheckpointFilterStage`` is inserted after every ``is_source_stage()`` stage.
+        - A ``_CheckpointRecorderStage`` is appended after the last stage.
+        - Every stage gets ``_checkpoint_path`` and ``_checkpoint_storage_options`` set as
+          instance attributes so ``BaseStageAdapter`` can write fan-out increment files.
+
+        This method does NOT mutate ``self.stages``, so calling ``run()`` again is safe.
+        """
+        from nemo_curator.stages.checkpoint import (
+            _CheckpointFilterStage,
+            _CheckpointRecorderStage,
+        )
+
+        storage_options = storage_options or {}
+        result: list[ProcessingStage] = []
+        for stage in stages:
+            # Stamp checkpoint info onto every stage so BaseStageAdapter can write increments
+            stage._checkpoint_path = checkpoint_path
+            stage._checkpoint_storage_options = storage_options
+            result.append(stage)
+            if stage.is_source_stage():
+                result.append(
+                    _CheckpointFilterStage(
+                        checkpoint_path=checkpoint_path,
+                        storage_options=storage_options,
+                    )
+                )
+
+        result.append(
+            _CheckpointRecorderStage(
+                checkpoint_path=checkpoint_path,
+                storage_options=storage_options,
+            )
+        )
+        return result

--- a/nemo_curator/stages/audio/datasets/fleurs/create_initial_manifest.py
+++ b/nemo_curator/stages/audio/datasets/fleurs/create_initial_manifest.py
@@ -100,6 +100,7 @@ class CreateInitialManifestFleursStage(ProcessingStage[_EmptyTask, AudioTask]):
                         task_id=f"task_id_{abs_wav}",
                         dataset_name=f"Fleurs_{self.lang}_{self.split}_{self.raw_data_dir}",
                         filepath_key=self.filepath_key,
+                        _metadata={"source_files": [abs_wav]},
                     )
                 )
         return entries
@@ -111,6 +112,9 @@ class CreateInitialManifestFleursStage(ProcessingStage[_EmptyTask, AudioTask]):
             download_file(file_url, str(dst_folder))
 
         extract_archive(f"{dst_folder}/{self.split}.tar.gz", str(dst_folder), force_extract=True)
+
+    def is_source_stage(self) -> bool:
+        return True
 
     def ray_stage_spec(self) -> dict[str, Any]:
         return {RayStageSpecKeys.IS_FANOUT_STAGE: True}

--- a/nemo_curator/stages/audio/datasets/readspeech/create_initial_manifest.py
+++ b/nemo_curator/stages/audio/datasets/readspeech/create_initial_manifest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import glob
+import hashlib
 import os
 import subprocess
 from dataclasses import dataclass
@@ -67,6 +68,9 @@ class CreateInitialManifestReadSpeechStage(ProcessingStage[_EmptyTask, AudioTask
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.filepath_key, self.text_key]
+
+    def is_source_stage(self) -> bool:
+        return True
 
     def ray_stage_spec(self) -> dict[str, Any]:
         return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
@@ -340,13 +344,16 @@ class CreateInitialManifestReadSpeechStage(ProcessingStage[_EmptyTask, AudioTask
         logger.info(f"Creating manifest with {len(selected_entries)} total samples")
 
         audio_tasks = []
-        for i, entry in enumerate(selected_entries):
+        for entry in selected_entries:
+            filepath = entry.get(self.filepath_key, "")
+            task_id = f"readspeech_{hashlib.sha256(filepath.encode()).hexdigest()[:16]}"
             audio_tasks.append(
                 AudioTask(
                     data=entry,
-                    task_id=f"readspeech_{i}",
+                    task_id=task_id,
                     dataset_name="DNS-ReadSpeech",
                     filepath_key=self.filepath_key,
+                    _metadata={"source_files": [filepath]} if filepath else {},
                 )
             )
 

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -302,6 +302,28 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
             "supports_batch_processing": self.supports_batch_processing(),
         }
 
+    def is_source_stage(self) -> bool:
+        """Whether this stage generates the initial resumable tasks from nothing.
+
+        Override to return ``True`` in stages that start lineage from an
+        ``_EmptyTask`` (e.g. ``FilePartitioningStage``).  When
+        ``Pipeline.run(checkpoint_path=...)`` is used, a
+        ``_CheckpointFilterStage`` is automatically injected *after* every
+        stage that returns ``True`` here.
+        """
+        return False
+
+    def get_cached_output(self, input_tasks: list[Task]) -> list[Task] | None:  # noqa: ARG002
+        """Return pre-existing output tasks if they are already on disk, else None.
+
+        Override in **file-writing fan-in** stages (e.g. dedup stages that
+        write parquet output) to skip re-computation when their deterministic
+        output files already exist from a previous run.
+
+        The default implementation returns ``None`` (always re-compute).
+        """
+        return None
+
     def ray_stage_spec(self) -> dict[str, Any]:
         """Get Ray configuration for this stage.
         Note : This is only used for Ray Data backend.

--- a/nemo_curator/stages/checkpoint.py
+++ b/nemo_curator/stages/checkpoint.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal checkpoint stages injected by Pipeline.run(checkpoint_path=...).
+
+Not part of the public API — use ``Pipeline.run(checkpoint_path=...)`` instead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.stages.resources import Resources
+from nemo_curator.tasks import Task
+
+if TYPE_CHECKING:
+    from nemo_curator.backends.base import WorkerMetadata
+
+
+@dataclass
+class _CheckpointFilterStage(ProcessingStage[Task, Task]):
+    """Skip tasks whose source partitions are already fully complete.
+
+    Injected automatically by :meth:`Pipeline.run` (with ``checkpoint_path``)
+    after every ``is_source_stage()`` stage.  Not intended for direct use.
+
+    A source partition is "complete" when the number of completed leaf tasks
+    recorded in the checkpoint equals (or exceeds) the expected count for that
+    partition.  The expected count accounts for secondary fan-outs via the
+    increment-based tracking written by :class:`BaseStageAdapter`.
+    """
+
+    checkpoint_path: str
+    storage_options: dict[str, Any] = field(default_factory=dict)
+    name: str = "_checkpoint_filter"
+    resources: Resources = field(default_factory=lambda: Resources(cpus=0.1))
+
+    def setup(self, worker_metadata: WorkerMetadata | None = None) -> None:
+        from nemo_curator.utils.checkpoint import CheckpointManager
+
+        self._checkpoint_mgr = CheckpointManager(
+            self.checkpoint_path, self.storage_options
+        ).load()
+
+    def process(self, task: Task) -> list[Task]:
+        source_files: list[str] = task._metadata.get("source_files", [])
+        if not source_files:
+            # Can't make a checkpoint decision without source_files — pass through
+            return [task]
+        if self._checkpoint_mgr.is_task_completed(source_files):
+            logger.debug(
+                f"Checkpoint: skipping completed task {task.task_id} "
+                f"(source_files={source_files[:3]}{'...' if len(source_files) > 3 else ''})"
+            )
+            return []
+        return [task]
+
+
+@dataclass
+class _CheckpointRecorderStage(ProcessingStage[Task, Task]):
+    """Record task completion to the checkpoint after the final pipeline stage.
+
+    Injected automatically by :meth:`Pipeline.run` (with ``checkpoint_path``)
+    as the last stage.  Not intended for direct use.
+
+    Passes the task through unchanged; only side-effect is writing a shard file
+    to ``checkpoint_path/completed/{task_id}.json``.
+    """
+
+    checkpoint_path: str
+    storage_options: dict[str, Any] = field(default_factory=dict)
+    name: str = "_checkpoint_recorder"
+    resources: Resources = field(default_factory=lambda: Resources(cpus=0.1))
+
+    def setup(self, worker_metadata: WorkerMetadata | None = None) -> None:
+        from nemo_curator.utils.checkpoint import CheckpointManager
+
+        # Write-only — no need to load existing state
+        self._checkpoint_mgr = CheckpointManager(
+            self.checkpoint_path, self.storage_options
+        )
+
+    def process(self, task: Task) -> Task:
+        source_files: list[str] = task._metadata.get("source_files", [])
+        if source_files:
+            self._checkpoint_mgr.mark_completed(task.task_id, source_files)
+        else:
+            logger.warning(
+                f"Checkpoint recorder: task {task.task_id} has no source_files in "
+                "_metadata — cannot record completion. This task will be re-processed "
+                "on the next resume."
+            )
+        return task

--- a/nemo_curator/stages/client_partitioning.py
+++ b/nemo_curator/stages/client_partitioning.py
@@ -71,10 +71,12 @@ class ClientPartitioningStage(FilePartitioningStage):
         tasks = []
         total = len(partitions)
         dataset_name = self._get_dataset_name(self.file_paths)
+        from nemo_curator.stages.file_partitioning import _compute_partition_id
+
         for i, group in enumerate(partitions):
             tasks.append(
                 FileGroupTask(
-                    task_id=f"file_group_{i}",
+                    task_id=f"file_group_{_compute_partition_id(group)}",
                     dataset_name=dataset_name,
                     data=group,
                     _metadata={

--- a/nemo_curator/stages/deduplication/fuzzy/connected_components.py
+++ b/nemo_curator/stages/deduplication/fuzzy/connected_components.py
@@ -27,6 +27,8 @@ from nemo_curator.stages.deduplication.fuzzy.utils import CURATOR_FUZZY_DUPLICAT
 from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
 from nemo_curator.stages.deduplication.io_utils import DeduplicationIO
 from nemo_curator.stages.resources import Resources
+from nemo_curator.stages.text.io.writer.utils import get_deterministic_hash
+from nemo_curator.tasks import Task
 from nemo_curator.tasks.file_group import FileGroupTask
 from nemo_curator.utils.file_utils import create_or_overwrite_dir, get_fs
 
@@ -152,6 +154,27 @@ class ConnectedComponentsStage(ProcessingStage[FileGroupTask, FileGroupTask], De
         logger.info("Computing weakly connected components completed successfully!")
         return res
 
+    def get_cached_output(self, input_tasks: list[Task]) -> list[Task] | None:
+        """Return pre-existing output if the deterministic output file already exists."""
+        all_files = [str(f) for task in input_tasks for f in task.data]
+        stable_id = get_deterministic_hash(all_files, "connected_components")
+        output_file = self.output_fs.sep.join([self.output_path, f"{stable_id}.parquet"])
+        if self.output_fs.exists(output_file):
+            logger.info(
+                f"ConnectedComponentsStage: cached output found at {output_file}, skipping."
+            )
+            return [
+                FileGroupTask(
+                    dataset_name=input_tasks[0].dataset_name,
+                    task_id=input_tasks[0].task_id,
+                    data=[output_file],
+                    _metadata={
+                        "storage_options": self.write_kwargs.get("storage_options"),
+                    },
+                )
+            ]
+        return None
+
     def process(self, task: FileGroupTask) -> FileGroupTask:
         err_msg = "ConnectedComponentsStage only support process batch"
         raise NotImplementedError(err_msg)
@@ -173,7 +196,8 @@ class ConnectedComponentsStage(ProcessingStage[FileGroupTask, FileGroupTask], De
         input_files = []
         for task in tasks:
             input_files.extend(task.data)
-        output_file = self.output_fs.sep.join([self.output_path, f"{tasks[0]._uuid}.parquet"])
+        _stable_id = get_deterministic_hash([str(f) for f in input_files], "connected_components")
+        output_file = self.output_fs.sep.join([self.output_path, f"{_stable_id}.parquet"])
         edgelist_columns = [self.source_field, self.destination_field]
         dfs = []
         for input_file in input_files:

--- a/nemo_curator/stages/deduplication/semantic/identify_duplicates.py
+++ b/nemo_curator/stages/deduplication/semantic/identify_duplicates.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.text.io.writer.utils import get_deterministic_hash
-from nemo_curator.tasks import FileGroupTask
+from nemo_curator.tasks import FileGroupTask, Task
 from nemo_curator.utils.file_utils import check_disallowed_kwargs
 
 
@@ -61,6 +61,29 @@ class IdentifyDuplicatesStage(ProcessingStage[FileGroupTask, FileGroupTask]):
 
         # break each file into 10 row groups by default
         self._num_row_groups_hint = self._num_row_groups_hint if self._num_row_groups_hint is not None else 10
+
+    def get_cached_output(self, input_tasks: list[Task]) -> list[Task] | None:
+        """Return pre-existing output if the deterministic output file already exists."""
+        all_files = [file for task in input_tasks for file in task.data]
+        output_file = os.path.join(
+            self.output_path,
+            get_deterministic_hash(all_files, input_tasks[0].task_id) + ".parquet",
+        )
+        if os.path.exists(output_file):
+            from loguru import logger
+
+            logger.info(
+                f"IdentifyDuplicatesStage: cached output found at {output_file}, skipping."
+            )
+            return [
+                FileGroupTask(
+                    task_id=f"identify_duplicates_{get_deterministic_hash(all_files, input_tasks[0].task_id)}",
+                    dataset_name=input_tasks[0].dataset_name,
+                    data=[output_file],
+                    _metadata={**input_tasks[0]._metadata},
+                )
+            ]
+        return None
 
     def process(self, task: FileGroupTask) -> FileGroupTask:
         msg = "RemovalStage does not support single task processing"

--- a/nemo_curator/stages/deduplication/semantic/kmeans.py
+++ b/nemo_curator/stages/deduplication/semantic/kmeans.py
@@ -24,7 +24,8 @@ from nemo_curator.stages.deduplication.io_utils import DeduplicationIO
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.stages.text.embedders.utils import create_list_series_from_1d_or_2d_ar
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.stages.text.io.writer.utils import get_deterministic_hash
+from nemo_curator.tasks import FileGroupTask, Task, _EmptyTask
 from nemo_curator.utils.file_utils import FILETYPE_TO_DEFAULT_EXTENSIONS, check_disallowed_kwargs
 
 from .utils import break_parquet_partition_into_groups, get_array_from_df
@@ -114,6 +115,36 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], Dedupl
 
         self.name = "KMeansStage"
         self.resources = Resources(cpus=1.0, gpus=1.0)
+
+    def get_cached_output(self, input_tasks: list[Task]) -> list[Task] | None:
+        """Return a dummy _EmptyTask if the output_path already contains KMeans output.
+
+        KMeans writes to centroid={k}/ subdirectories. We check if ANY centroid
+        directory exists in output_path as a proxy for completion.
+        """
+        import os
+
+        from nemo_curator.utils.file_utils import get_fs
+
+        try:
+            storage_options = getattr(self, "output_storage_options", None) or {}
+            fs = get_fs(self.output_path, storage_options)
+            if fs.exists(self.output_path) and fs.ls(self.output_path):
+                logger.info(
+                    f"KMeansReadFitWriteStage: output directory {self.output_path} "
+                    "already populated, skipping."
+                )
+                return [
+                    _EmptyTask(
+                        task_id="kmeans_cached",
+                        dataset_name=input_tasks[0].dataset_name if input_tasks else "kmeans",
+                        data=None,
+                        _metadata=input_tasks[0]._metadata if input_tasks else {},
+                    )
+                ]
+        except Exception:  # noqa: BLE001
+            pass
+        return None
 
     def process(self, task: FileGroupTask) -> _EmptyTask:
         msg = "KMeansReadFitWriteStage does not support single-task processing"
@@ -207,7 +238,8 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], Dedupl
             # Assign distances using the fitted cluster centers
             df = self._assign_distances(df, self.embedding_field, self.kmeans.cluster_centers_)  # noqa: PLW2901
 
-            output_filename = f"{tasks[0]._uuid}_{i}"
+            _all_input_files = [str(f) for task in tasks for f in task.data]
+            output_filename = f"{get_deterministic_hash(_all_input_files, str(i))}_{i}"
             # Write results for this subgroup
             self.write_parquet(
                 df,

--- a/nemo_curator/stages/deduplication/semantic/pairwise_io.py
+++ b/nemo_curator/stages/deduplication/semantic/pairwise_io.py
@@ -65,6 +65,9 @@ class ClusterWiseFilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask
         self.fs = get_fs(self.input_path, storage_options=self.storage_options)
         self.path_normalizer = self.fs.unstrip_protocol if is_remote_url(self.input_path) else (lambda x: x)
 
+    def is_source_stage(self) -> bool:
+        return True
+
     def ray_stage_spec(self) -> dict[str, Any]:
         """Ray stage specification for this stage."""
         return {
@@ -118,6 +121,7 @@ class ClusterWiseFilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask
                 _metadata={
                     "centroid_id": centroid_id,
                     "filetype": "parquet",
+                    "source_files": partition_files,
                 },
             )
             tasks.append(pairwise_task)

--- a/nemo_curator/stages/file_partitioning.py
+++ b/nemo_curator/stages/file_partitioning.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 from dataclasses import dataclass
 from typing import Any
 
@@ -27,6 +28,16 @@ from nemo_curator.utils.file_utils import (
     infer_dataset_name_from_path,
     parse_bytes_string_to_int,
 )
+
+
+def _compute_partition_id(files: list) -> str:
+    """Return a stable 16-char hex ID for a partition based on its sorted file paths.
+
+    Uses the sorted string representations so the ID is independent of enumeration
+    order and stable across runs even when the overall file set changes.
+    """
+    content = "|".join(sorted(str(f) for f in files)).encode()
+    return hashlib.sha256(content).hexdigest()[:16]
 
 
 @dataclass
@@ -96,6 +107,9 @@ class FilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], []
+
+    def is_source_stage(self) -> bool:
+        return True
 
     def ray_stage_spec(self) -> dict[str, Any]:
         """Ray stage specification for this stage."""
@@ -177,7 +191,7 @@ class FilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
                 logger.info(f"Reached limit of {self.limit} file groups")
                 break
             file_task = FileGroupTask(
-                task_id=f"file_group_{i}",
+                task_id=f"file_group_{_compute_partition_id(file_group)}",
                 dataset_name=dataset_name,
                 data=file_group,
                 _metadata={

--- a/nemo_curator/stages/interleaved/pdf/nemotron_parse/partitioning.py
+++ b/nemo_curator/stages/interleaved/pdf/nemotron_parse/partitioning.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field
 from typing import Any
@@ -80,6 +81,9 @@ class PDFPartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], []
 
+    def is_source_stage(self) -> bool:
+        return True
+
     def xenna_stage_spec(self) -> dict[str, Any]:
         return {"num_workers_per_node": 1}
 
@@ -129,7 +133,8 @@ class PDFPartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
         for i in range(0, len(entries), self.pdfs_per_task):
             batch = entries[i : i + self.pdfs_per_task]
             task_idx = i // self.pdfs_per_task
-            task_id = f"pdf_batch_{task_idx:06d}"
+            _batch_hash = hashlib.sha256("|".join(batch).encode()).hexdigest()[:16]
+            task_id = f"pdf_batch_{_batch_hash}"
             tasks.append(
                 FileGroupTask(
                     task_id=task_id,

--- a/nemo_curator/stages/text/download/base/url_generation.py
+++ b/nemo_curator/stages/text/download/base/url_generation.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
@@ -69,13 +70,16 @@ class URLGenerationStage(ProcessingStage[_EmptyTask, FileGroupTask]):
 
         return [
             FileGroupTask(
-                task_id=f"{task.task_id}_{i}",
+                task_id=f"url_{hashlib.sha256(url.encode()).hexdigest()[:16]}",
                 dataset_name=task.dataset_name,
                 data=[url],
-                _metadata={"source_url": url},
+                _metadata={"source_url": url, "source_files": [url]},
             )
-            for i, url in enumerate(urls)
+            for url in urls
         ]
+
+    def is_source_stage(self) -> bool:
+        return True
 
     def ray_stage_spec(self) -> dict[str, Any]:
         return {

--- a/nemo_curator/stages/video/caption/caption_enhancement.py
+++ b/nemo_curator/stages/video/caption/caption_enhancement.py
@@ -45,7 +45,7 @@ class CaptionEnhancementStage(ProcessingStage[VideoTask, VideoTask]):
     """
 
     model_dir: str = "models/qwen"
-    model_variant: str = "qwen"
+    model_variant: str = "qwen2.5"
     prompt_variant: str = "default"
     prompt_text: str | None = None
     model_batch_size: int = 128
@@ -68,12 +68,13 @@ class CaptionEnhancementStage(ProcessingStage[VideoTask, VideoTask]):
         )
 
     def _initialize_model(self) -> None:
-        if self.model_variant == "qwen":
+        if self.model_variant in ("qwen2.5", "qwen3"):
             self.model = QwenLM(
                 model_dir=self.model_dir,
                 caption_batch_size=self.model_batch_size,
                 fp8=self.fp8,
                 max_output_tokens=self.max_output_tokens,
+                model_variant=self.model_variant,
             )
         else:
             msg = f"Unsupported model variant: {self.model_variant}"

--- a/nemo_curator/stages/video/caption/caption_generation.py
+++ b/nemo_curator/stages/video/caption/caption_generation.py
@@ -35,7 +35,7 @@ class CaptionGenerationStage(ProcessingStage[VideoTask, VideoTask]):
     """
 
     model_dir: str = "models/qwen"
-    model_variant: str = "qwen"
+    model_variant: str = "qwen2.5"
     caption_batch_size: int = 16
     fp8: bool = False
     max_output_tokens: int = 512
@@ -53,7 +53,7 @@ class CaptionGenerationStage(ProcessingStage[VideoTask, VideoTask]):
         return ["data"], ["clips"]
 
     def _initialize_model(self) -> None:
-        if self.model_variant == "qwen":
+        if self.model_variant in ("qwen2.5", "qwen3"):
             self.model = QwenVL(
                 model_dir=self.model_dir,
                 model_variant=self.model_variant,
@@ -79,8 +79,8 @@ class CaptionGenerationStage(ProcessingStage[VideoTask, VideoTask]):
 
     def setup_on_node(self, node_info: NodeInfo, worker_metadata: WorkerMetadata) -> None:  # noqa: ARG002
         """Download weights and initialize vLLM once per node to avoid torch.compile race conditions."""
-        if self.model_variant == "qwen":
-            QwenVL.download_weights_on_node(self.model_dir)
+        if self.model_variant in ("qwen2.5", "qwen3"):
+            QwenVL.download_weights_on_node(self.model_dir, variant=self.model_variant)
         elif self.model_variant.startswith("nemotron"):
             NemotronHVL.download_weights_on_node(self.model_dir, variant=self.model_variant)
         self._initialize_model()

--- a/nemo_curator/stages/video/caption/caption_preparation.py
+++ b/nemo_curator/stages/video/caption/caption_preparation.py
@@ -19,6 +19,7 @@ from loguru import logger
 
 from nemo_curator.backends.base import WorkerMetadata
 from nemo_curator.models.prompt_formatter import PromptFormatter
+from nemo_curator.models.qwen_vl import QWEN_VL_PIXEL_PARAMS
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks.video import VideoTask, _Window
 from nemo_curator.utils import windowing_utils
@@ -130,6 +131,7 @@ class CaptionPreparationStage(ProcessingStage[VideoTask, VideoTask]):
                     skip_resize=self._skip_intermediate_resize,
                     return_bytes=self.generate_previews,
                     num_threads=max(int(self.resources.cpus), 1),
+                    pixel_params=QWEN_VL_PIXEL_PARAMS.get(self.model_variant),
                 ),
             ):
                 prompt = _get_prompt(

--- a/nemo_curator/utils/checkpoint.py
+++ b/nemo_curator/utils/checkpoint.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+import fsspec
+from loguru import logger
+
+from nemo_curator.utils.file_utils import get_fs
+
+
+def _path_join(base: str, *parts: str) -> str:
+    """Join path components, handling both local and remote (s3://, gs://) paths."""
+    if "://" in base:
+        return "/".join([base.rstrip("/")] + list(parts))
+    import os
+
+    return os.path.join(base, *parts)
+
+
+class CheckpointManager:
+    """Manages pipeline checkpoint state for resumability.
+
+    Uses sharded files to avoid distributed write conflicts — one file per event:
+
+    - ``completed/{task_id}.json``: written by _CheckpointRecorderStage after each leaf task.
+    - ``expected_increments/{source_key_hash}_{task_id}.json``: written by BaseStageAdapter
+      whenever a stage produces N > 1 outputs from a single input that already has
+      ``source_files``. Each increment file stores ``increment = N - 1``.
+
+    On load, ``expected[source_key] = 1 + sum(increments_for_source_key)``.
+    ``is_task_completed()`` returns True when ``completed_count >= expected``.
+
+    This correctly handles chained fan-outs: if Stage1 produces 10 from 1 partition
+    and Stage2 produces 3 from each of those 10 batches, the partition is only marked
+    complete after all 30 leaf tasks record completion.
+    """
+
+    def __init__(self, checkpoint_path: str, storage_options: dict[str, Any] | None = None):
+        self.checkpoint_path = checkpoint_path
+        self.storage_options = storage_options or {}
+        self._completed_path = _path_join(checkpoint_path, "completed")
+        self._increments_path = _path_join(checkpoint_path, "expected_increments")
+        # Populated by load()
+        self._expected: dict[str, int] = {}
+        self._completed_counts: dict[str, int] = defaultdict(int)
+
+    # ------------------------------------------------------------------
+    # Read API
+    # ------------------------------------------------------------------
+
+    def load(self) -> "CheckpointManager":
+        """Read all shard files from the checkpoint directory.
+
+        Builds ``_expected`` and ``_completed_counts`` in memory.
+        Safe to call concurrently with writers (worst case: a newly written shard
+        is missed and the task is processed again — never incorrect data).
+        """
+        fs = get_fs(self.checkpoint_path, self.storage_options)
+
+        # Load expected increments
+        self._expected = {}
+        if fs.exists(self._increments_path):
+            try:
+                increment_files = fs.ls(self._increments_path, detail=False)
+                for fpath in increment_files:
+                    if not str(fpath).endswith(".json"):
+                        continue
+                    try:
+                        with fsspec.open(fpath, "r", **self.storage_options) as f:
+                            data = json.load(f)
+                        source_key = data["source_key"]
+                        increment = int(data["increment"])
+                        self._expected[source_key] = self._expected.get(source_key, 1) + increment
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning(f"Checkpoint: failed to read increment file {fpath}: {e}")
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"Checkpoint: failed to list increment files: {e}")
+
+        # Load completed counts
+        self._completed_counts = defaultdict(int)
+        if fs.exists(self._completed_path):
+            try:
+                completed_files = fs.ls(self._completed_path, detail=False)
+                for fpath in completed_files:
+                    if not str(fpath).endswith(".json"):
+                        continue
+                    try:
+                        with fsspec.open(fpath, "r", **self.storage_options) as f:
+                            data = json.load(f)
+                        source_key = data["source_key"]
+                        self._completed_counts[source_key] += 1
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning(f"Checkpoint: failed to read completed file {fpath}: {e}")
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"Checkpoint: failed to list completed files: {e}")
+
+        total_completed = sum(self._completed_counts.values())
+        n_fanout_keys = sum(1 for v in self._expected.values() if v > 1)
+        logger.info(
+            f"Checkpoint loaded from {self.checkpoint_path}: "
+            f"{total_completed} completed task shards, "
+            f"{n_fanout_keys} source keys with secondary fan-outs"
+        )
+        return self
+
+    def get_completed_source_keys(self) -> frozenset[str]:
+        """Return source_keys that have completed all expected leaf tasks."""
+        return frozenset(
+            key
+            for key in self._completed_counts
+            if self._completed_counts[key] >= self._expected.get(key, 1)
+        )
+
+    def is_task_completed(self, source_files: list[str]) -> bool:
+        """Return True if all expected leaf tasks for this source partition are done."""
+        if not source_files:
+            return False
+        source_key = "|".join(sorted(source_files))
+        expected = self._expected.get(source_key, 1)
+        completed = self._completed_counts.get(source_key, 0)
+        return completed >= expected
+
+    # ------------------------------------------------------------------
+    # Write API
+    # ------------------------------------------------------------------
+
+    def mark_completed(self, task_id: str, source_files: list[str]) -> None:
+        """Write a completed shard for the given task.
+
+        Each call writes a unique file (keyed by task_id), so concurrent writers
+        never clobber each other.
+        """
+        if not source_files:
+            return
+        source_key = "|".join(sorted(source_files))
+        safe_task_id = task_id.replace("/", "_").replace(" ", "_").replace(":", "_")
+        path = _path_join(self._completed_path, f"{safe_task_id}.json")
+        self._write_json(
+            path,
+            {
+                "source_key": source_key,
+                "completed_at": datetime.now(tz=timezone.utc).isoformat(),
+            },
+        )
+
+    def write_expected_increment(
+        self, source_key: str, triggering_task_id: str, increment: int
+    ) -> None:
+        """Write an expected-count increment shard.
+
+        Called by BaseStageAdapter when it detects a fan-out:
+        one input with source_files produces N > 1 outputs → increment = N - 1.
+
+        Handles chained fan-outs correctly because each triggering task writes its
+        own file (unique filename = no races), and expected is summed on load.
+        """
+        key_hash = hashlib.sha256(source_key.encode()).hexdigest()[:16]
+        safe_task_id = (
+            triggering_task_id.replace("/", "_").replace(" ", "_").replace(":", "_")
+        )
+        filename = f"{key_hash}_{safe_task_id}.json"
+        path = _path_join(self._increments_path, filename)
+        self._write_json(path, {"source_key": source_key, "increment": increment})
+
+    # ------------------------------------------------------------------
+    # Class-level helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def exists(
+        checkpoint_path: str, storage_options: dict[str, Any] | None = None
+    ) -> bool:
+        """Return True if any checkpoint data exists at the given path."""
+        try:
+            fs = get_fs(checkpoint_path, storage_options or {})
+            return fs.exists(checkpoint_path)
+        except Exception:  # noqa: BLE001
+            return False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _write_json(self, path: str, data: dict[str, Any]) -> None:
+        """Write JSON data to path, ensuring parent directories exist."""
+        fs = get_fs(path, self.storage_options)
+        parent = path.rsplit("/", 1)[0] if "/" in path else path
+        try:
+            fs.makedirs(parent, exist_ok=True)
+        except Exception:  # noqa: BLE001
+            pass  # S3 / GCS don't need explicit directory creation
+        with fsspec.open(path, "w", **self.storage_options) as f:
+            json.dump(data, f)

--- a/nemo_curator/utils/windowing_utils.py
+++ b/nemo_curator/utils/windowing_utils.py
@@ -90,6 +90,7 @@ def split_video_into_windows(  # noqa: PLR0913
     return_bytes: bool = False,
     return_video_frames: bool = True,
     num_threads: int = 1,
+    pixel_params: dict | None = None,
 ) -> tuple[list[bytes], list[torch.Tensor | None], list[WindowFrameInfo]]:
     """Calculate windows and return video inputs for language model from input clips.
 
@@ -137,6 +138,7 @@ def split_video_into_windows(  # noqa: PLR0913
                 num_frames_to_use=num_frames_to_use,
                 flip_input=flip_input,
                 skip_resize=skip_resize,
+                pixel_params=pixel_params,
             )
 
             index = 0
@@ -305,6 +307,7 @@ def fetch_video(  # noqa: C901, PLR0911, PLR0912, PLR0913
     num_frames_to_use: int = 0,
     flip_input: bool = False,
     skip_resize: bool = False,
+    pixel_params: dict | None = None,
 ) -> tuple[torch.Tensor, list[int]]:
     """Load and preprocess video frames from a file.
 
@@ -332,15 +335,20 @@ def fetch_video(  # noqa: C901, PLR0911, PLR0912, PLR0913
     nframes, _, height, width = video.shape
 
     if do_preprocess or not skip_resize:
+        _p = pixel_params or {}
+        _image_factor = _p.get("image_factor", IMAGE_FACTOR)
+        _video_min_pixels = _p.get("video_min_pixels", VIDEO_MIN_PIXELS)
+        _video_max_pixels = _p.get("video_max_pixels", VIDEO_MAX_PIXELS)
+        _video_total_pixels = _p.get("video_total_pixels", VIDEO_TOTAL_PIXELS)
         max_pixels = max(
-            min(VIDEO_MAX_PIXELS, int(VIDEO_TOTAL_PIXELS / nframes * FRAME_FACTOR)),
-            int(VIDEO_MIN_PIXELS * 1.05),
+            min(_video_max_pixels, int(_video_total_pixels / nframes * FRAME_FACTOR)),
+            int(_video_min_pixels * 1.05),
         )
         resized_height, resized_width = smart_resize(
             height,
             width,
-            factor=IMAGE_FACTOR,
-            min_pixels=VIDEO_MIN_PIXELS,
+            factor=_image_factor,
+            min_pixels=_video_min_pixels,
             max_pixels=max_pixels,
         )
 

--- a/tests/models/test_qwen_vl.py
+++ b/tests/models/test_qwen_vl.py
@@ -34,7 +34,7 @@ class TestQwenVL:
         self.vllm_patcher.start()
 
         self.model_dir = "/test/model/dir"
-        self.model_variant = "qwen"
+        self.model_variant = "qwen2.5"
         self.caption_batch_size = 4
         self.qwen_vl = QwenVL(
             model_dir=self.model_dir,
@@ -55,8 +55,8 @@ class TestQwenVL:
     def test_constants(self) -> None:
         """Test that module constants are correctly defined."""
         assert _QWEN2_5_VL_MODEL_ID == "Qwen/Qwen2.5-VL-7B-Instruct"
-        assert "qwen" in _QWEN_VARIANTS_INFO
-        assert _QWEN_VARIANTS_INFO["qwen"] == _QWEN2_5_VL_MODEL_ID
+        assert "qwen2.5" in _QWEN_VARIANTS_INFO
+        assert _QWEN_VARIANTS_INFO["qwen2.5"] == _QWEN2_5_VL_MODEL_ID
 
     def test_initialization_default_parameters(self) -> None:
         """Test initialization with default parameters."""
@@ -92,9 +92,9 @@ class TestQwenVL:
     def test_initialization_different_variant(self) -> None:
         """Test initialization with different model variant."""
         # Note: This test assumes the variant exists in _QWEN_VARIANTS_INFO
-        qwen_vl = QwenVL(model_dir="/another/path", model_variant="qwen", caption_batch_size=8)
+        qwen_vl = QwenVL(model_dir="/another/path", model_variant="qwen2.5", caption_batch_size=8)
 
-        expected_weight_file = str(pathlib.Path("/another/path") / _QWEN_VARIANTS_INFO["qwen"])
+        expected_weight_file = str(pathlib.Path("/another/path") / _QWEN_VARIANTS_INFO["qwen2.5"])
         assert qwen_vl.weight_file == expected_weight_file
 
     def test_model_id_names_property(self) -> None:
@@ -375,8 +375,8 @@ class TestQwenVL:
         assert self.qwen_vl.weight_file == expected_path
 
         # Test with different paths
-        qwen_vl2 = QwenVL(model_dir="/different/path", model_variant="qwen", caption_batch_size=1)
-        expected_path2 = str(pathlib.Path("/different/path") / _QWEN_VARIANTS_INFO["qwen"])
+        qwen_vl2 = QwenVL(model_dir="/different/path", model_variant="qwen2.5", caption_batch_size=1)
+        expected_path2 = str(pathlib.Path("/different/path") / _QWEN_VARIANTS_INFO["qwen2.5"])
         assert qwen_vl2.weight_file == expected_path2
 
     def test_max_output_tokens_parameter(self) -> None:

--- a/tests/stages/common/test_client_partitioning.py
+++ b/tests/stages/common/test_client_partitioning.py
@@ -18,6 +18,7 @@ import pytest
 
 from nemo_curator.backends.base import WorkerMetadata
 from nemo_curator.stages.client_partitioning import ClientPartitioningStage, _read_list_json_rel
+from nemo_curator.stages.file_partitioning import _compute_partition_id
 from nemo_curator.tasks import FileGroupTask, _EmptyTask
 
 
@@ -109,7 +110,9 @@ class TestClientPartitioningStage:
         assert len(result) == 3
         assert isinstance(result[0], FileGroupTask)
         assert str(result[0].data[0]).endswith("file1.jsonl")
-        assert result[0].task_id == "file_group_0"
+        # task_id is now a content-hash based ID — check format, not exact value
+        assert result[0].task_id.startswith("file_group_")
+        assert len(result[0].task_id) == len("file_group_") + 16  # 16-char hex hash
         assert result[0]._metadata["partition_index"] == 0
         assert result[0]._metadata["total_partitions"] == 3
 

--- a/tests/stages/common/test_file_partitioning.py
+++ b/tests/stages/common/test_file_partitioning.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from nemo_curator.stages.file_partitioning import FilePartitioningStage
+from nemo_curator.stages.file_partitioning import FilePartitioningStage, _compute_partition_id
 from nemo_curator.tasks import FileGroupTask, _EmptyTask
 
 
@@ -135,7 +135,7 @@ class TestFilePartitioningStage:
         assert isinstance(result[0], FileGroupTask)
         assert result[0].data == [test_files[0]]
         assert result[0].dataset_name == "path"
-        assert result[0].task_id == "file_group_0"
+        assert result[0].task_id == f"file_group_{_compute_partition_id([test_files[0]])}"
 
     def test_process_with_files_per_partition(self, empty_task: _EmptyTask, tmp_path: Path):
         """Test processing with files_per_partition setting."""
@@ -167,7 +167,7 @@ class TestFilePartitioningStage:
 
         # Verify metadata
         for i, task in enumerate(result):
-            assert task.task_id == f"file_group_{i}"
+            assert task.task_id == f"file_group_{_compute_partition_id(task.data)}"
             assert task._metadata["partition_index"] == i
             assert task._metadata["total_partitions"] == 5  # Total partitions before limit
 

--- a/tests/utils/test_checkpoint.py
+++ b/tests/utils/test_checkpoint.py
@@ -1,0 +1,499 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for CheckpointManager and checkpoint stages.
+
+Tests cover:
+- Basic load/read/write lifecycle
+- Single fan-out: 1 source → N leaves; all must complete
+- Partial fan-out: 1 source → N leaves; M < N complete → not done
+- Chained fan-outs: 1 source → Stage1: 10 batches → Stage2: each 3 sub-batches → 30 leaves
+- _CheckpointFilterStage: skips completed, passes incomplete
+- _CheckpointRecorderStage: writes shard, passes task through
+- FilePartitioningStage: hash-based task IDs are stable across runs
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nemo_curator.utils.checkpoint import CheckpointManager, _path_join
+
+if TYPE_CHECKING:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _source_key(source_files: list[str]) -> str:
+    return "|".join(sorted(source_files))
+
+
+# ---------------------------------------------------------------------------
+# _path_join
+# ---------------------------------------------------------------------------
+
+class TestPathJoin:
+    def test_local_path(self):
+        assert _path_join("/a/b", "c", "d.json") == "/a/b/c/d.json"
+
+    def test_remote_path(self):
+        result = _path_join("s3://bucket/prefix", "sub", "file.json")
+        assert result == "s3://bucket/prefix/sub/file.json"
+
+    def test_trailing_slash_stripped(self):
+        assert _path_join("s3://bucket/prefix/", "file.json") == "s3://bucket/prefix/file.json"
+
+
+# ---------------------------------------------------------------------------
+# CheckpointManager — basic write/read cycle
+# ---------------------------------------------------------------------------
+
+class TestCheckpointManagerBasic:
+    def test_exists_returns_false_for_nonexistent(self, tmp_path: Path):
+        assert not CheckpointManager.exists(str(tmp_path / "nonexistent"))
+
+    def test_exists_returns_true_after_creation(self, tmp_path: Path):
+        ckpt_dir = tmp_path / "ckpt"
+        ckpt_dir.mkdir()
+        assert CheckpointManager.exists(str(ckpt_dir))
+
+    def test_load_empty_directory(self, tmp_path: Path):
+        mgr = CheckpointManager(str(tmp_path / "ckpt")).load()
+        assert mgr._expected == {}
+        assert dict(mgr._completed_counts) == {}
+
+    def test_is_task_completed_returns_false_when_nothing_recorded(self, tmp_path: Path):
+        mgr = CheckpointManager(str(tmp_path / "ckpt")).load()
+        assert not mgr.is_task_completed(["file_a.tar"])
+
+    def test_is_task_completed_returns_false_for_empty_source_files(self, tmp_path: Path):
+        mgr = CheckpointManager(str(tmp_path / "ckpt")).load()
+        assert not mgr.is_task_completed([])
+
+    def test_mark_completed_then_load(self, tmp_path: Path):
+        ckpt_path = str(tmp_path / "ckpt")
+        mgr = CheckpointManager(ckpt_path)
+        mgr.mark_completed("task_001", ["file_a.tar"])
+
+        mgr2 = CheckpointManager(ckpt_path).load()
+        assert mgr2.is_task_completed(["file_a.tar"])
+
+    def test_mark_completed_multiple_sources(self, tmp_path: Path):
+        ckpt_path = str(tmp_path / "ckpt")
+        mgr = CheckpointManager(ckpt_path)
+        mgr.mark_completed("task_a", ["file_a.tar"])
+        mgr.mark_completed("task_b", ["file_b.tar"])
+
+        mgr2 = CheckpointManager(ckpt_path).load()
+        assert mgr2.is_task_completed(["file_a.tar"])
+        assert mgr2.is_task_completed(["file_b.tar"])
+        assert not mgr2.is_task_completed(["file_c.tar"])
+
+    def test_source_key_ordering_is_stable(self, tmp_path: Path):
+        """source_key uses sorted order so ["b","a"] == ["a","b"]."""
+        ckpt_path = str(tmp_path / "ckpt")
+        mgr = CheckpointManager(ckpt_path)
+        mgr.mark_completed("task_x", ["b.tar", "a.tar"])
+
+        mgr2 = CheckpointManager(ckpt_path).load()
+        # Both orderings should match
+        assert mgr2.is_task_completed(["a.tar", "b.tar"])
+        assert mgr2.is_task_completed(["b.tar", "a.tar"])
+
+
+# ---------------------------------------------------------------------------
+# CheckpointManager — single fan-out (1 source → N leaves)
+# ---------------------------------------------------------------------------
+
+class TestCheckpointManagerSingleFanOut:
+    def test_single_fanout_not_complete_until_all_leaves_recorded(self, tmp_path: Path):
+        """1 source → 5 leaves; after 4 completions, not done; after 5th, done."""
+        ckpt_path = str(tmp_path / "ckpt")
+        source = ["a.tar"]
+        N = 5
+
+        # Write increment: source → N leaves
+        mgr_write = CheckpointManager(ckpt_path)
+        mgr_write.write_expected_increment(
+            source_key=_source_key(source),
+            triggering_task_id="file_group_abc123",
+            increment=N - 1,  # 4
+        )
+
+        # Write N-1 completions
+        for i in range(N - 1):
+            mgr_write.mark_completed(f"leaf_task_{i}", source)
+
+        mgr_read = CheckpointManager(ckpt_path).load()
+        # expected = 1 + (N-1) = N = 5; completed = 4 → not done
+        assert not mgr_read.is_task_completed(source)
+
+        # Write the last completion
+        mgr_write.mark_completed(f"leaf_task_{N - 1}", source)
+        mgr_read2 = CheckpointManager(ckpt_path).load()
+        assert mgr_read2.is_task_completed(source)
+
+    def test_no_increment_written_means_expected_is_1(self, tmp_path: Path):
+        """Without secondary fan-out, 1 completion is enough."""
+        ckpt_path = str(tmp_path / "ckpt")
+        source = ["b.tar"]
+        mgr = CheckpointManager(ckpt_path)
+        mgr.mark_completed("single_leaf", source)
+
+        mgr2 = CheckpointManager(ckpt_path).load()
+        assert mgr2.is_task_completed(source)
+
+    def test_partial_fanout_not_complete(self, tmp_path: Path):
+        """7 out of 10 completed — should NOT be marked done."""
+        ckpt_path = str(tmp_path / "ckpt")
+        source = ["c.tar"]
+        N = 10
+
+        mgr = CheckpointManager(ckpt_path)
+        mgr.write_expected_increment(_source_key(source), "trig_task_xyz", N - 1)
+        for i in range(7):
+            mgr.mark_completed(f"leaf_{i}", source)
+
+        mgr2 = CheckpointManager(ckpt_path).load()
+        assert not mgr2.is_task_completed(source)
+
+
+# ---------------------------------------------------------------------------
+# CheckpointManager — chained fan-outs
+# ---------------------------------------------------------------------------
+
+class TestCheckpointManagerChainedFanOut:
+    def test_chained_fanout_correct_expected_count(self, tmp_path: Path):
+        """1 source → Stage1: 10 batches → Stage2: each 3 sub-batches → 30 leaves.
+
+        Stage1 fan-out: 1 FileGroupTask triggers N=10 → increment written once: +9
+        Stage2 fan-out: each of 10 batches triggers N=3 → increment written 10 times: +2 each
+
+        expected = 1 + 9 + 10*2 = 30
+        """
+        ckpt_path = str(tmp_path / "ckpt")
+        source = ["d.tar"]
+        key = _source_key(source)
+
+        mgr = CheckpointManager(ckpt_path)
+
+        # Stage1 fan-out: 1 input → 10 batches
+        mgr.write_expected_increment(key, "file_group_d", increment=9)
+
+        # Stage2 fan-out: each of 10 batches → 3 sub-batches
+        for batch_i in range(10):
+            mgr.write_expected_increment(key, f"batch_{batch_i}", increment=2)
+
+        # Complete 29 out of 30 leaves
+        for leaf_i in range(29):
+            mgr.mark_completed(f"sub_batch_{leaf_i}", source)
+
+        mgr2 = CheckpointManager(ckpt_path).load()
+        assert not mgr2.is_task_completed(source)  # 29 < 30
+
+        # Complete the 30th
+        mgr.mark_completed("sub_batch_29", source)
+        mgr3 = CheckpointManager(ckpt_path).load()
+        assert mgr3.is_task_completed(source)  # 30 >= 30
+
+    def test_chained_fanout_partial_second_stage(self, tmp_path: Path):
+        """Same chained setup but only Stage1 completes partially — not done."""
+        ckpt_path = str(tmp_path / "ckpt")
+        source = ["e.tar"]
+        key = _source_key(source)
+
+        mgr = CheckpointManager(ckpt_path)
+
+        # Only the Stage1 increment (no Stage2 increments yet, only 5 Stage2 batches written)
+        mgr.write_expected_increment(key, "fg_e", increment=9)  # expected so far: 10
+        for batch_i in range(5):
+            mgr.write_expected_increment(key, f"batch_e_{batch_i}", increment=2)
+        # expected now: 1+9+5*2 = 20 (Stage2 only ran for 5 of 10 batches before crash)
+
+        # 15 completions
+        for leaf_i in range(15):
+            mgr.mark_completed(f"leaf_e_{leaf_i}", source)
+
+        mgr2 = CheckpointManager(ckpt_path).load()
+        # 15 < 20 — not complete
+        assert not mgr2.is_task_completed(source)
+
+
+# ---------------------------------------------------------------------------
+# CheckpointManager — get_completed_source_keys
+# ---------------------------------------------------------------------------
+
+class TestCheckpointManagerCompletedKeys:
+    def test_completed_keys_returns_only_fully_done(self, tmp_path: Path):
+        ckpt_path = str(tmp_path / "ckpt")
+        source_a = ["a.tar"]
+        source_b = ["b.tar"]
+
+        mgr = CheckpointManager(ckpt_path)
+
+        # source_a: 1 completion (no fan-out) — done
+        mgr.mark_completed("task_a", source_a)
+
+        # source_b: fan-out=3, only 2 completed — not done
+        mgr.write_expected_increment(_source_key(source_b), "trig_b", increment=2)
+        mgr.mark_completed("task_b1", source_b)
+        mgr.mark_completed("task_b2", source_b)
+
+        mgr2 = CheckpointManager(ckpt_path).load()
+        completed_keys = mgr2.get_completed_source_keys()
+        assert _source_key(source_a) in completed_keys
+        assert _source_key(source_b) not in completed_keys
+
+
+# ---------------------------------------------------------------------------
+# _CheckpointFilterStage
+# ---------------------------------------------------------------------------
+
+class TestCheckpointFilterStage:
+    def _make_task(self, task_id: str, source_files: list[str]):
+        """Create a minimal FileGroupTask-like object for testing."""
+        from nemo_curator.tasks import FileGroupTask
+        return FileGroupTask(
+            task_id=task_id,
+            dataset_name="test_ds",
+            data=source_files,
+            _metadata={"source_files": source_files},
+        )
+
+    def test_filter_passes_incomplete_task(self, tmp_path: Path):
+        from nemo_curator.stages.checkpoint import _CheckpointFilterStage
+
+        ckpt_path = str(tmp_path / "ckpt")
+        stage = _CheckpointFilterStage(checkpoint_path=ckpt_path)
+        stage.setup()
+
+        task = self._make_task("task_a", ["file_a.tar"])
+        result = stage.process(task)
+        assert result == [task]
+
+    def test_filter_skips_completed_task(self, tmp_path: Path):
+        from nemo_curator.stages.checkpoint import _CheckpointFilterStage
+
+        ckpt_path = str(tmp_path / "ckpt")
+        # Pre-record completion
+        mgr = CheckpointManager(ckpt_path)
+        mgr.mark_completed("task_a_leaf", ["file_a.tar"])
+
+        stage = _CheckpointFilterStage(checkpoint_path=ckpt_path)
+        stage.setup()
+
+        task = self._make_task("task_a", ["file_a.tar"])
+        result = stage.process(task)
+        assert result == []
+
+    def test_filter_passes_task_with_no_source_files(self, tmp_path: Path):
+        from nemo_curator.stages.checkpoint import _CheckpointFilterStage
+
+        ckpt_path = str(tmp_path / "ckpt")
+        stage = _CheckpointFilterStage(checkpoint_path=ckpt_path)
+        stage.setup()
+
+        from nemo_curator.tasks import FileGroupTask
+        task = FileGroupTask(
+            task_id="no_src",
+            dataset_name="ds",
+            data=[],
+            _metadata={},  # no source_files
+        )
+        result = stage.process(task)
+        assert result == [task]
+
+    def test_filter_partial_fanout_not_skipped(self, tmp_path: Path):
+        """If only 3 of 5 sub-tasks are complete, the source partition is NOT skipped."""
+        from nemo_curator.stages.checkpoint import _CheckpointFilterStage
+
+        ckpt_path = str(tmp_path / "ckpt")
+        source = ["multi.tar"]
+        key = _source_key(source)
+
+        mgr = CheckpointManager(ckpt_path)
+        mgr.write_expected_increment(key, "trig", increment=4)  # expect 5
+        for i in range(3):
+            mgr.mark_completed(f"leaf_{i}", source)
+
+        stage = _CheckpointFilterStage(checkpoint_path=ckpt_path)
+        stage.setup()
+
+        task = self._make_task("source_task", source)
+        result = stage.process(task)
+        assert result == [task]
+
+
+# ---------------------------------------------------------------------------
+# _CheckpointRecorderStage
+# ---------------------------------------------------------------------------
+
+class TestCheckpointRecorderStage:
+    def _make_task(self, task_id: str, source_files: list[str]):
+        from nemo_curator.tasks import FileGroupTask
+        return FileGroupTask(
+            task_id=task_id,
+            dataset_name="test_ds",
+            data=source_files,
+            _metadata={"source_files": source_files},
+        )
+
+    def test_recorder_passes_task_through(self, tmp_path: Path):
+        from nemo_curator.stages.checkpoint import _CheckpointRecorderStage
+
+        ckpt_path = str(tmp_path / "ckpt")
+        stage = _CheckpointRecorderStage(checkpoint_path=ckpt_path)
+        stage.setup()
+
+        task = self._make_task("task_z", ["z.tar"])
+        result = stage.process(task)
+        assert result is task
+
+    def test_recorder_writes_completed_shard(self, tmp_path: Path):
+        from nemo_curator.stages.checkpoint import _CheckpointRecorderStage
+
+        ckpt_path = str(tmp_path / "ckpt")
+        stage = _CheckpointRecorderStage(checkpoint_path=ckpt_path)
+        stage.setup()
+
+        task = self._make_task("task_z", ["z.tar"])
+        stage.process(task)
+
+        # Reload and verify
+        mgr = CheckpointManager(ckpt_path).load()
+        assert mgr.is_task_completed(["z.tar"])
+
+    def test_recorder_no_shard_when_no_source_files(self, tmp_path: Path):
+        from nemo_curator.stages.checkpoint import _CheckpointRecorderStage
+
+        ckpt_path = str(tmp_path / "ckpt")
+        stage = _CheckpointRecorderStage(checkpoint_path=ckpt_path)
+        stage.setup()
+
+        from nemo_curator.tasks import FileGroupTask
+        task = FileGroupTask(
+            task_id="no_src",
+            dataset_name="ds",
+            data=[],
+            _metadata={},
+        )
+        stage.process(task)
+
+        completed_dir = Path(ckpt_path) / "completed"
+        assert not completed_dir.exists() or len(list(completed_dir.glob("*.json"))) == 0
+
+    def test_recorder_multiple_tasks_writes_multiple_shards(self, tmp_path: Path):
+        from nemo_curator.stages.checkpoint import _CheckpointRecorderStage
+
+        ckpt_path = str(tmp_path / "ckpt")
+        stage = _CheckpointRecorderStage(checkpoint_path=ckpt_path)
+        stage.setup()
+
+        source = ["shared.tar"]
+        for i in range(5):
+            task = self._make_task(f"leaf_{i}", source)
+            stage.process(task)
+
+        # 5 separate shard files written
+        completed_dir = Path(ckpt_path) / "completed"
+        shards = list(completed_dir.glob("*.json"))
+        assert len(shards) == 5
+
+        # All point to the same source_key
+        for shard in shards:
+            data = json.loads(shard.read_text())
+            assert data["source_key"] == _source_key(source)
+
+
+# ---------------------------------------------------------------------------
+# FilePartitioningStage — hash-based task ID stability
+# ---------------------------------------------------------------------------
+
+class TestFilePartitioningHashTaskId:
+    def test_task_id_stable_across_runs(self, tmp_path: Path):
+        """Same file set → same task IDs regardless of invocation order."""
+        files = [str(tmp_path / f"f{i}.jsonl") for i in range(5)]
+        for f in files:
+            Path(f).write_text("{}\n")
+
+        from nemo_curator.stages.file_partitioning import FilePartitioningStage
+        from nemo_curator.tasks import _EmptyTask
+
+        empty = _EmptyTask(task_id="empty", dataset_name="ds", data=None, _metadata={})
+
+        stage1 = FilePartitioningStage(file_paths=files, files_per_partition=1)
+        stage2 = FilePartitioningStage(file_paths=files, files_per_partition=1)
+
+        result1 = stage1.process(empty)
+        result2 = stage2.process(empty)
+
+        ids1 = {t.task_id for t in result1}
+        ids2 = {t.task_id for t in result2}
+        assert ids1 == ids2
+
+    def test_task_id_independent_of_other_partitions(self, tmp_path: Path):
+        """Adding a new file doesn't change the task IDs of existing partitions."""
+        files_a = [str(tmp_path / f"a{i}.jsonl") for i in range(3)]
+        for f in files_a:
+            Path(f).write_text("{}\n")
+        file_new = str(tmp_path / "new.jsonl")
+        Path(file_new).write_text("{}\n")
+
+        from nemo_curator.stages.file_partitioning import FilePartitioningStage
+        from nemo_curator.tasks import _EmptyTask
+
+        empty = _EmptyTask(task_id="empty", dataset_name="ds", data=None, _metadata={})
+
+        stage_orig = FilePartitioningStage(file_paths=files_a, files_per_partition=1)
+        stage_extended = FilePartitioningStage(file_paths=files_a + [file_new], files_per_partition=1)
+
+        result_orig = stage_orig.process(empty)
+        result_extended = stage_extended.process(empty)
+
+        orig_ids = {t.task_id for t in result_orig}
+        extended_ids = {t.task_id for t in result_extended}
+
+        # All original IDs must appear in the extended run
+        assert orig_ids.issubset(extended_ids)
+        # Extended has one more (the new file)
+        assert len(extended_ids) == len(orig_ids) + 1
+
+    def test_source_files_in_metadata(self, tmp_path: Path):
+        """Every FileGroupTask must have source_files set in _metadata."""
+        files = [str(tmp_path / f"f{i}.jsonl") for i in range(3)]
+        for f in files:
+            Path(f).write_text("{}\n")
+
+        from nemo_curator.stages.file_partitioning import FilePartitioningStage
+        from nemo_curator.tasks import _EmptyTask
+
+        empty = _EmptyTask(task_id="empty", dataset_name="ds", data=None, _metadata={})
+        stage = FilePartitioningStage(file_paths=files, files_per_partition=1)
+        result = stage.process(empty)
+
+        for task in result:
+            assert "source_files" in task._metadata
+            assert len(task._metadata["source_files"]) > 0
+
+    def test_is_source_stage(self):
+        from nemo_curator.stages.file_partitioning import FilePartitioningStage
+        stage = FilePartitioningStage(file_paths=[])
+        assert stage.is_source_stage() is True

--- a/tutorials/image/getting-started/image_curation_example.py
+++ b/tutorials/image/getting-started/image_curation_example.py
@@ -141,7 +141,7 @@ def main(args: argparse.Namespace) -> None:
     executor = XennaExecutor()
 
     # Execute pipeline
-    pipeline.run(executor)
+    pipeline.run(executor, checkpoint_path=args.checkpoint_dir)
 
     end_time = time.time()
 
@@ -290,6 +290,17 @@ if __name__ == "__main__":
         type=int,
         default=100,
         help="Number of images per tar file in output dataset"
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
+        type=str,
+        default=None,
+        help=(
+            "Path to checkpoint directory for pipeline resumability. "
+            "When provided, .tar partitions that have already been fully "
+            "processed are skipped on restart. Must be on a shared filesystem "
+            "(NFS or object storage) for multi-node clusters."
+        ),
     )
 
     args = parser.parse_args()

--- a/tutorials/image/getting-started/image_dedup_example.py
+++ b/tutorials/image/getting-started/image_dedup_example.py
@@ -167,14 +167,14 @@ def main(args: argparse.Namespace) -> None:
     pipeline = create_image_embedding_pipeline(args)
     print(pipeline.describe())
     print("\n" + "=" * 50 + "\n")
-    pipeline.run()
+    pipeline.run(checkpoint_path=args.checkpoint_dir)
 
     # Step 2.2: Create image deduplication pipeline (pairwise executor is XennaExecutor by default)
     print("Step 2.2: Running image deduplication pipeline...")
     start_time = time.time()
     pipeline = create_embedding_deduplication_workflow(args)
     print("\n" + "=" * 50 + "\n")
-    pipeline.run()
+    pipeline.run(checkpoint_path=args.checkpoint_dir)
 
     # Step 2.3: Create image deduplication pipeline
     print("Step 2.3: Running image deduplication pipeline...")
@@ -182,7 +182,7 @@ def main(args: argparse.Namespace) -> None:
     pipeline = create_image_deduplication_pipeline(args)
     print(pipeline.describe())
     print("\n" + "=" * 50 + "\n")
-    pipeline.run()
+    pipeline.run(checkpoint_path=args.checkpoint_dir)
 
     end_time = time.time()
 
@@ -295,6 +295,17 @@ if __name__ == "__main__":
         type=float,
         default=0.25,
         help="GPU allocation per worker for embedding generation"
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
+        type=str,
+        default=None,
+        help=(
+            "Path to checkpoint directory for pipeline resumability. "
+            "When provided, .tar partitions that have already been fully "
+            "processed are skipped on restart. Must be on a shared filesystem "
+            "(NFS or object storage) for multi-node clusters."
+        ),
     )
 
     args = parser.parse_args()

--- a/tutorials/video/getting-started/video_split_clip_example.py
+++ b/tutorials/video/getting-started/video_split_clip_example.py
@@ -272,7 +272,8 @@ def create_video_splitting_argparser() -> argparse.ArgumentParser:  # noqa: PLR0
             "Required models depend on selected algorithms:\n"
             "  - TransNetV2: For scene detection (--splitting-algorithm transnetv2)\n"
             "  - Cosmos-Embed1: For embeddings (--embedding-algorithm cosmos-embed1-*)\n"
-            "  - Qwen2.5-VL: For captioning (--captioning-algorithm qwen)\n"
+            "  - Qwen2.5-VL: For captioning (--captioning-algorithm qwen2.5)\n"
+            "  - Qwen3-VL: For captioning (--captioning-algorithm qwen3)\n"
             "  - Nemotron Nano VL: For captioning (--captioning-algorithm nemotron[-bf16|-fp8|-nvfp4])\n"
             "  - Aesthetic models: For filtering (--aesthetic-threshold)\n"
             "Default: ./models\n"
@@ -556,11 +557,12 @@ def create_video_splitting_argparser() -> argparse.ArgumentParser:  # noqa: PLR0
     parser.add_argument(
         "--captioning-algorithm",
         type=str,
-        default="qwen",
-        choices=["qwen", "nemotron", "nemotron-bf16", "nemotron-fp8", "nemotron-nvfp4"],
+        default="qwen2.5",
+        choices=["qwen2.5", "qwen3", "nemotron", "nemotron-bf16", "nemotron-fp8", "nemotron-nvfp4"],
         help=(
             "Captioning algorithm to use. Options:\n"
-            "  - qwen: Qwen2.5-VL-7B-Instruct (default)\n"
+            "  - qwen2.5: Qwen2.5-VL-7B-Instruct (default)\n"
+            "  - qwen3: Qwen3-VL-8B-Instruct\n"
             "  - nemotron / nemotron-bf16: Nemotron Nano 12B v2 VL BF16 (auto-downloaded from HF)\n"
             "  - nemotron-fp8: Nemotron Nano 12B v2 VL FP8 quantized\n"
             "  - nemotron-nvfp4: Nemotron Nano 12B v2 VL NVFP4-QAD quantized"
@@ -671,8 +673,8 @@ def create_video_splitting_argparser() -> argparse.ArgumentParser:  # noqa: PLR0
     parser.add_argument(
         "--enhance-captions-algorithm",
         type=str,
-        default="qwen",
-        choices=["qwen"],
+        default="qwen2.5",
+        choices=["qwen2.5", "qwen3"],
         help="Caption enhancement algorithm to use.",
     )
     parser.add_argument(
@@ -713,8 +715,8 @@ def create_video_splitting_argparser() -> argparse.ArgumentParser:  # noqa: PLR0
     parser.add_argument(
         "--enhanced-caption-models",
         type=str,
-        default="qwen_lm",
-        choices=["qwen_lm"],
+        default="qwen2.5_lm",
+        choices=["qwen2.5_lm", "qwen3_lm"],
         help="Enhanced LLM models to use to improve captions",
     )
     return parser


### PR DESCRIPTION
## Add Qwen3-VL support alongside Qwen2.5

### Summary

- Renamed the existing `"qwen"` variant string to `"qwen2.5"` throughout the codebase for clarity
- Added `"qwen3"` variant backed by `Qwen/Qwen3-VL-8B-Instruct` (revision `0c351dd`) for captioning and `Qwen/Qwen2.5-14B-Instruct` for caption enhancement
- Added `QWEN_VL_PIXEL_PARAMS` dict in `qwen_vl.py` mapping each variant to its model-specific image/video pixel bounds (factor=28 for qwen2.5, factor=32 for qwen3)
- Threaded `pixel_params` through `split_video_into_windows` → `fetch_video` so each variant uses the correct resize geometry during preprocessing
- Updated `prompt_formatter.py` to derive `VARIANT_MAPPING` from `_QWEN_VARIANTS_INFO` directly, keeping it in sync automatically

### Files changed

- `nemo_curator/models/qwen_vl.py` — Add qwen3 constants, `_QWEN_REVISIONS_INFO`, `QwenVariant` type alias, `QWEN_VL_PIXEL_PARAMS`; update `download_weights_on_node` to accept `variant`
- `nemo_curator/models/qwen_lm.py` — Add `_QWEN_LM_VARIANTS_INFO`, `QwenLMVariant` type alias, `model_variant` param
- `nemo_curator/models/prompt_formatter.py` — Derive `VARIANT_MAPPING` from `_QWEN_VARIANTS_INFO`; handle `"qwen2.5"` and `"qwen3"` in dispatch
- `nemo_curator/utils/windowing_utils.py` — Add `pixel_params: dict | None` to `fetch_video` and `split_video_into_windows`; use per-variant pixel bounds in resize
- `nemo_curator/stages/video/caption/caption_preparation.py` — Pass `QWEN_VL_PIXEL_PARAMS.get(model_variant)` to `split_video_into_windows`
- `nemo_curator/stages/video/caption/caption_generation.py` — Handle `"qwen2.5"` and `"qwen3"` for model init and weight download
- `nemo_curator/stages/video/caption/caption_enhancement.py` — Handle `"qwen2.5"` and `"qwen3"`; pass `model_variant` to `QwenLM`
- `tutorials/video/getting-started/video_split_clip_example.py` — Add `"qwen3"` to `--captioning-algorithm` and `--enhance-captions-algorithm` choices; rename defaults to `"qwen2.5"` / `"qwen2.5_lm"`
- `tests/models/test_qwen_vl.py` — Update variant string `"qwen"` → `"qwen2.5"`

### Test plan

- [ ] All 27 unit tests in `tests/models/test_qwen_vl.py` and `tests/models/test_qwen_lm.py` pass
- [ ] `ruff check` reports no new errors in modified files
- [ ] Run end-to-end pipeline with `--captioning-algorithm qwen2.5` to verify backward-compatible behavior
- [ ] Run end-to-end pipeline with `--captioning-algorithm qwen3` on a GPU node to verify Qwen3-VL loads and produces captions
