### PR TITLE
ci: add H100 timeout overrides for benchmark tests

### DIFF
--- a/benchmarking/ci-h100-overrides.yaml
+++ b/benchmarking/ci-h100-overrides.yaml
@@ -10,4 +10,4 @@ entry_overrides:
   score_filter_xenna:
     timeout_s: 800
   video_transnetv2_motion_aesthetic_filter_embeddings:
-    timeout_s: 600
+    timeout_s: 900

--- a/benchmarking/ci-h100-overrides.yaml
+++ b/benchmarking/ci-h100-overrides.yaml
@@ -1,0 +1,13 @@
+# Per-entry field overrides applied on top of nightly-benchmark.yaml.
+# Used by both generate_ci_tests.py (SLURM TIME) and run.py (subprocess timeout).
+entry_overrides:
+  domain_classification_xenna:
+    timeout_s: 1400
+  fuzzy_dedup_identification:
+    timeout_s: 1200
+  semdedup_identification_xenna:
+    timeout_s: 1200
+  score_filter_xenna:
+    timeout_s: 800
+  video_transnetv2_motion_aesthetic_filter_embeddings:
+    timeout_s: 600

--- a/benchmarking/ci-h100-overrides.yaml
+++ b/benchmarking/ci-h100-overrides.yaml
@@ -1,5 +1,5 @@
 # Per-entry field overrides applied on top of nightly-benchmark.yaml.
-# Used by both generate_ci_tests.py (SLURM TIME) and run.py (subprocess timeout).
+# Consumed by generate_ci_tests.py to set SLURM TIME for CI jobs.
 entry_overrides:
   domain_classification_xenna:
     timeout_s: 1400

--- a/benchmarking/tools/generate_ci_tests.py
+++ b/benchmarking/tools/generate_ci_tests.py
@@ -69,6 +69,16 @@ def generate_job(entry: dict, scope: str) -> dict:
     }
 
 
+def load_entry_overrides(curator_dir: str) -> dict:
+    """Load per-entry field overrides from ci-overrides.yaml if it exists."""
+    overrides_path = Path(curator_dir) / "benchmarking" / "ci-h100-overrides.yaml"
+    if not overrides_path.exists():
+        return {}
+    with open(overrides_path, encoding="utf-8") as f:
+        data = yaml.load(f)
+    return data.get("entry_overrides", {}) if data else {}
+
+
 def generate_pipeline(curator_dir: str, scope: str) -> dict:
     """
     Generate a GitLab CI pipeline from Curator benchmark entries.
@@ -84,6 +94,8 @@ def generate_pipeline(curator_dir: str, scope: str) -> dict:
     with open(config_path, encoding="utf-8") as f:
         config = yaml.load(f)
 
+    entry_overrides = load_entry_overrides(curator_dir)
+
     if scope == "NONE":
         scope = "nightly"
 
@@ -92,6 +104,11 @@ def generate_pipeline(curator_dir: str, scope: str) -> dict:
     }
 
     entries = config.get("entries", [])
+    for entry in entries:
+        overrides = entry_overrides.get(entry["name"])
+        if overrides:
+            entry.update(overrides)
+
     job_count = 0
     for entry in entries:
         if not entry.get("enabled", True):

--- a/benchmarking/tools/generate_ci_tests.py
+++ b/benchmarking/tools/generate_ci_tests.py
@@ -70,7 +70,7 @@ def generate_job(entry: dict, scope: str) -> dict:
 
 
 def load_entry_overrides(curator_dir: str) -> dict:
-    """Load per-entry field overrides from ci-overrides.yaml if it exists."""
+    """Load per-entry field overrides from ci-h100-overrides.yaml if it exists."""
     overrides_path = Path(curator_dir) / "benchmarking" / "ci-h100-overrides.yaml"
     if not overrides_path.exists():
         return {}


### PR DESCRIPTION
## Description

  - Add per-entry timeout override support via ci-h100-overrides.yaml, bump walltime for 5 tests that hit SLURM
  time limits on H100

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
