### PR TITLE
feat: (experimental) Dynamo aggregated backend - inference (4/5)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,6 +65,11 @@ COPY docker/common/install_ffmpeg.sh .
 RUN bash install_ffmpeg.sh && \
     rm install_ffmpeg.sh
 
+# Install etcd + nats-server (required by the Dynamo inference backend)
+COPY docker/common/install_etcd_nats.sh .
+RUN bash install_etcd_nats.sh && \
+    rm install_etcd_nats.sh
+
 
 FROM nemo_curator_dep AS nemo_curator
 

--- a/docker/common/install_etcd_nats.sh
+++ b/docker/common/install_etcd_nats.sh
@@ -27,7 +27,6 @@ for i in "$@"; do
         --NATS_VERSION=?*) NATS_VERSION="${i#*=}";;
         *) ;;
     esac
-    shift
 done
 
 ARCH=$(uname -m)

--- a/docker/common/install_etcd_nats.sh
+++ b/docker/common/install_etcd_nats.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -xeuo pipefail
+
+# Versions pinned to match upstream ai-dynamo/dynamo container/context.yaml,
+# so Dynamo-Curator integration runs the same etcd/nats-server binaries as
+# Dynamo's own runtime images.
+ETCD_VERSION=3.5.21
+NATS_VERSION=2.10.28
+
+for i in "$@"; do
+    case $i in
+        --ETCD_VERSION=?*) ETCD_VERSION="${i#*=}";;
+        --NATS_VERSION=?*) NATS_VERSION="${i#*=}";;
+        *) ;;
+    esac
+    shift
+done
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    x86_64)  ETCD_ARCH="amd64"; NATS_ARCH="amd64" ;;
+    aarch64) ETCD_ARCH="arm64"; NATS_ARCH="arm64" ;;
+    *) echo "Unsupported architecture: $ARCH" && exit 1 ;;
+esac
+
+echo "Installing etcd ${ETCD_VERSION} (${ETCD_ARCH})..."
+curl -fsSL -o /tmp/etcd.tar.gz \
+    "https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}.tar.gz"
+tar xzf /tmp/etcd.tar.gz -C /tmp/
+install -m 0755 /tmp/etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}/etcd /usr/local/bin/
+install -m 0755 /tmp/etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}/etcdctl /usr/local/bin/
+rm -rf /tmp/etcd*
+
+etcd --version
+
+echo "Installing nats-server ${NATS_VERSION} (${NATS_ARCH})..."
+curl -fsSL -o /tmp/nats.tar.gz \
+    "https://github.com/nats-io/nats-server/releases/download/v${NATS_VERSION}/nats-server-v${NATS_VERSION}-linux-${NATS_ARCH}.tar.gz"
+tar xzf /tmp/nats.tar.gz -C /tmp/
+install -m 0755 /tmp/nats-server-v${NATS_VERSION}-linux-${NATS_ARCH}/nats-server /usr/local/bin/
+rm -rf /tmp/nats*
+
+nats-server --version
+
+echo "etcd ${ETCD_VERSION} and nats-server ${NATS_VERSION} installed successfully."

--- a/nemo_curator/core/serve/dynamo/backend.py
+++ b/nemo_curator/core/serve/dynamo/backend.py
@@ -63,7 +63,8 @@ from nemo_curator.core.serve.subprocess_mgr import (
     SubprocessError,
     _check_binary,
     _wait_for_port,
-    graceful_stop_actors,
+    reacquire_detached_actor_handles,
+    sweep_orphan_actors_by_prefix,
 )
 from nemo_curator.core.utils import ignore_ray_head_node
 
@@ -80,9 +81,10 @@ class DynamoBackend(InferenceBackend):
     - ``start()`` enters the ``nemo_curator_dynamo`` namespace, sweeps any
       leftover actors + PGs from a prior driver session, then deploys
       infra → workers → frontend and blocks on a ``/v1/models`` health check.
-    - ``stop()`` reconnects to the same namespace, parallel-stops every actor
-      (SIGTERM → SIGKILL escalation inside ``graceful_stop_actors``), and
-      removes the replica + infra PGs.
+    - ``stop()`` re-enters the same namespace in a fresh Ray session; because
+      ``ActorHandle`` objects do not survive a ``ray.shutdown()`` boundary,
+      the stored handles are refreshed by name before the parallel
+      SIGTERM → SIGKILL teardown runs. Replica + infra PGs are then removed.
     """
 
     def __init__(self, server: InferenceServer) -> None:
@@ -152,15 +154,16 @@ class DynamoBackend(InferenceBackend):
         try:
             with ray.init(namespace=NEMO_CURATOR_DYNAMO_NAMESPACE, ignore_reinit_error=True):
                 self._teardown_actors_and_pgs()
-                # Safety net for PGs left behind when atexit didn't run
-                # (e.g. Jupyter kernel restart). Guard against an empty
-                # prefix — an early-failing ``start()`` (e.g. ``mode="disagg"``)
-                # leaves ``_pg_name_prefix`` unset, and ``remove_named_pgs_with_prefix("")``
-                # would match every PG in the namespace.
+                # Safety net for PGs left behind when the driver crashed
+                # between start() and stop(). Guard against an empty prefix
+                # -- an early-failing ``start()`` (e.g. ``mode="disagg"``)
+                # leaves ``_pg_name_prefix`` unset, and
+                # ``remove_named_pgs_with_prefix("")`` would match every
+                # PG in the namespace.
                 if self._pg_name_prefix:
                     remove_named_pgs_with_prefix(self._pg_name_prefix)
         except Exception:  # noqa: BLE001
-            logger.debug("Could not connect to Ray during Dynamo shutdown (cluster may be gone)")
+            logger.warning("Dynamo backend shutdown hit an error (cluster may be gone)", exc_info=True)
 
         self._cleanup_runtime_dir()
         self._server._host = "localhost"
@@ -478,9 +481,19 @@ class DynamoBackend(InferenceBackend):
     # ------------------------------------------------------------------
 
     def _teardown_actors_and_pgs(self) -> None:
-        """Parallel-stop every actor, then release the placement groups."""
-        procs = self._all_actor_procs()
-        ManagedSubprocess.stop_many(procs)
+        """Parallel-stop every actor, then release the placement groups.
+
+        ``ActorHandle`` objects stored on ``self`` during ``start()`` belong to
+        that session's Ray job and are invalid here (``stop()`` opened its own
+        ``with ray.init()``), so the handles are refreshed by detached-actor
+        name before any ``.remote()`` call is issued.
+        """
+        refreshed = reacquire_detached_actor_handles(
+            self._all_actor_procs(),
+            actor_name_prefix=self._actor_name_prefix,
+            namespace=NEMO_CURATOR_DYNAMO_NAMESPACE,
+        )
+        ManagedSubprocess.stop_many(refreshed)
 
         self._frontend_actor = None
         self._worker_actors.clear()
@@ -498,40 +511,17 @@ class DynamoBackend(InferenceBackend):
             self._infra_pg = None
 
     def _sweep_orphan_actors(self) -> None:
-        """Graceful-stop leftover detached actors matching our PG name prefix.
+        """Reap any detached actors left behind by a prior driver session.
 
         ``remove_named_pgs_with_prefix`` force-kills actors scheduled into
-        the reaped PGs; that skips their ``atexit`` hook and orphans the
-        subprocess tree. Sweeping named actors first lets ``graceful_stop_actors``
-        SIGTERM the process groups cleanly.
+        the reaped PGs, which would orphan the subprocess tree; sweeping
+        named actors first lets ``graceful_stop_actors`` ``killpg`` each
+        process group cleanly.
         """
-        try:
-            from ray.util.state import list_actors
-        except ImportError:
-            return
-
-        try:
-            alive = list_actors(filters=[("state", "=", "ALIVE")])
-        except Exception:  # noqa: BLE001
-            logger.debug("Could not list actors for orphan sweep")
-            return
-
-        prefix = self._pg_name_prefix
-        stale: list[tuple[str, Any]] = []
-        for entry in alive:
-            name = getattr(entry, "name", "") or ""
-            if not name.startswith(prefix):
-                continue
-            try:
-                actor = ray.get_actor(name, namespace=NEMO_CURATOR_DYNAMO_NAMESPACE)
-            except Exception as exc:  # noqa: BLE001
-                logger.debug(f"Orphan-actor lookup for {name!r} failed: {exc}")
-                continue
-            stale.append((name, actor))
-
-        if stale:
-            logger.info(f"Sweeping {len(stale)} orphan Dynamo actor(s) from a prior session")
-            graceful_stop_actors(stale)
+        sweep_orphan_actors_by_prefix(
+            prefix=self._pg_name_prefix,
+            namespace=NEMO_CURATOR_DYNAMO_NAMESPACE,
+        )
 
     def _cleanup_runtime_dir(self) -> None:
         if self._runtime_dir is None:

--- a/nemo_curator/core/serve/dynamo/backend.py
+++ b/nemo_curator/core/serve/dynamo/backend.py
@@ -153,8 +153,12 @@ class DynamoBackend(InferenceBackend):
             with ray.init(namespace=NEMO_CURATOR_DYNAMO_NAMESPACE, ignore_reinit_error=True):
                 self._teardown_actors_and_pgs()
                 # Safety net for PGs left behind when atexit didn't run
-                # (e.g. Jupyter kernel restart).
-                remove_named_pgs_with_prefix(self._pg_name_prefix)
+                # (e.g. Jupyter kernel restart). Guard against an empty
+                # prefix — an early-failing ``start()`` (e.g. ``mode="disagg"``)
+                # leaves ``_pg_name_prefix`` unset, and ``remove_named_pgs_with_prefix("")``
+                # would match every PG in the namespace.
+                if self._pg_name_prefix:
+                    remove_named_pgs_with_prefix(self._pg_name_prefix)
         except Exception:  # noqa: BLE001
             logger.debug("Could not connect to Ray during Dynamo shutdown (cluster may be gone)")
 
@@ -176,25 +180,22 @@ class DynamoBackend(InferenceBackend):
         self._infra_ip = get_bundle_node_ip(self._infra_pg, INFRA_ETCD_BUNDLE)
         server._host = self._infra_ip
 
-        etcd_port = (
-            int(backend_cfg.etcd_endpoint.rsplit(":", 1)[-1])
-            if backend_cfg.etcd_endpoint
-            else get_free_port_in_bundle(self._infra_pg, INFRA_ETCD_BUNDLE, DEFAULT_ETCD_PORT)
-        )
-        nats_port = (
-            int(backend_cfg.nats_url.rsplit(":", 1)[-1])
-            if backend_cfg.nats_url
-            else get_free_port_in_bundle(self._infra_pg, INFRA_NATS_BUNDLE, DEFAULT_NATS_PORT)
-        )
         server.port = get_free_port_in_bundle(self._infra_pg, INFRA_FRONTEND_BUNDLE, server.port)
 
-        if not backend_cfg.etcd_endpoint:
+        if backend_cfg.etcd_endpoint:
+            etcd_endpoint = backend_cfg.etcd_endpoint
+        else:
+            etcd_port = get_free_port_in_bundle(self._infra_pg, INFRA_ETCD_BUNDLE, DEFAULT_ETCD_PORT)
             self._etcd_actor = self._start_etcd(etcd_port)
-        if not backend_cfg.nats_url:
-            self._nats_actor = self._start_nats(nats_port)
+            etcd_endpoint = f"http://{self._infra_ip}:{etcd_port}"
 
-        etcd_endpoint = backend_cfg.etcd_endpoint or f"http://{self._infra_ip}:{etcd_port}"
-        nats_url = backend_cfg.nats_url or f"nats://{self._infra_ip}:{nats_port}"
+        if backend_cfg.nats_url:
+            nats_url = backend_cfg.nats_url
+        else:
+            nats_port = get_free_port_in_bundle(self._infra_pg, INFRA_NATS_BUNDLE, DEFAULT_NATS_PORT)
+            self._nats_actor = self._start_nats(nats_port)
+            nats_url = f"nats://{self._infra_ip}:{nats_port}"
+
         base_env = {"ETCD_ENDPOINTS": etcd_endpoint, "NATS_SERVER": nats_url}
 
         expected_models: set[str] = set()

--- a/nemo_curator/core/serve/dynamo/backend.py
+++ b/nemo_curator/core/serve/dynamo/backend.py
@@ -12,23 +12,548 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+"""NVIDIA Dynamo inference backend for aggregated serving.
 
+One detached placement group per replica carries its TP bundles; a
+separate STRICT_PACK PG co-locates etcd, NATS, and the Dynamo frontend.
+``mode="disagg"`` raises ``NotImplementedError`` for now.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import http
+import json
+import os
+import shutil
+import tempfile
+import time
+import urllib.request
+import uuid
+from typing import TYPE_CHECKING, Any, cast
+
+import ray
+from loguru import logger
+
+from nemo_curator.backends.utils import check_total_gpu_capacity
 from nemo_curator.core.serve.base import InferenceBackend
+from nemo_curator.core.serve.dynamo.config import DynamoServerConfig
+from nemo_curator.core.serve.dynamo.constants import (
+    DEFAULT_ETCD_PORT,
+    DEFAULT_NATS_PORT,
+    ETCD_ACTOR_LABEL,
+    FRONTEND_ACTOR_LABEL,
+    INFRA_ETCD_BUNDLE,
+    INFRA_FRONTEND_BUNDLE,
+    INFRA_NATS_BUNDLE,
+    INFRA_NUM_BUNDLES,
+    NATS_ACTOR_LABEL,
+    NEMO_CURATOR_DYNAMO_NAMESPACE,
+)
+from nemo_curator.core.serve.dynamo.infra import build_infra_pg, engine_kwargs_to_cli_flags
+from nemo_curator.core.serve.dynamo.vllm import launch_replicas, merge_model_runtime_envs
+from nemo_curator.core.serve.placement import (
+    _get_gpu_topology,
+    get_bundle_node_ip,
+    get_free_port_in_bundle,
+    remove_named_pgs_with_prefix,
+)
+from nemo_curator.core.serve.subprocess_mgr import (
+    ManagedSubprocess,
+    SubprocessError,
+    _check_binary,
+    _wait_for_port,
+    graceful_stop_actors,
+)
+from nemo_curator.core.utils import ignore_ray_head_node
 
 if TYPE_CHECKING:
+    from ray.util.placement_group import PlacementGroup
+
+    from nemo_curator.core.serve.dynamo.config import DynamoVLLMModelConfig
     from nemo_curator.core.serve.server import InferenceServer
 
 
 class DynamoBackend(InferenceBackend):
-    """Dynamo backend for ``InferenceServer``."""
+    """Dynamo backend for ``InferenceServer`` — aggregated serving on Ray PGs.
 
-    def __init__(self, server: "InferenceServer") -> None:
+    - ``start()`` enters the ``nemo_curator_dynamo`` namespace, sweeps any
+      leftover PGs + actors from a prior driver session, then deploys
+      infra → workers → frontend and blocks on a ``/v1/models`` health check.
+    - ``stop()`` reconnects to the same namespace, parallel-stops every actor
+      (SIGTERM → SIGKILL escalation inside ``graceful_stop_actors``), and
+      removes the replica + infra PGs.
+    """
+
+    def __init__(self, server: InferenceServer) -> None:
+        if not isinstance(server.backend, DynamoServerConfig):
+            msg = f"DynamoBackend requires DynamoServerConfig; got {type(server.backend).__name__}"
+            raise TypeError(msg)
         self._server = server
+        self._backend_cfg: DynamoServerConfig = server.backend
+        # InferenceServer._validate_model_configs has already enforced that every
+        # entry is a DynamoVLLMModelConfig; narrow once for the IDE.
+        self._models: list[DynamoVLLMModelConfig] = cast("list[DynamoVLLMModelConfig]", server.models)
+        self._runtime_dir: str | None = None
+        self._infra_pg: PlacementGroup | None = None
+        self._replica_pgs: list[PlacementGroup] = []
+        self._infra_ip: str | None = None
+        self._etcd_actor: ManagedSubprocess | None = None
+        self._nats_actor: ManagedSubprocess | None = None
+        self._worker_actors: list[ManagedSubprocess] = []
+        self._frontend_actor: ManagedSubprocess | None = None
+        self._actor_name_prefix: str = ""
+        self._pg_name_prefix: str = ""
+
+    # ------------------------------------------------------------------
+    # Entry points
+    # ------------------------------------------------------------------
 
     def start(self) -> None:
-        msg = "DynamoBackend is not yet implemented."
-        raise NotImplementedError(msg)
+        server = self._server
+        backend_cfg = self._backend_cfg
+
+        if not self._models:
+            msg = "At least one DynamoVLLMModelConfig is required."
+            raise ValueError(msg)
+
+        for model_config in self._models:
+            if model_config.mode == "disagg":
+                msg = (
+                    f"Disaggregated serving (mode='disagg') on model "
+                    f"'{model_config.resolved_model_name}' is not yet supported by DynamoBackend; "
+                    f"this lands in the next PR in the Inference Server stack."
+                )
+                raise NotImplementedError(msg)
+
+        if not backend_cfg.etcd_endpoint:
+            _check_binary("etcd")
+        if not backend_cfg.nats_url:
+            _check_binary("nats-server")
+
+        short_id = uuid.uuid4().hex[:8]
+        self._pg_name_prefix = f"dynamo_{server.name}_"
+        self._actor_name_prefix = f"{self._pg_name_prefix}{short_id}"
+        self._runtime_dir = tempfile.mkdtemp(prefix=f"nemo_curator_dynamo_{short_id}_")
+        logger.info(f"Dynamo runtime dir: {self._runtime_dir}")
+
+        with ray.init(namespace=NEMO_CURATOR_DYNAMO_NAMESPACE, ignore_reinit_error=True):
+            remove_named_pgs_with_prefix(self._pg_name_prefix)
+            self._sweep_orphan_actors()
+
+            try:
+                self._deploy_and_healthcheck(server, backend_cfg)
+            except Exception:
+                self._teardown_actors_and_pgs()
+                self._cleanup_runtime_dir()
+                raise
 
     def stop(self) -> None:
-        pass
+        try:
+            with ray.init(namespace=NEMO_CURATOR_DYNAMO_NAMESPACE, ignore_reinit_error=True):
+                self._teardown_actors_and_pgs()
+                # Safety net for PGs left behind when atexit didn't run
+                # (e.g. Jupyter kernel restart).
+                remove_named_pgs_with_prefix(self._pg_name_prefix)
+        except Exception:  # noqa: BLE001
+            logger.debug("Could not connect to Ray during Dynamo shutdown (cluster may be gone)")
+
+        self._cleanup_runtime_dir()
+        self._server._host = "localhost"
+        logger.info("Dynamo backend stopped")
+
+    # ------------------------------------------------------------------
+    # Deployment
+    # ------------------------------------------------------------------
+
+    def _deploy_and_healthcheck(self, server: InferenceServer, backend_cfg: DynamoServerConfig) -> None:
+        """Validate, create PGs, launch infra/workers/frontend, health-check."""
+        topology = _get_gpu_topology()
+        self._validate_gpu_requirements(self._models)
+
+        infra_pg_name = f"{self._actor_name_prefix}_pg_infra"
+        self._infra_pg = build_infra_pg(name=infra_pg_name, num_bundles=INFRA_NUM_BUNDLES)
+        self._infra_ip = get_bundle_node_ip(self._infra_pg, INFRA_ETCD_BUNDLE)
+        server._host = self._infra_ip
+
+        etcd_port = (
+            int(backend_cfg.etcd_endpoint.rsplit(":", 1)[-1])
+            if backend_cfg.etcd_endpoint
+            else get_free_port_in_bundle(self._infra_pg, INFRA_ETCD_BUNDLE, DEFAULT_ETCD_PORT)
+        )
+        nats_port = (
+            int(backend_cfg.nats_url.rsplit(":", 1)[-1])
+            if backend_cfg.nats_url
+            else get_free_port_in_bundle(self._infra_pg, INFRA_NATS_BUNDLE, DEFAULT_NATS_PORT)
+        )
+        server.port = get_free_port_in_bundle(self._infra_pg, INFRA_FRONTEND_BUNDLE, server.port)
+
+        if not backend_cfg.etcd_endpoint:
+            self._etcd_actor = self._start_etcd(etcd_port)
+        if not backend_cfg.nats_url:
+            self._nats_actor = self._start_nats(nats_port)
+
+        etcd_endpoint = backend_cfg.etcd_endpoint or f"http://{self._infra_ip}:{etcd_port}"
+        nats_url = backend_cfg.nats_url or f"nats://{self._infra_ip}:{nats_port}"
+        base_env = {"ETCD_ENDPOINTS": etcd_endpoint, "NATS_SERVER": nats_url}
+
+        expected_models: set[str] = set()
+        placements: list[dict[str, Any]] = []
+
+        for model_config in self._models:
+            model_name = model_config.resolved_model_name
+            expected_models.add(model_name)
+            tp_size = model_config.engine_kwargs.get("tensor_parallel_size", 1)
+            logger.info(f"Deploying model '{model_name}' (TP={tp_size}, replicas={model_config.num_replicas})")
+
+            pgs, actors, entries = launch_replicas(
+                model_config,
+                base_env=base_env,
+                namespace=backend_cfg.namespace,
+                request_plane=backend_cfg.request_plane,
+                event_plane=backend_cfg.event_plane,
+                runtime_dir=self._runtime_dir,
+                actor_name_prefix=self._actor_name_prefix,
+                router_mode=backend_cfg.router.mode,
+                router_kv_events=backend_cfg.router.kv_events,
+                topology=topology,
+            )
+            self._replica_pgs.extend(pgs)
+            self._worker_actors.extend(actors)
+            placements.extend(entries)
+
+        manifest_data = {
+            "models": sorted(expected_models),
+            "endpoint": server.endpoint,
+            "etcd": etcd_endpoint,
+            "nats": nats_url,
+            "port": server.port,
+            "placements": placements,
+        }
+        self._write_manifest(manifest_data, ready=False)
+
+        self._frontend_actor = self._launch_frontend(
+            server.port,
+            base_env,
+            backend_cfg=backend_cfg,
+            runtime_env=merge_model_runtime_envs(self._models),
+        )
+
+        self._wait_for_models(server, expected_models)
+        self._write_manifest(manifest_data, ready=True)
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_gpu_requirements(models: list[DynamoVLLMModelConfig]) -> None:
+        """Coarse fail-fast on cluster-wide GPU over-commit.
+
+        Ray's per-PG ``STRICT_PACK`` / ``STRICT_SPREAD`` is the authoritative
+        admission gate; this produces a better error than the admission timeout.
+        Cross-model validators (frontend-config coherence, disagg-TP-fit,
+        unique model names) land in the next PR.
+        """
+        total_needed = 0
+        for model_config in models:
+            tp_size = model_config.engine_kwargs.get("tensor_parallel_size", 1)
+            total_needed += model_config.num_replicas * tp_size
+        check_total_gpu_capacity(total_needed, ignore_head_node=ignore_ray_head_node())
+
+    # ------------------------------------------------------------------
+    # Infra actors
+    # ------------------------------------------------------------------
+
+    def _start_infra_service(
+        self,
+        *,
+        label: str,
+        bundle_index: int,
+        port: int,
+        command: list[str],
+        subprocess_env: dict[str, str] | None = None,
+    ) -> ManagedSubprocess:
+        proc = ManagedSubprocess.spawn(
+            label,
+            self._infra_pg,
+            bundle_index,
+            num_gpus=0,
+            command=command,
+            runtime_dir=self._runtime_dir,
+            actor_name_prefix=self._actor_name_prefix,
+            subprocess_env=subprocess_env,
+        )
+        short_label = label.rsplit("_", 1)[-1].lower()
+        logger.info(f"Starting {short_label} on port {port} via {self._infra_ip}")
+        _wait_for_port(self._infra_ip, port, timeout_s=30, label=short_label)
+        logger.info(f"{short_label} is ready")
+        return proc
+
+    def _start_etcd(self, port: int) -> ManagedSubprocess:
+        data_dir = os.path.join(self._runtime_dir, "etcd_data")
+        os.makedirs(data_dir, exist_ok=True)
+        peer_port = get_free_port_in_bundle(self._infra_pg, INFRA_ETCD_BUNDLE, port + 1)
+        return self._start_infra_service(
+            label=ETCD_ACTOR_LABEL,
+            bundle_index=INFRA_ETCD_BUNDLE,
+            port=port,
+            command=[
+                "etcd",
+                "--listen-client-urls",
+                f"http://0.0.0.0:{port}",
+                "--advertise-client-urls",
+                f"http://{self._infra_ip}:{port}",
+                "--listen-peer-urls",
+                f"http://127.0.0.1:{peer_port}",
+                "--initial-advertise-peer-urls",
+                f"http://127.0.0.1:{peer_port}",
+                "--initial-cluster",
+                f"default=http://127.0.0.1:{peer_port}",
+                "--data-dir",
+                data_dir,
+            ],
+            subprocess_env={"ALLOW_NONE_AUTHENTICATION": "yes"},
+        )
+
+    def _start_nats(self, port: int) -> ManagedSubprocess:
+        store_dir = os.path.join(self._runtime_dir, "nats_data")
+        os.makedirs(store_dir, exist_ok=True)
+        return self._start_infra_service(
+            label=NATS_ACTOR_LABEL,
+            bundle_index=INFRA_NATS_BUNDLE,
+            port=port,
+            command=["nats-server", "-p", str(port), "-js", "--store_dir", store_dir],
+        )
+
+    # ------------------------------------------------------------------
+    # Frontend
+    # ------------------------------------------------------------------
+
+    def _launch_frontend(
+        self,
+        port: int,
+        base_env: dict[str, str],
+        *,
+        backend_cfg: DynamoServerConfig,
+        runtime_env: dict[str, Any] | None = None,
+    ) -> ManagedSubprocess:
+        """Launch the Dynamo frontend bound to the infra node.
+
+        Router wiring is minimal: ``--router-mode`` if set, followed by every
+        entry in ``router_kwargs`` as ``--key value``. Full per-key router
+        flag translation (kv_events, temperature, etc.) lands in the next PR.
+        """
+        frontend_env = dict(base_env)
+        router_mode = backend_cfg.router.mode
+        if router_mode:
+            # Dynamo KV-aware routing depends on a stable Python hash seed so
+            # prefix hashes agree across processes.
+            frontend_env["PYTHONHASHSEED"] = "0"
+
+        python_args = [
+            "-m",
+            "dynamo.frontend",
+            "--http-port",
+            str(port),
+            "--namespace",
+            backend_cfg.namespace,
+            "--discovery-backend",
+            "etcd",
+            "--request-plane",
+            backend_cfg.request_plane,
+            "--event-plane",
+            backend_cfg.event_plane,
+        ]
+        if router_mode:
+            python_args.extend(["--router-mode", router_mode])
+        python_args.extend(engine_kwargs_to_cli_flags(backend_cfg.router.router_kwargs))
+
+        logger.info(f"Starting Dynamo frontend on port {port}")
+        return ManagedSubprocess.spawn(
+            FRONTEND_ACTOR_LABEL,
+            self._infra_pg,
+            INFRA_FRONTEND_BUNDLE,
+            num_gpus=0,
+            python_args=python_args,
+            runtime_dir=self._runtime_dir,
+            actor_name_prefix=self._actor_name_prefix,
+            subprocess_env=frontend_env,
+            runtime_env=runtime_env,
+        )
+
+    # ------------------------------------------------------------------
+    # Health
+    # ------------------------------------------------------------------
+
+    def _wait_for_models(self, server: InferenceServer, expected_models: set[str]) -> None:
+        """Poll ``/v1/models`` until all *expected_models* appear."""
+        models_url = f"{server.endpoint}/models"
+        deadline = time.monotonic() + server.health_check_timeout_s
+        start_time = time.monotonic()
+        attempt = 0
+        last_error: str | None = None
+        models_found: set[str] = set()
+
+        # Worker set is fixed for the lifetime of this wait; freeze it once.
+        monitored = self._all_actor_procs()
+
+        while time.monotonic() < deadline:
+            attempt += 1
+            self._check_subprocess_health(monitored)
+
+            try:
+                resp = urllib.request.urlopen(models_url, timeout=5)  # noqa: S310
+                if resp.status == http.HTTPStatus.OK:
+                    body = json.loads(resp.read())
+                    models_found = {m["id"] for m in body.get("data", [])}
+                    if expected_models.issubset(models_found):
+                        logger.info(
+                            f"All Dynamo models registered after {attempt} health check(s): {sorted(expected_models)}"
+                        )
+                        return
+                    if server.verbose:
+                        missing = sorted(expected_models - models_found)
+                        logger.debug(f"Models so far: {sorted(models_found)}, waiting for: {missing}")
+            except Exception as exc:  # noqa: BLE001
+                last_error = str(exc)
+                if server.verbose:
+                    logger.debug(f"Health check attempt {attempt} failed, retrying...")
+            time.sleep(2)
+
+        self._check_subprocess_health(monitored)
+        elapsed_s = round(time.monotonic() - start_time, 1)
+        msg = (
+            f"Models {sorted(expected_models)} did not all appear at {models_url} "
+            f"within {server.health_check_timeout_s}s"
+        )
+        raise SubprocessError(
+            msg,
+            debug_context={
+                "backend": "dynamo",
+                "models_expected": sorted(expected_models),
+                "models_found": sorted(models_found),
+                "elapsed_s": elapsed_s,
+                "last_error": last_error,
+            },
+        )
+
+    def _all_actor_procs(self) -> list[ManagedSubprocess]:
+        procs: list[ManagedSubprocess] = []
+        if self._frontend_actor is not None:
+            procs.append(self._frontend_actor)
+        procs.extend(self._worker_actors)
+        if self._etcd_actor is not None:
+            procs.append(self._etcd_actor)
+        if self._nats_actor is not None:
+            procs.append(self._nats_actor)
+        return procs
+
+    def _check_subprocess_health(self, monitored: list[ManagedSubprocess]) -> None:
+        """Detect subprocess exits via ``ray.wait()`` on the cached run refs."""
+        ref_to_proc = {p.run_ref: p for p in monitored if p.run_ref is not None}
+        if not ref_to_proc:
+            return
+
+        ready, _ = ray.wait(list(ref_to_proc.keys()), num_returns=len(ref_to_proc), timeout=0)
+        for ref in ready:
+            proc = ref_to_proc[ref]
+            log_tail = ""
+            with contextlib.suppress(Exception):
+                log_tail = proc.read_log_tail()
+            self._raise_subprocess_error(proc.label, log_tail, reason="subprocess exited unexpectedly")
+
+    @staticmethod
+    def _raise_subprocess_error(label: str, log_tail: str, *, reason: str) -> None:
+        tail = "\n".join(log_tail.splitlines()[-50:]) if log_tail else "(no log output)"
+        msg = f"Dynamo {label} {reason}.\n\n--- {label} log (last 50 lines) ---\n{tail}"
+        raise SubprocessError(
+            msg,
+            debug_context={"label": label, "reason": reason, "log_tail": tail},
+        )
+
+    # ------------------------------------------------------------------
+    # Teardown
+    # ------------------------------------------------------------------
+
+    def _teardown_actors_and_pgs(self) -> None:
+        """Parallel-stop every actor, then release the placement groups."""
+        procs = self._all_actor_procs()
+        ManagedSubprocess.stop_many(procs)
+
+        self._frontend_actor = None
+        self._worker_actors.clear()
+        self._etcd_actor = None
+        self._nats_actor = None
+
+        for pg in self._replica_pgs:
+            with contextlib.suppress(Exception):
+                ray.util.remove_placement_group(pg)
+        self._replica_pgs.clear()
+
+        if self._infra_pg is not None:
+            with contextlib.suppress(Exception):
+                ray.util.remove_placement_group(self._infra_pg)
+            self._infra_pg = None
+
+    def _sweep_orphan_actors(self) -> None:
+        """Graceful-stop leftover detached actors matching our PG name prefix.
+
+        ``remove_named_pgs_with_prefix`` force-kills actors scheduled into
+        the reaped PGs; that skips their ``atexit`` hook and orphans the
+        subprocess tree. Sweeping named actors first lets ``graceful_stop_actors``
+        SIGTERM the process groups cleanly.
+        """
+        try:
+            from ray.util.state import list_actors
+        except ImportError:
+            return
+
+        try:
+            alive = list_actors(filters=[("state", "=", "ALIVE")])
+        except Exception:  # noqa: BLE001
+            logger.debug("Could not list actors for orphan sweep")
+            return
+
+        prefix = self._pg_name_prefix
+        stale: list[tuple[str, Any]] = []
+        for entry in alive:
+            name = getattr(entry, "name", "") or ""
+            if not name.startswith(prefix):
+                continue
+            try:
+                actor = ray.get_actor(name, namespace=NEMO_CURATOR_DYNAMO_NAMESPACE)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(f"Orphan-actor lookup for {name!r} failed: {exc}")
+                continue
+            stale.append((name, actor))
+
+        if stale:
+            logger.info(f"Sweeping {len(stale)} orphan Dynamo actor(s) from a prior session")
+            graceful_stop_actors(stale)
+
+    def _cleanup_runtime_dir(self) -> None:
+        if self._runtime_dir is None:
+            return
+        try:
+            shutil.rmtree(self._runtime_dir)
+            logger.debug(f"Cleaned up runtime dir: {self._runtime_dir}")
+        except FileNotFoundError:
+            pass
+        except Exception:  # noqa: BLE001
+            logger.debug(f"Failed to clean up runtime dir: {self._runtime_dir}")
+        self._runtime_dir = None
+
+    # ------------------------------------------------------------------
+    # Manifest
+    # ------------------------------------------------------------------
+
+    def _write_manifest(self, data: dict[str, Any], *, ready: bool) -> None:
+        manifest = {**data, "ready": ready, "timestamp": time.time()}
+        logger.debug(f"Deployment manifest (ready={ready}): {json.dumps(manifest, indent=2)}")
+
+        if not self._runtime_dir:
+            return
+        manifest_path = os.path.join(self._runtime_dir, "manifest.json")
+        with open(manifest_path, "w") as f:
+            json.dump(manifest, f, indent=2)

--- a/nemo_curator/core/serve/dynamo/backend.py
+++ b/nemo_curator/core/serve/dynamo/backend.py
@@ -78,7 +78,7 @@ class DynamoBackend(InferenceBackend):
     """Dynamo backend for ``InferenceServer`` — aggregated serving on Ray PGs.
 
     - ``start()`` enters the ``nemo_curator_dynamo`` namespace, sweeps any
-      leftover PGs + actors from a prior driver session, then deploys
+      leftover actors + PGs from a prior driver session, then deploys
       infra → workers → frontend and blocks on a ``/v1/models`` health check.
     - ``stop()`` reconnects to the same namespace, parallel-stops every actor
       (SIGTERM → SIGKILL escalation inside ``graceful_stop_actors``), and
@@ -138,8 +138,8 @@ class DynamoBackend(InferenceBackend):
         logger.info(f"Dynamo runtime dir: {self._runtime_dir}")
 
         with ray.init(namespace=NEMO_CURATOR_DYNAMO_NAMESPACE, ignore_reinit_error=True):
-            remove_named_pgs_with_prefix(self._pg_name_prefix)
             self._sweep_orphan_actors()
+            remove_named_pgs_with_prefix(self._pg_name_prefix)
 
             try:
                 self._deploy_and_healthcheck(server, backend_cfg)

--- a/nemo_curator/core/serve/dynamo/constants.py
+++ b/nemo_curator/core/serve/dynamo/constants.py
@@ -19,6 +19,16 @@ DEFAULT_DYNAMO_NAMESPACE = "curator"
 DEFAULT_DYNAMO_REQUEST_PLANE = "nats"
 DEFAULT_DYNAMO_EVENT_PLANE = "nats"
 
+ETCD_ACTOR_LABEL = "Dynamo_ETCD"
+NATS_ACTOR_LABEL = "Dynamo_NATS"
+FRONTEND_ACTOR_LABEL = "Dynamo_Frontend"
+
+# Layout of the infra placement group shared by etcd, NATS, and the Dynamo frontend.
+INFRA_ETCD_BUNDLE = 0
+INFRA_NATS_BUNDLE = 1
+INFRA_FRONTEND_BUNDLE = 2
+INFRA_NUM_BUNDLES = 3
+
 NEMO_CURATOR_DYNAMO_NAMESPACE = "nemo_curator_dynamo"
 """Ray namespace used for all Dynamo-related detached actors and placement groups.
 

--- a/nemo_curator/core/serve/dynamo/infra.py
+++ b/nemo_curator/core/serve/dynamo/infra.py
@@ -22,6 +22,7 @@ infrastructure there stays reusable and free of Dynamo conventions
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING, Any, Literal
 
 from nemo_curator.core.serve.constants import PLACEMENT_GROUP_READY_TIMEOUT_S, WORKER_NODE_LABEL
@@ -30,6 +31,26 @@ from nemo_curator.core.utils import ignore_ray_head_node
 
 if TYPE_CHECKING:
     from ray.util.placement_group import PlacementGroup
+
+
+def model_name_to_component(name: str) -> str:
+    """Sanitize *name* into a valid Dynamo component slug.
+
+    Dynamo endpoints use ``dyn://namespace.component.endpoint`` where dots
+    are delimiters, so any dotted identifier in the model name has to be
+    flattened. Generic across engines (vLLM, SGLang, ...).
+    """
+    slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+    if not slug:
+        msg = f"Model name {name!r} produces an empty component slug after sanitization."
+        raise ValueError(msg)
+    return slug
+
+
+def dynamo_endpoint(namespace: str, component: str, role: str | None = None) -> str:
+    """Build the ``dyn://namespace.component.endpoint`` URI a Dynamo worker registers under."""
+    suffix = f"_{role}" if role else ""
+    return f"dyn://{namespace}.{component}{suffix}.generate"
 
 
 def build_infra_pg(

--- a/nemo_curator/core/serve/dynamo/vllm.py
+++ b/nemo_curator/core/serve/dynamo/vllm.py
@@ -262,6 +262,7 @@ def _launch_vllm_worker(  # noqa: PLR0913
     python_args += ["--kv-events-config", kv_events_config]
 
     if spec.is_multi_node:
+        assert master_addr is not None, "master_addr must be set for multi-node replicas"  # noqa: S101
         python_args += [
             "--nnodes",
             str(spec.nnodes),

--- a/nemo_curator/core/serve/dynamo/vllm.py
+++ b/nemo_curator/core/serve/dynamo/vllm.py
@@ -17,14 +17,18 @@
 from __future__ import annotations
 
 import json
-import re
 from functools import reduce
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
 from nemo_curator.core.serve.base import BaseModelConfig
-from nemo_curator.core.serve.dynamo.infra import build_worker_actor_name, engine_kwargs_to_cli_flags
+from nemo_curator.core.serve.dynamo.infra import (
+    build_worker_actor_name,
+    dynamo_endpoint,
+    engine_kwargs_to_cli_flags,
+    model_name_to_component,
+)
 from nemo_curator.core.serve.placement import (
     build_replica_pg,
     get_bundle_node_ip,
@@ -44,26 +48,6 @@ if TYPE_CHECKING:
 # installed ai-dynamo — required because ai-dynamo's CLI surface tracks
 # a specific vLLM version.
 DYNAMO_VLLM_RUNTIME_ENV: dict[str, Any] = {"uv": ["ai-dynamo[vllm]"]}
-
-
-def model_name_to_component(name: str) -> str:
-    """Sanitize *name* into a valid Dynamo component slug.
-
-    Dynamo endpoints use ``dyn://namespace.component.endpoint`` where
-    dots are delimiters, so any dotted identifier in the model name has
-    to be flattened.
-    """
-    slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
-    if not slug:
-        msg = f"Model name {name!r} produces an empty component slug after sanitization."
-        raise ValueError(msg)
-    return slug
-
-
-def dynamo_endpoint(namespace: str, component: str, role: str | None = None) -> str:
-    """Build the ``dyn://namespace.component.endpoint`` URI a Dynamo worker registers under."""
-    suffix = f"_{role}" if role else ""
-    return f"dyn://{namespace}.{component}{suffix}.generate"
 
 
 def dynamo_runtime_env(model_config: DynamoVLLMModelConfig) -> dict[str, Any]:

--- a/nemo_curator/core/serve/dynamo/vllm.py
+++ b/nemo_curator/core/serve/dynamo/vllm.py
@@ -1,0 +1,288 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dynamo vLLM worker launch helpers for aggregated serving."""
+
+from __future__ import annotations
+
+import json
+import re
+from functools import reduce
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from nemo_curator.core.serve.base import BaseModelConfig
+from nemo_curator.core.serve.dynamo.infra import build_worker_actor_name, engine_kwargs_to_cli_flags
+from nemo_curator.core.serve.placement import (
+    build_replica_pg,
+    get_bundle_node_ip,
+    get_free_port_in_bundle,
+    plan_replica_bundle_shape,
+)
+from nemo_curator.core.serve.subprocess_mgr import ManagedSubprocess
+
+if TYPE_CHECKING:
+    from ray.util.placement_group import PlacementGroup
+
+    from nemo_curator.core.serve.dynamo.config import DynamoVLLMModelConfig
+    from nemo_curator.core.serve.placement import ReplicaBundleSpec
+
+
+# Installs ai-dynamo[vllm] to pin the exact vLLM release matching the
+# installed ai-dynamo — required because ai-dynamo's CLI surface tracks
+# a specific vLLM version.
+DYNAMO_VLLM_RUNTIME_ENV: dict[str, Any] = {"uv": ["ai-dynamo[vllm]"]}
+
+
+def model_name_to_component(name: str) -> str:
+    """Sanitize *name* into a valid Dynamo component slug.
+
+    Dynamo endpoints use ``dyn://namespace.component.endpoint`` where
+    dots are delimiters, so any dotted identifier in the model name has
+    to be flattened.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+    if not slug:
+        msg = f"Model name {name!r} produces an empty component slug after sanitization."
+        raise ValueError(msg)
+    return slug
+
+
+def dynamo_endpoint(namespace: str, component: str, role: str | None = None) -> str:
+    """Build the ``dyn://namespace.component.endpoint`` URI a Dynamo worker registers under."""
+    suffix = f"_{role}" if role else ""
+    return f"dyn://{namespace}.{component}{suffix}.generate"
+
+
+def dynamo_runtime_env(model_config: DynamoVLLMModelConfig) -> dict[str, Any]:
+    """Merge the user's ``runtime_env`` with the Dynamo-vLLM package pin."""
+    return BaseModelConfig.merge_runtime_envs(DYNAMO_VLLM_RUNTIME_ENV, model_config.runtime_env or None)
+
+
+def merge_model_runtime_envs(models: list[DynamoVLLMModelConfig]) -> dict[str, Any]:
+    """Merge every model's ``runtime_env`` onto the Dynamo-vLLM pin for the shared frontend actor."""
+    envs = [m.runtime_env for m in models if m.runtime_env]
+    user_merged = reduce(BaseModelConfig.merge_runtime_envs, envs) if envs else None
+    return BaseModelConfig.merge_runtime_envs(DYNAMO_VLLM_RUNTIME_ENV, user_merged)
+
+
+def aggregated_model_uses_exact_kv_events(
+    model_config: DynamoVLLMModelConfig, *, router_mode: str | None, router_kv_events: bool
+) -> bool:
+    """True if this aggregated model should publish ZMQ KV events."""
+    if model_config.mode == "disagg":
+        return False
+    if router_mode != "kv":
+        return False
+    return router_kv_events
+
+
+def build_worker_kv_events_config(
+    model_config: DynamoVLLMModelConfig,
+    *,
+    pg: PlacementGroup,
+    bundle_index: int,
+    port_seed: int,
+    enabled: bool,
+) -> str:
+    """JSON blob for ``--kv-events-config``.
+
+    Always passed explicitly. Without this, Dynamo's ``args.py`` auto-creates
+    a ``KVEventsConfig`` bound to ``tcp://*:20080`` when ``prefix_caching`` is
+    enabled (vLLM >=0.16 default), causing every worker on the same node to
+    fight over the same port.
+    """
+    template = dict(model_config.kv_events_config)
+
+    if not enabled:
+        template["enable_kv_cache_events"] = False
+        template.pop("endpoint", None)
+        return json.dumps(template)
+
+    kv_events_port = get_free_port_in_bundle(pg, bundle_index, port_seed)
+    template.update(
+        {
+            "publisher": "zmq",
+            "topic": "kv-events",
+            "endpoint": f"tcp://*:{kv_events_port}",
+            "enable_kv_cache_events": True,
+        }
+    )
+    return json.dumps(template)
+
+
+def launch_replicas(  # noqa: PLR0913
+    model_config: DynamoVLLMModelConfig,
+    *,
+    base_env: dict[str, str],
+    namespace: str,
+    request_plane: str,
+    event_plane: str,
+    runtime_dir: str,
+    actor_name_prefix: str,
+    router_mode: str | None,
+    router_kv_events: bool,
+    topology: list[dict[str, Any]] | None = None,
+) -> tuple[list[PlacementGroup], list[ManagedSubprocess], list[dict[str, Any]]]:
+    """Plan PGs and launch every worker actor for one non-disagg model.
+
+    Returns ``(replica_pgs, worker_actors, manifest_entries)``; callers own
+    the returned handles and are responsible for teardown.
+    """
+    tp_size = model_config.engine_kwargs.get("tensor_parallel_size", 1)
+    model_name = model_config.resolved_model_name
+    component = model_name_to_component(model_name)
+    spec = plan_replica_bundle_shape(tp_size, _topology=topology)
+
+    replica_pgs: list[PlacementGroup] = []
+    worker_actors: list[ManagedSubprocess] = []
+    entries: list[dict[str, Any]] = []
+
+    for replica_index in range(model_config.num_replicas):
+        pg_name = f"{actor_name_prefix}_pg_{component}_DP{replica_index}"
+        pg = build_replica_pg(spec, name=pg_name)
+        replica_pgs.append(pg)
+
+        master_addr = get_bundle_node_ip(pg, 0) if spec.is_multi_node else None
+        if spec.is_multi_node:
+            logger.info(
+                f"Replica {replica_index}: multi-node TP across {spec.nnodes} nodes "
+                f"(total {spec.total_gpus} GPUs, master={master_addr})"
+            )
+        else:
+            logger.info(f"Replica {replica_index}: single-node, {spec.total_gpus} GPU(s)")
+
+        for node_rank in range(spec.nnodes):
+            worker_actors.append(
+                _launch_vllm_worker(
+                    model_config=model_config,
+                    base_env=base_env,
+                    pg=pg,
+                    spec=spec,
+                    replica_index=replica_index,
+                    node_rank=node_rank,
+                    master_addr=master_addr,
+                    namespace=namespace,
+                    request_plane=request_plane,
+                    event_plane=event_plane,
+                    runtime_dir=runtime_dir,
+                    actor_name_prefix=actor_name_prefix,
+                    router_mode=router_mode,
+                    router_kv_events=router_kv_events,
+                )
+            )
+
+        entries.append(
+            {
+                "model": model_name,
+                "replica": replica_index,
+                "nnodes": spec.nnodes,
+                "gpus_per_node": spec.per_node_gpus,
+                "multi_node": spec.is_multi_node,
+                "master_addr": master_addr,
+            }
+        )
+
+    return replica_pgs, worker_actors, entries
+
+
+def _launch_vllm_worker(  # noqa: PLR0913
+    *,
+    model_config: DynamoVLLMModelConfig,
+    base_env: dict[str, str],
+    pg: PlacementGroup,
+    spec: ReplicaBundleSpec,
+    replica_index: int,
+    node_rank: int,
+    master_addr: str | None,
+    namespace: str,
+    request_plane: str,
+    event_plane: str,
+    runtime_dir: str,
+    actor_name_prefix: str,
+    router_mode: str | None,
+    router_kv_events: bool,
+) -> ManagedSubprocess:
+    """Spawn one ``python -m dynamo.vllm`` actor, pinned to bundle *node_rank*.
+
+    Rank 0 is the "real" worker (model registration + scheduler + KV events
+    publisher). Rank >0 is ``--headless`` — no scheduler, so KV events are
+    always disabled for it even if rank 0 publishes.
+    """
+    model_name = model_config.resolved_model_name
+    component = model_name_to_component(model_name)
+    tp_size = model_config.engine_kwargs.get("tensor_parallel_size", 1)
+    is_rank_zero = node_rank == 0
+
+    kv_events_enabled = is_rank_zero and aggregated_model_uses_exact_kv_events(
+        model_config, router_mode=router_mode, router_kv_events=router_kv_events
+    )
+    kv_events_config = build_worker_kv_events_config(
+        model_config,
+        pg=pg,
+        bundle_index=node_rank,
+        port_seed=20080 + replica_index + node_rank,
+        enabled=kv_events_enabled,
+    )
+
+    python_args: list[str] = [
+        "-m",
+        "dynamo.vllm",
+        "--model",
+        model_config.model_identifier,
+    ]
+    if is_rank_zero:
+        python_args += [
+            "--served-model-name",
+            model_name,
+            "--endpoint",
+            dynamo_endpoint(namespace, component),
+            "--discovery-backend",
+            "etcd",
+            "--request-plane",
+            request_plane,
+            "--event-plane",
+            event_plane,
+        ]
+    else:
+        python_args.append("--headless")
+
+    python_args += ["--kv-events-config", kv_events_config]
+
+    if spec.is_multi_node:
+        python_args += [
+            "--nnodes",
+            str(spec.nnodes),
+            "--node-rank",
+            str(node_rank),
+            "--master-addr",
+            master_addr,
+        ]
+
+    python_args += engine_kwargs_to_cli_flags(model_config.engine_kwargs)
+    python_args += engine_kwargs_to_cli_flags(model_config.dynamo_kwargs)
+
+    label = build_worker_actor_name(model_name, replica_index, node_rank, tp_size)
+    return ManagedSubprocess.spawn(
+        label,
+        pg,
+        node_rank,
+        num_gpus=spec.per_node_gpus,
+        python_args=python_args,
+        runtime_dir=runtime_dir,
+        actor_name_prefix=actor_name_prefix,
+        subprocess_env=base_env,
+        runtime_env=dynamo_runtime_env(model_config),
+    )

--- a/nemo_curator/core/serve/subprocess_mgr.py
+++ b/nemo_curator/core/serve/subprocess_mgr.py
@@ -21,14 +21,19 @@ path, and exposes the lifecycle operations (``spawn``, ``stop``,
 callers never have to hand-write ``ray.get(actor.<something>.remote())``
 plumbing.
 
-Each spawned actor owns one subprocess launched with
-``start_new_session=True`` so the child becomes a process-group leader.
-Teardown is driver-initiated (see ``graceful_stop_actors``): SIGTERM
--> bounded wait -> escalated SIGKILL on the process group ->
-``ray.kill`` for the actor itself. A Python ``atexit`` hook inside the
-actor covers the clean-exit path; hard kills (``ray.kill``, PG removal,
-SIGKILL) bypass atexit, which is why ``graceful_stop_actors`` does the
-SIGKILL step explicitly before falling through to ``ray.kill``.
+Every subprocess is launched with ``start_new_session=True``, so it
+becomes its own session and process-group leader with ``pgid == pid``.
+For the Dynamo -> vLLM path we care about, descendants are created via
+Python ``multiprocessing`` without calling ``setsid()``, so they stay in
+that process group.
+
+Teardown is driver-initiated (see ``graceful_stop_actors``): SIGTERM on
+the subprocess group -> bounded wait -> escalated SIGKILL on the same
+group -> ``ray.kill`` for the actor itself. A Python ``atexit`` hook
+inside the actor covers the clean-exit path; hard kills (``ray.kill``,
+PG removal, SIGKILL) bypass atexit, which is why
+``graceful_stop_actors`` does the SIGKILL step explicitly before
+falling through to ``ray.kill``.
 
 Placement-group construction, bundle-level helpers, and the orphan PG
 sweep live in ``placement``.
@@ -208,13 +213,7 @@ class ManagedSubprocess:
         return ray.get(self.run_ref, timeout=timeout)
 
     def stop(self, *, timeout_s: float | None = None) -> None:
-        """Best-effort graceful stop: SIGTERM the subprocess, then hard-kill the actor.
-
-        Calls ``actor.stop.remote()`` (reaps the subprocess group) with a
-        bounded wait, then falls back to ``ray.kill`` if stop times out.
-        Use this before ``remove_placement_group`` so the subprocess tree
-        dies before Ray hard-kills the actor.
-        """
+        """Best-effort graceful stop: reap the subprocess group, then kill the actor."""
         type(self).stop_many([self], timeout_s=timeout_s)
 
     @classmethod
@@ -223,41 +222,46 @@ class ManagedSubprocess:
 
         Kicks off every ``actor.stop.remote()`` first so subprocess
         teardown happens concurrently, then waits on all of them with a
-        shared deadline and force-kills anything that did not drain.
+        shared deadline before tearing down the actors.
         """
         graceful_stop_actors([(p.label, p.actor) for p in procs], timeout_s=timeout_s)
 
 
 # ---------------------------------------------------------------------------
-# Subprocess reaper + Ray actor class factory
+# Subprocess helpers + Ray actor class factory
 # ---------------------------------------------------------------------------
 
 
-def _stop_subprocess(proc: subprocess.Popen, sigterm_wait: float = SIGTERM_WAIT_S) -> int | None:
-    """SIGTERM -> wait -> SIGKILL a subprocess and its entire process group.
+def _reap_process_group(pgid: int, *, sigterm_wait: float = SIGTERM_WAIT_S) -> None:
+    """SIGTERM the whole process group, wait briefly, then SIGKILL.
 
-    Subprocesses are launched with ``start_new_session=True`` so they become
-    process-group leaders. Signaling the group (``os.killpg``) ensures child
-    processes (e.g. vLLM torch.distributed workers) are also terminated
-    rather than becoming orphans.
+    Because every managed subprocess is launched with
+    ``start_new_session=True``, ``pgid == pid`` for the launcher and every
+    descendant that did not explicitly call ``setsid()`` remains in that
+    group. The group persists while any member is alive, so this still
+    works even if the launcher itself already exited.
     """
-    if proc.poll() is not None:
-        return proc.returncode
-    pgid: int | None = None
-    with contextlib.suppress(OSError):
-        pgid = os.getpgid(proc.pid)
-    is_group_leader = pgid is not None and pgid == proc.pid
-    if is_group_leader:
+    with contextlib.suppress(ProcessLookupError):
         os.killpg(pgid, signal.SIGTERM)
-    else:
-        proc.terminate()
-    try:
-        proc.wait(timeout=sigterm_wait)
-    except Exception:  # noqa: BLE001
-        if is_group_leader:
-            os.killpg(pgid, signal.SIGKILL)
-        else:
-            proc.kill()
+    deadline = time.monotonic() + sigterm_wait
+    while time.monotonic() < deadline:
+        try:
+            os.killpg(pgid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.1)
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(pgid, signal.SIGKILL)
+
+
+def _stop_subprocess(proc: subprocess.Popen, sigterm_wait: float = SIGTERM_WAIT_S) -> int | None:
+    """Reap the subprocess's process group and return its exit code.
+
+    Assumes ``proc`` was launched with ``start_new_session=True``, so
+    ``proc.pid`` is the process-group id to target.
+    """
+    _reap_process_group(proc.pid, sigterm_wait=sigterm_wait)
+    with contextlib.suppress(Exception):
         proc.wait(timeout=SIGKILL_WAIT_S)
     return proc.returncode
 
@@ -271,20 +275,19 @@ def _define_subprocess_actor(actor_type: str = "SubprocessActor") -> type:  # no
 
     Lifecycle:
 
-    1. Create with GPU options (``num_gpus=...``).
-    2. Launch subprocess via ``initialize()`` (injects the actor's
-       Ray-assigned ``CUDA_VISIBLE_DEVICES`` into the child env).
-    3. ``run()`` blocks until exit -- returned ObjectRef resolves then.
+    1. ``initialize`` Popens the subprocess with ``start_new_session=True``
+       so the whole subtree shares one process group (``pgid == popen.pid``).
+    2. ``run`` blocks until the subprocess exits; the returned ObjectRef
+       resolves on exit so ``ray.wait`` can be used for liveness.
+    3. ``stop`` / ``force_sigkill_subprocess`` reap that process group.
 
-    Teardown is driver-initiated via ``graceful_stop_actors`` (see its
-    docstring for the SIGTERM -> SIGKILL -> ``ray.kill`` escalation). The
-    only actor-side teardown piece we register is a standard Python
-    ``atexit`` hook: if the actor process ever exits cleanly (e.g. the
-    raylet shuts it down through normal channels), the hook reaps the
-    subprocess group. ``atexit`` does not run on hard kill (``ray.kill``,
-    PG removal, SIGKILL), which is why callers must go through
-    ``graceful_stop_actors`` / ``ManagedSubprocess.stop`` to avoid
-    orphaning the subprocess tree.
+    Teardown is driver-initiated via ``graceful_stop_actors``. The only
+    actor-side teardown piece we register is a standard Python ``atexit``
+    hook: if the actor process ever exits cleanly (e.g. the raylet shuts
+    it down through normal channels), the hook reaps the subprocess
+    group. ``atexit`` does not run on hard kill (``ray.kill``, PG
+    removal, SIGKILL), which is why callers must go through
+    ``graceful_stop_actors`` / ``ManagedSubprocess.stop`` first.
     """
     import ray
 
@@ -348,7 +351,11 @@ def _define_subprocess_actor(actor_type: str = "SubprocessActor") -> type:  # no
 
             try:
                 self._proc = _sp.Popen(  # noqa: S603
-                    command, env=merged_env, stdout=stdout, stderr=_sp.STDOUT, start_new_session=True
+                    command,
+                    env=merged_env,
+                    stdout=stdout,
+                    stderr=_sp.STDOUT,
+                    start_new_session=True,
                 )
             except Exception:
                 if self._log_fh is not None:
@@ -391,28 +398,20 @@ def _define_subprocess_actor(actor_type: str = "SubprocessActor") -> type:  # no
                 return ""
 
         def stop(self, sigterm_wait: float = SIGTERM_WAIT_S) -> int | None:
-            """Gracefully stop the subprocess (SIGTERM group -> wait -> SIGKILL)."""
-            if self._proc is None:
-                return None
-            rc = _stop_subprocess(self._proc, sigterm_wait)
+            """Gracefully stop the subprocess tree via ``killpg``."""
+            rc: int | None = None
+            if self._proc is not None:
+                rc = _stop_subprocess(self._proc, sigterm_wait)
             if self._log_fh:
                 with contextlib.suppress(Exception):
                     self._log_fh.close()
             return rc
 
         def force_sigkill_subprocess(self) -> None:
-            """SIGKILL the subprocess group without waiting.
-
-            Escalation path when ``stop()`` is hung (e.g. the subprocess is
-            stuck in ``proc.wait()``). Non-blocking: one ``killpg`` syscall
-            and return; callers that need to wait should follow with
-            ``ray.kill`` to tear down the actor itself.
-            """
-            if self._proc is None or self._proc.poll() is not None:
-                return
-            with contextlib.suppress(OSError):
-                pgid = os.getpgid(self._proc.pid)
-                os.killpg(pgid, signal.SIGKILL)
+            """SIGKILL the whole process group without a grace period."""
+            if self._proc is not None:
+                with contextlib.suppress(ProcessLookupError):
+                    os.killpg(self._proc.pid, signal.SIGKILL)
 
         def _cleanup(self) -> None:
             """atexit hook: last-line-of-defense subprocess reap."""
@@ -475,16 +474,15 @@ def graceful_stop_actors(
     Escalation order per actor:
 
     1. ``actor.stop.remote()`` -- actor-driven SIGTERM on the subprocess
-       group with a bounded wait (finishes with SIGKILL if needed).
+       group with a bounded wait, then SIGKILL if needed.
     2. If stop did not drain in time, ``actor.force_sigkill_subprocess.remote()``
        -- host-side SIGKILL on the subprocess group. This runs on the
        actor's node (because actor methods always do), so it works
        multi-node without any driver-side connectivity assumption.
     3. ``ray.kill(actor)`` -- tear down the actor itself.
 
-    Without the step-2 escalation, ``ray.kill`` can orphan subprocesses:
-    ``ray.kill`` hard-kills the actor, which bypasses the actor's
-    ``atexit`` hook and leaves the subprocess tree behind.
+    Without the step-2 escalation, ``ray.kill`` can orphan subprocesses
+    because it bypasses the actor's ``atexit`` hook.
     """
     if not labeled_actors:
         return

--- a/nemo_curator/core/serve/subprocess_mgr.py
+++ b/nemo_curator/core/serve/subprocess_mgr.py
@@ -29,14 +29,16 @@ that process group.
 
 Teardown is driver-initiated (see ``graceful_stop_actors``): SIGTERM on
 the subprocess group -> bounded wait -> escalated SIGKILL on the same
-group -> ``ray.kill`` for the actor itself. A Python ``atexit`` hook
-inside the actor covers the clean-exit path; hard kills (``ray.kill``,
-PG removal, SIGKILL) bypass atexit, which is why
-``graceful_stop_actors`` does the SIGKILL step explicitly before
-falling through to ``ray.kill``.
+group -> ``ray.kill`` for the actor itself. ``ray.kill`` on its own
+SIGKILLs the actor process but leaves the launcher subprocess (which
+was Popen'd by the actor) reparented to init and alive, so the
+killpg-first ordering is required; it is not about the atexit hook.
 
-Placement-group construction, bundle-level helpers, and the orphan PG
-sweep live in ``placement``.
+Backends that use the ``with ray.init()`` attach/detach pattern around
+start/stop must refresh stored ``ActorHandle`` references between the
+two sessions -- see ``reacquire_detached_actor_handles`` below. The
+companion orphan sweeper ``sweep_orphan_actors_by_prefix`` matches
+``remove_named_pgs_with_prefix`` in ``placement``.
 """
 
 from __future__ import annotations
@@ -63,6 +65,21 @@ from nemo_curator.core.serve.constants import (
     SIGKILL_WAIT_S,
     SIGTERM_WAIT_S,
 )
+
+# ---------------------------------------------------------------------------
+# Naming
+# ---------------------------------------------------------------------------
+
+
+def _detached_actor_name(prefix: str, label: str) -> str:
+    """Assemble the Ray detached-actor name for a given *prefix* and *label*.
+
+    Both ``ManagedSubprocess.spawn`` (when naming a new actor) and
+    ``reacquire_detached_actor_handles`` (when re-looking it up in a later
+    session) must agree on this formula, so it lives in one place.
+    """
+    return f"{prefix}_{label}" if prefix else label
+
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -119,19 +136,18 @@ class ManagedSubprocess:
         """Create a detached Ray actor bound to ``pg``'s bundle *bundle_index* and launch its subprocess.
 
         Pass *command* for binary subprocesses (etcd, nats) or *python_args*
-        for Python module invocations (``["-m", "dynamo.vllm", ...]``). When
-        *python_args* is used, the actor prepends its own ``sys.executable``
+        for Python module invocations (``["-m", "dynamo.vllm", ...]``).
+        When *python_args* is used, the actor prepends its own ``sys.executable``
         -- which inside a ``runtime_env`` points to the isolated virtualenv's
         Python, not the driver's. This ensures subprocesses load packages
-        from the runtime_env (e.g. the correct vLLM version).
+        from the runtime_env.
 
         The actor class is created per-call with ``__name__`` set to *label*,
         so the Ray dashboard shows descriptive names.
 
         The subprocess inherits the actor's ``os.environ`` (raylet env +
         ``runtime_env`` contributions). *subprocess_env* adds targeted
-        overrides on top (e.g. ``ETCD_ENDPOINTS``, ``NATS_SERVER``,
-        ``CUDA_VISIBLE_DEVICES``).
+        overrides on top (e.g. ``CUDA_VISIBLE_DEVICES``).
 
         Args:
             label: Human-readable label (used for actor naming, class naming, logs).
@@ -159,7 +175,7 @@ class ManagedSubprocess:
         actor_cls = _define_subprocess_actor(label)
 
         log_file = os.path.join(runtime_dir, f"{label}.log") if runtime_dir else None
-        actor_name = f"{actor_name_prefix}_{label}" if actor_name_prefix else label
+        actor_name = _detached_actor_name(actor_name_prefix, label)
 
         if runtime_env:
             merged_runtime_env = {**runtime_env}
@@ -281,13 +297,12 @@ def _define_subprocess_actor(actor_type: str = "SubprocessActor") -> type:  # no
        resolves on exit so ``ray.wait`` can be used for liveness.
     3. ``stop`` / ``force_sigkill_subprocess`` reap that process group.
 
-    Teardown is driver-initiated via ``graceful_stop_actors``. The only
-    actor-side teardown piece we register is a standard Python ``atexit``
-    hook: if the actor process ever exits cleanly (e.g. the raylet shuts
-    it down through normal channels), the hook reaps the subprocess
-    group. ``atexit`` does not run on hard kill (``ray.kill``, PG
-    removal, SIGKILL), which is why callers must go through
-    ``graceful_stop_actors`` / ``ManagedSubprocess.stop`` first.
+    Teardown is driver-initiated via ``graceful_stop_actors`` so the
+    actor can ``killpg`` its subprocess group before ``ray.kill`` hard-kills
+    the actor process itself -- otherwise the Popen-launched child
+    reparents to init and keeps running. A Python ``atexit`` hook is
+    registered as a backup for clean actor exits (e.g. a normal raylet
+    shutdown); it does not fire on ``ray.kill`` / PG removal / SIGKILL.
     """
     import ray
 
@@ -481,23 +496,134 @@ def graceful_stop_actors(
        multi-node without any driver-side connectivity assumption.
     3. ``ray.kill(actor)`` -- tear down the actor itself.
 
-    Without the step-2 escalation, ``ray.kill`` can orphan subprocesses
-    because it bypasses the actor's ``atexit`` hook.
+    Step 2 matters because ``ray.kill`` SIGKILLs the actor process; its
+    Popen child (the launcher) reparents to init and keeps running, and
+    that launcher's own children (e.g. vLLM EngineCore) stay alive too.
+    Sending ``killpg`` first ensures the whole subprocess tree is gone
+    before the actor itself is torn down. Each dispatch is guarded
+    individually so a single invalid handle (e.g. a stale
+    cross-``ray.init()``-session handle) does not abort the batch.
     """
     if not labeled_actors:
         return
     import ray
 
     wait = timeout_s if timeout_s is not None else SIGTERM_WAIT_S + SIGKILL_WAIT_S + 5
-    refs = [actor.stop.remote() for _, actor in labeled_actors]
-    with contextlib.suppress(Exception):
-        ray.wait(refs, num_returns=len(refs), timeout=wait)
+    refs = [_dispatch_actor_stop(label, actor) for label, actor in labeled_actors]
+    valid_refs = [r for r in refs if r is not None]
+    if valid_refs:
+        with contextlib.suppress(Exception):
+            ray.wait(valid_refs, num_returns=len(valid_refs), timeout=wait)
+
     for (label, actor), ref in zip(labeled_actors, refs, strict=True):
-        try:
-            ray.get(ref, timeout=0)
-        except Exception:  # noqa: BLE001 - any failure here means escalate
-            logger.debug(f"{label} actor stop() did not drain in time, SIGKILL-ing subprocess group")
+        if not _actor_stop_drained(ref):
+            logger.debug(f"{label} actor.stop did not drain; escalating to host-side SIGKILL")
             with contextlib.suppress(Exception):
                 ray.get(actor.force_sigkill_subprocess.remote(), timeout=SIGKILL_WAIT_S)
         with contextlib.suppress(Exception):
             ray.kill(actor, no_restart=True)
+
+
+def _dispatch_actor_stop(label: str, actor: ActorHandle) -> ObjectRef | None:
+    """Best-effort dispatch of ``actor.stop.remote()`` for one actor."""
+    try:
+        return actor.stop.remote()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(f"{label} actor.stop.remote() dispatch failed: {exc}")
+        return None
+
+
+def _actor_stop_drained(ref: ObjectRef | None) -> bool:
+    """Return True iff the actor-side ``stop()`` completed successfully."""
+    if ref is None:
+        return False
+    import ray
+
+    try:
+        ray.get(ref, timeout=0)
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Cross-session helpers: refreshing handles + sweeping orphans by prefix
+# ---------------------------------------------------------------------------
+
+
+def reacquire_detached_actor_handles(
+    procs: list[ManagedSubprocess],
+    *,
+    actor_name_prefix: str,
+    namespace: str,
+) -> list[ManagedSubprocess]:
+    """Refresh each ``proc.actor`` in place by re-looking up its detached actor.
+
+    ``ActorHandle`` objects are pinned to the Ray job that created them, so
+    any handle stored across a ``with ray.init()`` boundary raises
+    ``ActorHandleNotFoundError`` on ``.remote()``. Backends that use the
+    start/stop attach-detach pattern must re-acquire their handles inside
+    the stop-side ``with ray.init()`` before calling any actor method.
+
+    Actor names follow the ``ManagedSubprocess.spawn`` convention:
+    ``f"{actor_name_prefix}_{label}"``, or just ``label`` when the prefix
+    is empty.
+
+    Returns a filtered list containing only procs whose actor was
+    successfully re-acquired; entries whose actor is already gone are
+    dropped so callers can safely pass the result to
+    ``ManagedSubprocess.stop_many``.
+    """
+    import ray
+
+    refreshed: list[ManagedSubprocess] = []
+    for proc in procs:
+        actor_name = _detached_actor_name(actor_name_prefix, proc.label)
+        try:
+            proc.actor = ray.get_actor(actor_name, namespace=namespace)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(f"Could not re-acquire detached actor {actor_name!r}: {exc}")
+            continue
+        refreshed.append(proc)
+    return refreshed
+
+
+def sweep_orphan_actors_by_prefix(*, prefix: str, namespace: str) -> int:
+    """Graceful-stop any ALIVE detached actor whose name starts with *prefix*.
+
+    Intended for orphan cleanup after a driver restart: detached actors
+    outlive the driver that created them, so a reconnecting driver (in the
+    same *namespace*) can list them by name, re-acquire handles, and reap
+    them + their subprocess trees via ``graceful_stop_actors``. Returns the
+    number of orphans reaped. Mirrors ``remove_named_pgs_with_prefix`` in
+    ``placement``.
+    """
+    try:
+        from ray.util.state import list_actors
+    except ImportError:
+        return 0
+
+    import ray
+
+    try:
+        alive = list_actors(filters=[("state", "=", "ALIVE")])
+    except Exception:  # noqa: BLE001
+        logger.debug("Could not list actors for orphan sweep")
+        return 0
+
+    stale: list[tuple[str, ActorHandle]] = []
+    for entry in alive:
+        name = getattr(entry, "name", "") or ""
+        if not name.startswith(prefix):
+            continue
+        try:
+            actor = ray.get_actor(name, namespace=namespace)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(f"Orphan-actor lookup for {name!r} failed: {exc}")
+            continue
+        stale.append((name, actor))
+
+    if stale:
+        logger.info(f"Sweeping {len(stale)} orphan actor(s) with prefix {prefix!r}")
+        graceful_stop_actors(stale)
+    return len(stale)

--- a/tests/core/serve/dynamo/conftest.py
+++ b/tests/core/serve/dynamo/conftest.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest import mock
+
+import pytest
+
+from nemo_curator.core.serve.subprocess_mgr import ManagedSubprocess
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture
+def captured_spawn() -> Iterator[list[dict[str, Any]]]:
+    """Patch ``ManagedSubprocess.spawn`` to record calls without launching Ray actors.
+
+    Yields the ``calls`` list — each entry is the kwargs the test code passed
+    (``label``, ``pg``, ``bundle_index``, plus every keyword arg).
+    """
+    calls: list[dict[str, Any]] = []
+
+    def fake_spawn(label, pg, bundle_index, **kwargs) -> ManagedSubprocess:  # noqa: ANN001
+        calls.append({"label": label, "pg": pg, "bundle_index": bundle_index, **kwargs})
+        return ManagedSubprocess(label=label, actor=object())
+
+    with mock.patch.object(ManagedSubprocess, "spawn", side_effect=fake_spawn):
+        yield calls

--- a/tests/core/serve/dynamo/test_backend.py
+++ b/tests/core/serve/dynamo/test_backend.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from nemo_curator.core.serve import DynamoServerConfig, DynamoVLLMModelConfig, InferenceServer
+from nemo_curator.core.serve.dynamo import vllm as dynamo_vllm
+from nemo_curator.core.serve.dynamo.backend import DynamoBackend
+from nemo_curator.core.serve.placement import ReplicaBundleSpec
+from nemo_curator.core.serve.subprocess_mgr import ManagedSubprocess
+
+# ---------------------------------------------------------------------------
+# Pure helpers in vllm.py
+# ---------------------------------------------------------------------------
+
+
+class TestModelNameToComponent:
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("Qwen3-0.6B", "qwen3_0_6b"),
+            ("Qwen/Qwen3-0.6B", "qwen_qwen3_0_6b"),
+            ("meta-llama/Llama-3.1-8B", "meta_llama_llama_3_1_8b"),
+            ("simple", "simple"),
+        ],
+    )
+    def test_sanitizes(self, name: str, expected: str) -> None:
+        assert dynamo_vllm.model_name_to_component(name) == expected
+
+    def test_rejects_empty_slug(self) -> None:
+        with pytest.raises(ValueError, match="empty component slug"):
+            dynamo_vllm.model_name_to_component("---")
+
+
+class TestDynamoEndpoint:
+    def test_without_role(self) -> None:
+        assert dynamo_vllm.dynamo_endpoint("curator", "qwen") == "dyn://curator.qwen.generate"
+
+    def test_with_role(self) -> None:
+        assert dynamo_vllm.dynamo_endpoint("curator", "qwen", role="decode") == "dyn://curator.qwen_decode.generate"
+
+
+class TestAggregatedModelUsesExactKvEvents:
+    def test_non_kv_router_returns_false(self) -> None:
+        mc = DynamoVLLMModelConfig(model_identifier="m")
+        assert not dynamo_vllm.aggregated_model_uses_exact_kv_events(
+            mc, router_mode="round_robin", router_kv_events=True
+        )
+
+    def test_kv_router_with_events_returns_true(self) -> None:
+        mc = DynamoVLLMModelConfig(model_identifier="m")
+        assert dynamo_vllm.aggregated_model_uses_exact_kv_events(mc, router_mode="kv", router_kv_events=True)
+
+    def test_kv_router_without_events_returns_false(self) -> None:
+        mc = DynamoVLLMModelConfig(model_identifier="m")
+        assert not dynamo_vllm.aggregated_model_uses_exact_kv_events(mc, router_mode="kv", router_kv_events=False)
+
+
+# ---------------------------------------------------------------------------
+# Worker launch args
+# ---------------------------------------------------------------------------
+
+
+def _capture_spawn(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture ``ManagedSubprocess.spawn`` calls without launching Ray actors."""
+    calls: list[dict[str, Any]] = []
+
+    @classmethod
+    def fake_spawn(_cls, label, pg, bundle_index, **kwargs) -> ManagedSubprocess:  # noqa: ANN001
+        calls.append({"label": label, "pg": pg, "bundle_index": bundle_index, **kwargs})
+        return ManagedSubprocess(label=label, actor=object())
+
+    monkeypatch.setattr(ManagedSubprocess, "spawn", fake_spawn)
+    return calls
+
+
+def _single_node_spec(num_gpus: int = 1) -> ReplicaBundleSpec:
+    return ReplicaBundleSpec(
+        bundles=[{"CPU": 1, "GPU": num_gpus}],
+        strategy="STRICT_PACK",
+        nnodes=1,
+        per_node_gpus=num_gpus,
+    )
+
+
+def _multi_node_spec(nnodes: int, per_node_gpus: int) -> ReplicaBundleSpec:
+    return ReplicaBundleSpec(
+        bundles=[{"CPU": 1, "GPU": per_node_gpus}] * nnodes,
+        strategy="STRICT_SPREAD",
+        nnodes=nnodes,
+        per_node_gpus=per_node_gpus,
+    )
+
+
+class TestAggregatedWorkerLaunchArgs:
+    """Verify the Python args passed to ``python -m dynamo.vllm`` for aggregated workers."""
+
+    def _launch_one(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        model_config: DynamoVLLMModelConfig,
+        *,
+        spec: ReplicaBundleSpec,
+        router_mode: str | None = None,
+        router_kv_events: bool = False,
+    ) -> list[dict[str, Any]]:
+        calls = _capture_spawn(monkeypatch)
+        monkeypatch.setattr(
+            dynamo_vllm,
+            "plan_replica_bundle_shape",
+            lambda _tp, _topology=None: spec,
+        )
+        monkeypatch.setattr(dynamo_vllm, "build_replica_pg", lambda _spec, **_kw: object())
+        monkeypatch.setattr(dynamo_vllm, "get_bundle_node_ip", lambda _pg, _bundle: "10.0.0.5")
+        monkeypatch.setattr(
+            dynamo_vllm,
+            "get_free_port_in_bundle",
+            lambda _pg, _bundle, _seed: 24567,
+        )
+
+        dynamo_vllm.launch_replicas(
+            model_config,
+            base_env={"ETCD_ENDPOINTS": "http://10.0.0.5:2379", "NATS_SERVER": "nats://10.0.0.5:4222"},
+            namespace="curator",
+            request_plane="nats",
+            event_plane="nats",
+            runtime_dir="/tmp/rt",  # noqa: S108
+            actor_name_prefix="dynamo_default_abcd1234",
+            router_mode=router_mode,
+            router_kv_events=router_kv_events,
+            topology=None,
+        )
+        return calls
+
+    def test_single_node_disables_kv_events_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mc = DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B", num_replicas=1)
+        calls = self._launch_one(monkeypatch, mc, spec=_single_node_spec(1))
+        assert len(calls) == 1
+        python_args = calls[0]["python_args"]
+        idx = python_args.index("--kv-events-config")
+        assert json.loads(python_args[idx + 1]) == {"enable_kv_cache_events": False}
+        assert "--headless" not in python_args
+        assert "--nnodes" not in python_args
+
+    def test_kv_router_enables_exact_kv_events(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mc = DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B", num_replicas=1)
+        calls = self._launch_one(monkeypatch, mc, spec=_single_node_spec(1), router_mode="kv", router_kv_events=True)
+        python_args = calls[0]["python_args"]
+        cfg = json.loads(python_args[python_args.index("--kv-events-config") + 1])
+        assert cfg["enable_kv_cache_events"] is True
+        assert cfg["endpoint"] == "tcp://*:24567"
+        assert cfg["publisher"] == "zmq"
+        assert cfg["topic"] == "kv-events"
+
+    def test_multi_node_rank0_adds_nnodes_and_master(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mc = DynamoVLLMModelConfig(
+            model_identifier="Qwen/Qwen3-0.6B",
+            engine_kwargs={"tensor_parallel_size": 8},
+            num_replicas=1,
+        )
+        calls = self._launch_one(monkeypatch, mc, spec=_multi_node_spec(2, 4))
+        assert len(calls) == 2
+
+        rank0 = calls[0]["python_args"]
+        assert rank0[rank0.index("--nnodes") + 1] == "2"
+        assert rank0[rank0.index("--node-rank") + 1] == "0"
+        assert rank0[rank0.index("--master-addr") + 1] == "10.0.0.5"
+        assert "--headless" not in rank0
+
+        headless = calls[1]["python_args"]
+        assert "--headless" in headless
+        assert headless[headless.index("--node-rank") + 1] == "1"
+        assert headless[headless.index("--master-addr") + 1] == "10.0.0.5"
+        cfg = json.loads(headless[headless.index("--kv-events-config") + 1])
+        assert cfg["enable_kv_cache_events"] is False
+
+    def test_dynamo_kwargs_are_appended_as_cli_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mc = DynamoVLLMModelConfig(
+            model_identifier="Qwen/Qwen3-0.6B",
+            dynamo_kwargs={"tool_call_parser": "hermes", "reasoning_parser": "deepseek-r1"},
+            num_replicas=1,
+        )
+        calls = self._launch_one(monkeypatch, mc, spec=_single_node_spec(1))
+        python_args = calls[0]["python_args"]
+        assert python_args[python_args.index("--tool-call-parser") + 1] == "hermes"
+        assert python_args[python_args.index("--reasoning-parser") + 1] == "deepseek-r1"
+
+    def test_multi_replica_spawns_n_workers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mc = DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B", num_replicas=3)
+        calls = self._launch_one(monkeypatch, mc, spec=_single_node_spec(1))
+        assert len(calls) == 3
+        labels = [c["label"] for c in calls]
+        assert labels == ["Dynamo_DP0_Qwen3-0.6B", "Dynamo_DP1_Qwen3-0.6B", "Dynamo_DP2_Qwen3-0.6B"]
+
+
+# ---------------------------------------------------------------------------
+# Backend-level behavior
+# ---------------------------------------------------------------------------
+
+
+class TestDynamoBackendStartRejectsDisagg:
+    def test_start_raises_notimplemented_for_disagg_mode(self) -> None:
+        from nemo_curator.core.serve.dynamo.config import DynamoRoleConfig
+
+        server = InferenceServer(
+            models=[
+                DynamoVLLMModelConfig(
+                    model_identifier="Qwen/Qwen3-0.6B",
+                    mode="disagg",
+                    prefill=DynamoRoleConfig(num_replicas=1),
+                    decode=DynamoRoleConfig(num_replicas=1),
+                ),
+            ],
+            backend=DynamoServerConfig(),
+        )
+        backend = DynamoBackend(server)
+
+        with pytest.raises(NotImplementedError, match="Disaggregated serving"):
+            backend.start()
+
+
+class TestDynamoBackendValidateGpuRequirements:
+    def test_rejects_overcommit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_check(gpus_needed: int, *, ignore_head_node: bool = False) -> None:  # noqa: ARG001
+            if gpus_needed > 4:
+                msg = f"Not enough GPUs: need {gpus_needed}, have 4"
+                raise RuntimeError(msg)
+
+        monkeypatch.setattr("nemo_curator.core.serve.dynamo.backend.check_total_gpu_capacity", fake_check)
+
+        server = InferenceServer(
+            models=[
+                DynamoVLLMModelConfig(
+                    model_identifier="Qwen/Qwen3-0.6B",
+                    engine_kwargs={"tensor_parallel_size": 4},
+                    num_replicas=2,
+                ),
+            ],
+            backend=DynamoServerConfig(),
+        )
+        with pytest.raises(RuntimeError, match="Not enough GPUs"):
+            DynamoBackend._validate_gpu_requirements(server.models)
+
+    def test_accepts_within_budget(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        recorded: list[int] = []
+
+        def fake_check(gpus_needed: int, *, ignore_head_node: bool = False) -> None:  # noqa: ARG001
+            recorded.append(gpus_needed)
+
+        monkeypatch.setattr("nemo_curator.core.serve.dynamo.backend.check_total_gpu_capacity", fake_check)
+
+        server = InferenceServer(
+            models=[
+                DynamoVLLMModelConfig(
+                    model_identifier="Qwen/Qwen3-0.6B",
+                    engine_kwargs={"tensor_parallel_size": 2},
+                    num_replicas=2,
+                ),
+            ],
+            backend=DynamoServerConfig(),
+        )
+        DynamoBackend._validate_gpu_requirements(server.models)
+        assert recorded == [4]
+
+
+class TestDynamoBackendLaunchFrontend:
+    def test_router_flags_and_router_kwargs_passthrough(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nemo_curator.core.serve.dynamo.config import DynamoRouterConfig
+
+        calls = _capture_spawn(monkeypatch)
+
+        backend_cfg = DynamoServerConfig(
+            namespace="curator",
+            request_plane="nats",
+            event_plane="nats",
+            router=DynamoRouterConfig(
+                mode="kv",
+                router_kwargs={"router_temperature": 0.1, "router_ttl_secs": 60},
+            ),
+        )
+        server = InferenceServer(
+            models=[DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B")],
+            backend=backend_cfg,
+        )
+        backend = DynamoBackend(server)
+        backend._runtime_dir = "/tmp/rt"  # noqa: S108
+        backend._actor_name_prefix = "prefix"
+        backend._infra_pg = object()
+
+        backend._launch_frontend(port=9999, base_env={"ETCD_ENDPOINTS": "e"}, backend_cfg=backend_cfg)
+
+        python_args = calls[0]["python_args"]
+        assert python_args[:2] == ["-m", "dynamo.frontend"]
+        assert python_args[python_args.index("--http-port") + 1] == "9999"
+        assert python_args[python_args.index("--namespace") + 1] == "curator"
+        assert python_args[python_args.index("--router-mode") + 1] == "kv"
+        assert python_args[python_args.index("--router-temperature") + 1] == "0.1"
+        assert python_args[python_args.index("--router-ttl-secs") + 1] == "60"
+        # PYTHONHASHSEED must be pinned when router-mode is set (Dynamo requirement).
+        assert calls[0]["subprocess_env"]["PYTHONHASHSEED"] == "0"
+
+    def test_no_router_mode_omits_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = _capture_spawn(monkeypatch)
+
+        backend_cfg = DynamoServerConfig()
+        server = InferenceServer(
+            models=[DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B")],
+            backend=backend_cfg,
+        )
+        backend = DynamoBackend(server)
+        backend._runtime_dir = "/tmp/rt"  # noqa: S108
+        backend._actor_name_prefix = "prefix"
+        backend._infra_pg = object()
+
+        backend._launch_frontend(port=9999, base_env={}, backend_cfg=backend_cfg)
+
+        python_args = calls[0]["python_args"]
+        assert "--router-mode" not in python_args
+        assert "PYTHONHASHSEED" not in calls[0]["subprocess_env"]

--- a/tests/core/serve/dynamo/test_backend.py
+++ b/tests/core/serve/dynamo/test_backend.py
@@ -14,11 +14,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 from typing import Any
 
 import pytest
 
+import nemo_curator.core.serve.dynamo.backend as dynamo_backend
 from nemo_curator.core.serve import DynamoServerConfig, DynamoVLLMModelConfig, InferenceServer
 from nemo_curator.core.serve.dynamo import vllm as dynamo_vllm
 from nemo_curator.core.serve.dynamo.backend import DynamoBackend
@@ -277,6 +279,33 @@ class TestDynamoBackendValidateGpuRequirements:
         )
         DynamoBackend._validate_gpu_requirements(server.models)
         assert recorded == [4]
+
+
+class TestDynamoBackendStart:
+    def test_sweeps_orphan_actors_before_removing_placement_groups(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        order: list[str] = []
+        server = InferenceServer(
+            models=[DynamoVLLMModelConfig(model_identifier="m")],
+            backend=DynamoServerConfig(
+                etcd_endpoint="http://127.0.0.1:2379",
+                nats_url="nats://127.0.0.1:4222",
+            ),
+        )
+        backend = DynamoBackend(server)
+
+        monkeypatch.setattr(dynamo_backend.ray, "init", lambda **_kwargs: contextlib.nullcontext())
+        monkeypatch.setattr(dynamo_backend.tempfile, "mkdtemp", lambda **_kwargs: "/tmp/dynamo-test-runtime")  # noqa: S108
+        monkeypatch.setattr(backend, "_sweep_orphan_actors", lambda: order.append("actors"))
+        monkeypatch.setattr(
+            dynamo_backend,
+            "remove_named_pgs_with_prefix",
+            lambda _prefix: order.append("pgs"),
+        )
+        monkeypatch.setattr(backend, "_deploy_and_healthcheck", lambda *_args: order.append("deploy"))
+
+        backend.start()
+
+        assert order == ["actors", "pgs", "deploy"]
 
 
 class TestDynamoBackendLaunchFrontend:

--- a/tests/core/serve/dynamo/test_backend.py
+++ b/tests/core/serve/dynamo/test_backend.py
@@ -12,214 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Tests for ``DynamoBackend`` entry points: disagg rejection, ``start()``
+teardown ordering, and ``_launch_frontend`` router-flag wiring."""
+
 from __future__ import annotations
 
 import contextlib
-import json
 from typing import Any
+from unittest import mock
 
 import pytest
 
 import nemo_curator.core.serve.dynamo.backend as dynamo_backend
 from nemo_curator.core.serve import DynamoServerConfig, DynamoVLLMModelConfig, InferenceServer
-from nemo_curator.core.serve.dynamo import vllm as dynamo_vllm
 from nemo_curator.core.serve.dynamo.backend import DynamoBackend
-from nemo_curator.core.serve.placement import ReplicaBundleSpec
-from nemo_curator.core.serve.subprocess_mgr import ManagedSubprocess
-
-# ---------------------------------------------------------------------------
-# Pure helpers in vllm.py
-# ---------------------------------------------------------------------------
+from nemo_curator.core.serve.dynamo.config import DynamoRoleConfig, DynamoRouterConfig
 
 
-class TestModelNameToComponent:
-    @pytest.mark.parametrize(
-        ("name", "expected"),
-        [
-            ("Qwen3-0.6B", "qwen3_0_6b"),
-            ("Qwen/Qwen3-0.6B", "qwen_qwen3_0_6b"),
-            ("meta-llama/Llama-3.1-8B", "meta_llama_llama_3_1_8b"),
-            ("simple", "simple"),
-        ],
-    )
-    def test_sanitizes(self, name: str, expected: str) -> None:
-        assert dynamo_vllm.model_name_to_component(name) == expected
-
-    def test_rejects_empty_slug(self) -> None:
-        with pytest.raises(ValueError, match="empty component slug"):
-            dynamo_vllm.model_name_to_component("---")
-
-
-class TestDynamoEndpoint:
-    def test_without_role(self) -> None:
-        assert dynamo_vllm.dynamo_endpoint("curator", "qwen") == "dyn://curator.qwen.generate"
-
-    def test_with_role(self) -> None:
-        assert dynamo_vllm.dynamo_endpoint("curator", "qwen", role="decode") == "dyn://curator.qwen_decode.generate"
-
-
-class TestAggregatedModelUsesExactKvEvents:
-    def test_non_kv_router_returns_false(self) -> None:
-        mc = DynamoVLLMModelConfig(model_identifier="m")
-        assert not dynamo_vllm.aggregated_model_uses_exact_kv_events(
-            mc, router_mode="round_robin", router_kv_events=True
-        )
-
-    def test_kv_router_with_events_returns_true(self) -> None:
-        mc = DynamoVLLMModelConfig(model_identifier="m")
-        assert dynamo_vllm.aggregated_model_uses_exact_kv_events(mc, router_mode="kv", router_kv_events=True)
-
-    def test_kv_router_without_events_returns_false(self) -> None:
-        mc = DynamoVLLMModelConfig(model_identifier="m")
-        assert not dynamo_vllm.aggregated_model_uses_exact_kv_events(mc, router_mode="kv", router_kv_events=False)
-
-
-# ---------------------------------------------------------------------------
-# Worker launch args
-# ---------------------------------------------------------------------------
-
-
-def _capture_spawn(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
-    """Capture ``ManagedSubprocess.spawn`` calls without launching Ray actors."""
-    calls: list[dict[str, Any]] = []
-
-    @classmethod
-    def fake_spawn(_cls, label, pg, bundle_index, **kwargs) -> ManagedSubprocess:  # noqa: ANN001
-        calls.append({"label": label, "pg": pg, "bundle_index": bundle_index, **kwargs})
-        return ManagedSubprocess(label=label, actor=object())
-
-    monkeypatch.setattr(ManagedSubprocess, "spawn", fake_spawn)
-    return calls
-
-
-def _single_node_spec(num_gpus: int = 1) -> ReplicaBundleSpec:
-    return ReplicaBundleSpec(
-        bundles=[{"CPU": 1, "GPU": num_gpus}],
-        strategy="STRICT_PACK",
-        nnodes=1,
-        per_node_gpus=num_gpus,
-    )
-
-
-def _multi_node_spec(nnodes: int, per_node_gpus: int) -> ReplicaBundleSpec:
-    return ReplicaBundleSpec(
-        bundles=[{"CPU": 1, "GPU": per_node_gpus}] * nnodes,
-        strategy="STRICT_SPREAD",
-        nnodes=nnodes,
-        per_node_gpus=per_node_gpus,
-    )
-
-
-class TestAggregatedWorkerLaunchArgs:
-    """Verify the Python args passed to ``python -m dynamo.vllm`` for aggregated workers."""
-
-    def _launch_one(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        model_config: DynamoVLLMModelConfig,
-        *,
-        spec: ReplicaBundleSpec,
-        router_mode: str | None = None,
-        router_kv_events: bool = False,
-    ) -> list[dict[str, Any]]:
-        calls = _capture_spawn(monkeypatch)
-        monkeypatch.setattr(
-            dynamo_vllm,
-            "plan_replica_bundle_shape",
-            lambda _tp, _topology=None: spec,
-        )
-        monkeypatch.setattr(dynamo_vllm, "build_replica_pg", lambda _spec, **_kw: object())
-        monkeypatch.setattr(dynamo_vllm, "get_bundle_node_ip", lambda _pg, _bundle: "10.0.0.5")
-        monkeypatch.setattr(
-            dynamo_vllm,
-            "get_free_port_in_bundle",
-            lambda _pg, _bundle, _seed: 24567,
-        )
-
-        dynamo_vllm.launch_replicas(
-            model_config,
-            base_env={"ETCD_ENDPOINTS": "http://10.0.0.5:2379", "NATS_SERVER": "nats://10.0.0.5:4222"},
-            namespace="curator",
-            request_plane="nats",
-            event_plane="nats",
-            runtime_dir="/tmp/rt",  # noqa: S108
-            actor_name_prefix="dynamo_default_abcd1234",
-            router_mode=router_mode,
-            router_kv_events=router_kv_events,
-            topology=None,
-        )
-        return calls
-
-    def test_single_node_disables_kv_events_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        mc = DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B", num_replicas=1)
-        calls = self._launch_one(monkeypatch, mc, spec=_single_node_spec(1))
-        assert len(calls) == 1
-        python_args = calls[0]["python_args"]
-        idx = python_args.index("--kv-events-config")
-        assert json.loads(python_args[idx + 1]) == {"enable_kv_cache_events": False}
-        assert "--headless" not in python_args
-        assert "--nnodes" not in python_args
-
-    def test_kv_router_enables_exact_kv_events(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        mc = DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B", num_replicas=1)
-        calls = self._launch_one(monkeypatch, mc, spec=_single_node_spec(1), router_mode="kv", router_kv_events=True)
-        python_args = calls[0]["python_args"]
-        cfg = json.loads(python_args[python_args.index("--kv-events-config") + 1])
-        assert cfg["enable_kv_cache_events"] is True
-        assert cfg["endpoint"] == "tcp://*:24567"
-        assert cfg["publisher"] == "zmq"
-        assert cfg["topic"] == "kv-events"
-
-    def test_multi_node_rank0_adds_nnodes_and_master(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        mc = DynamoVLLMModelConfig(
-            model_identifier="Qwen/Qwen3-0.6B",
-            engine_kwargs={"tensor_parallel_size": 8},
-            num_replicas=1,
-        )
-        calls = self._launch_one(monkeypatch, mc, spec=_multi_node_spec(2, 4))
-        assert len(calls) == 2
-
-        rank0 = calls[0]["python_args"]
-        assert rank0[rank0.index("--nnodes") + 1] == "2"
-        assert rank0[rank0.index("--node-rank") + 1] == "0"
-        assert rank0[rank0.index("--master-addr") + 1] == "10.0.0.5"
-        assert "--headless" not in rank0
-
-        headless = calls[1]["python_args"]
-        assert "--headless" in headless
-        assert headless[headless.index("--node-rank") + 1] == "1"
-        assert headless[headless.index("--master-addr") + 1] == "10.0.0.5"
-        cfg = json.loads(headless[headless.index("--kv-events-config") + 1])
-        assert cfg["enable_kv_cache_events"] is False
-
-    def test_dynamo_kwargs_are_appended_as_cli_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        mc = DynamoVLLMModelConfig(
-            model_identifier="Qwen/Qwen3-0.6B",
-            dynamo_kwargs={"tool_call_parser": "hermes", "reasoning_parser": "deepseek-r1"},
-            num_replicas=1,
-        )
-        calls = self._launch_one(monkeypatch, mc, spec=_single_node_spec(1))
-        python_args = calls[0]["python_args"]
-        assert python_args[python_args.index("--tool-call-parser") + 1] == "hermes"
-        assert python_args[python_args.index("--reasoning-parser") + 1] == "deepseek-r1"
-
-    def test_multi_replica_spawns_n_workers(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        mc = DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B", num_replicas=3)
-        calls = self._launch_one(monkeypatch, mc, spec=_single_node_spec(1))
-        assert len(calls) == 3
-        labels = [c["label"] for c in calls]
-        assert labels == ["Dynamo_DP0_Qwen3-0.6B", "Dynamo_DP1_Qwen3-0.6B", "Dynamo_DP2_Qwen3-0.6B"]
-
-
-# ---------------------------------------------------------------------------
-# Backend-level behavior
-# ---------------------------------------------------------------------------
-
-
-class TestDynamoBackendStartRejectsDisagg:
-    def test_start_raises_notimplemented_for_disagg_mode(self) -> None:
-        from nemo_curator.core.serve.dynamo.config import DynamoRoleConfig
-
+class TestDynamoBackendStart:
+    def test_rejects_disagg_mode(self) -> None:
         server = InferenceServer(
             models=[
                 DynamoVLLMModelConfig(
@@ -231,59 +42,13 @@ class TestDynamoBackendStartRejectsDisagg:
             ],
             backend=DynamoServerConfig(),
         )
-        backend = DynamoBackend(server)
-
         with pytest.raises(NotImplementedError, match="Disaggregated serving"):
-            backend.start()
+            DynamoBackend(server).start()
 
-
-class TestDynamoBackendValidateGpuRequirements:
-    def test_rejects_overcommit(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        def fake_check(gpus_needed: int, *, ignore_head_node: bool = False) -> None:  # noqa: ARG001
-            if gpus_needed > 4:
-                msg = f"Not enough GPUs: need {gpus_needed}, have 4"
-                raise RuntimeError(msg)
-
-        monkeypatch.setattr("nemo_curator.core.serve.dynamo.backend.check_total_gpu_capacity", fake_check)
-
-        server = InferenceServer(
-            models=[
-                DynamoVLLMModelConfig(
-                    model_identifier="Qwen/Qwen3-0.6B",
-                    engine_kwargs={"tensor_parallel_size": 4},
-                    num_replicas=2,
-                ),
-            ],
-            backend=DynamoServerConfig(),
-        )
-        with pytest.raises(RuntimeError, match="Not enough GPUs"):
-            DynamoBackend._validate_gpu_requirements(server.models)
-
-    def test_accepts_within_budget(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        recorded: list[int] = []
-
-        def fake_check(gpus_needed: int, *, ignore_head_node: bool = False) -> None:  # noqa: ARG001
-            recorded.append(gpus_needed)
-
-        monkeypatch.setattr("nemo_curator.core.serve.dynamo.backend.check_total_gpu_capacity", fake_check)
-
-        server = InferenceServer(
-            models=[
-                DynamoVLLMModelConfig(
-                    model_identifier="Qwen/Qwen3-0.6B",
-                    engine_kwargs={"tensor_parallel_size": 2},
-                    num_replicas=2,
-                ),
-            ],
-            backend=DynamoServerConfig(),
-        )
-        DynamoBackend._validate_gpu_requirements(server.models)
-        assert recorded == [4]
-
-
-class TestDynamoBackendStart:
-    def test_sweeps_orphan_actors_before_removing_placement_groups(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        order: list[str] = []
+    def test_sweeps_orphan_actors_before_removing_placement_groups(self) -> None:
+        """``remove_named_pgs_with_prefix`` force-kills actors scheduled into
+        the reaped PGs; sweeping named actors first lets ``graceful_stop_actors``
+        ``killpg`` each process group cleanly."""
         server = InferenceServer(
             models=[DynamoVLLMModelConfig(model_identifier="m")],
             backend=DynamoServerConfig(
@@ -292,73 +57,90 @@ class TestDynamoBackendStart:
             ),
         )
         backend = DynamoBackend(server)
+        order: list[str] = []
 
-        monkeypatch.setattr(dynamo_backend.ray, "init", lambda **_kwargs: contextlib.nullcontext())
-        monkeypatch.setattr(dynamo_backend.tempfile, "mkdtemp", lambda **_kwargs: "/tmp/dynamo-test-runtime")  # noqa: S108
-        monkeypatch.setattr(backend, "_sweep_orphan_actors", lambda: order.append("actors"))
-        monkeypatch.setattr(
-            dynamo_backend,
-            "remove_named_pgs_with_prefix",
-            lambda _prefix: order.append("pgs"),
-        )
-        monkeypatch.setattr(backend, "_deploy_and_healthcheck", lambda *_args: order.append("deploy"))
-
-        backend.start()
+        with (
+            mock.patch.object(dynamo_backend.ray, "init", return_value=contextlib.nullcontext()),
+            mock.patch.object(dynamo_backend.tempfile, "mkdtemp", return_value="/tmp/dynamo-test-runtime"),  # noqa: S108
+            mock.patch.object(backend, "_sweep_orphan_actors", side_effect=lambda: order.append("actors")),
+            mock.patch.object(
+                dynamo_backend,
+                "remove_named_pgs_with_prefix",
+                side_effect=lambda _prefix: order.append("pgs"),
+            ),
+            mock.patch.object(backend, "_deploy_and_healthcheck", side_effect=lambda *_a: order.append("deploy")),
+        ):
+            backend.start()
 
         assert order == ["actors", "pgs", "deploy"]
 
 
 class TestDynamoBackendLaunchFrontend:
-    def test_router_flags_and_router_kwargs_passthrough(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from nemo_curator.core.serve.dynamo.config import DynamoRouterConfig
+    @staticmethod
+    def _make_backend(backend_cfg: DynamoServerConfig) -> DynamoBackend:
+        server = InferenceServer(
+            models=[DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B")],
+            backend=backend_cfg,
+        )
+        backend = DynamoBackend(server)
+        backend._runtime_dir = "/tmp/rt"  # noqa: S108
+        backend._actor_name_prefix = "prefix"
+        backend._infra_pg = object()
+        return backend
 
-        calls = _capture_spawn(monkeypatch)
-
+    def test_router_flags_and_router_kwargs_passthrough(self, captured_spawn: list[dict[str, Any]]) -> None:
+        """``PYTHONHASHSEED=0`` is pinned when ``router-mode`` is set: Dynamo KV
+        routing relies on a stable prefix-hash across frontend + worker processes."""
         backend_cfg = DynamoServerConfig(
-            namespace="curator",
-            request_plane="nats",
-            event_plane="nats",
             router=DynamoRouterConfig(
                 mode="kv",
                 router_kwargs={"router_temperature": 0.1, "router_ttl_secs": 60},
             ),
         )
-        server = InferenceServer(
-            models=[DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B")],
-            backend=backend_cfg,
-        )
-        backend = DynamoBackend(server)
-        backend._runtime_dir = "/tmp/rt"  # noqa: S108
-        backend._actor_name_prefix = "prefix"
-        backend._infra_pg = object()
+        backend = self._make_backend(backend_cfg)
 
         backend._launch_frontend(port=9999, base_env={"ETCD_ENDPOINTS": "e"}, backend_cfg=backend_cfg)
 
-        python_args = calls[0]["python_args"]
-        assert python_args[:2] == ["-m", "dynamo.frontend"]
-        assert python_args[python_args.index("--http-port") + 1] == "9999"
-        assert python_args[python_args.index("--namespace") + 1] == "curator"
-        assert python_args[python_args.index("--router-mode") + 1] == "kv"
-        assert python_args[python_args.index("--router-temperature") + 1] == "0.1"
-        assert python_args[python_args.index("--router-ttl-secs") + 1] == "60"
-        # PYTHONHASHSEED must be pinned when router-mode is set (Dynamo requirement).
-        assert calls[0]["subprocess_env"]["PYTHONHASHSEED"] == "0"
+        assert captured_spawn[0]["python_args"] == [
+            "-m",
+            "dynamo.frontend",
+            "--http-port",
+            "9999",
+            "--namespace",
+            "curator",
+            "--discovery-backend",
+            "etcd",
+            "--request-plane",
+            "nats",
+            "--event-plane",
+            "nats",
+            "--router-mode",
+            "kv",
+            "--router-temperature",
+            "0.1",
+            "--router-ttl-secs",
+            "60",
+        ]
+        assert captured_spawn[0]["subprocess_env"] == {"ETCD_ENDPOINTS": "e", "PYTHONHASHSEED": "0"}
 
-    def test_no_router_mode_omits_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        calls = _capture_spawn(monkeypatch)
-
+    def test_no_router_mode_omits_flag_and_hashseed(self, captured_spawn: list[dict[str, Any]]) -> None:
         backend_cfg = DynamoServerConfig()
-        server = InferenceServer(
-            models=[DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B")],
-            backend=backend_cfg,
-        )
-        backend = DynamoBackend(server)
-        backend._runtime_dir = "/tmp/rt"  # noqa: S108
-        backend._actor_name_prefix = "prefix"
-        backend._infra_pg = object()
+        backend = self._make_backend(backend_cfg)
 
         backend._launch_frontend(port=9999, base_env={}, backend_cfg=backend_cfg)
 
-        python_args = calls[0]["python_args"]
-        assert "--router-mode" not in python_args
-        assert "PYTHONHASHSEED" not in calls[0]["subprocess_env"]
+        assert captured_spawn[0]["python_args"] == [
+            "-m",
+            "dynamo.frontend",
+            "--http-port",
+            "9999",
+            "--namespace",
+            "curator",
+            "--discovery-backend",
+            "etcd",
+            "--request-plane",
+            "nats",
+            "--event-plane",
+            "nats",
+        ]
+        assert captured_spawn[0]["subprocess_env"] == {}

--- a/tests/core/serve/dynamo/test_infra.py
+++ b/tests/core/serve/dynamo/test_infra.py
@@ -16,7 +16,42 @@ from __future__ import annotations
 
 import pytest
 
-from nemo_curator.core.serve.dynamo.infra import build_worker_actor_name, engine_kwargs_to_cli_flags
+from nemo_curator.core.serve.dynamo.infra import (
+    build_worker_actor_name,
+    dynamo_endpoint,
+    engine_kwargs_to_cli_flags,
+    model_name_to_component,
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Qwen3-0.6B", "qwen3_0_6b"),
+        ("Qwen/Qwen3-0.6B", "qwen_qwen3_0_6b"),
+        ("meta-llama/Llama-3.1-8B", "meta_llama_llama_3_1_8b"),
+        ("simple", "simple"),
+    ],
+)
+def test_model_name_to_component(name: str, expected: str) -> None:
+    assert model_name_to_component(name) == expected
+
+
+def test_model_name_to_component_rejects_empty_slug() -> None:
+    with pytest.raises(ValueError, match="empty component slug"):
+        model_name_to_component("---")
+
+
+@pytest.mark.parametrize(
+    ("namespace", "component", "role", "expected"),
+    [
+        ("curator", "qwen", None, "dyn://curator.qwen.generate"),
+        ("curator", "qwen", "decode", "dyn://curator.qwen_decode.generate"),
+        ("curator", "qwen", "prefill", "dyn://curator.qwen_prefill.generate"),
+    ],
+)
+def test_dynamo_endpoint(namespace: str, component: str, role: str | None, expected: str) -> None:
+    assert dynamo_endpoint(namespace, component, role=role) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/core/serve/dynamo/test_vllm.py
+++ b/tests/core/serve/dynamo/test_vllm.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from nemo_curator.core.serve import DynamoVLLMModelConfig
+from nemo_curator.core.serve.dynamo import vllm as dynamo_vllm
+
+_SINGLE_NODE_1GPU = [{"node_id": "n1", "num_gpus": 1, "is_head": False}]
+_SINGLE_NODE_8GPU = [{"node_id": "n1", "num_gpus": 8, "is_head": False}]
+_TWO_NODES_4GPU = [
+    {"node_id": "n1", "num_gpus": 4, "is_head": False},
+    {"node_id": "n2", "num_gpus": 4, "is_head": False},
+]
+
+
+@pytest.mark.parametrize(
+    ("router_mode", "router_kv_events", "expected"),
+    [
+        ("round_robin", True, False),  # non-kv router never publishes
+        ("kv", False, False),  # kv router without events opt-in stays approximate
+        ("kv", True, True),  # kv router + events opt-in publishes ZMQ events
+    ],
+)
+def test_aggregated_model_uses_exact_kv_events(router_mode: str, router_kv_events: bool, expected: bool) -> None:
+    mc = DynamoVLLMModelConfig(model_identifier="m")
+    assert (
+        dynamo_vllm.aggregated_model_uses_exact_kv_events(
+            mc, router_mode=router_mode, router_kv_events=router_kv_events
+        )
+        is expected
+    )
+
+
+class TestLaunchReplicas:
+    @staticmethod
+    def _launch(
+        model_config: DynamoVLLMModelConfig,
+        *,
+        topology: list[dict[str, Any]],
+        router_mode: str | None = None,
+        router_kv_events: bool = False,
+    ) -> None:
+        """Run ``launch_replicas`` with real ``plan_replica_bundle_shape`` over
+        the given *topology*; mock only the Ray PG + bundle-port plumbing."""
+        with (
+            mock.patch.object(dynamo_vllm, "build_replica_pg", return_value=object()),
+            mock.patch.object(dynamo_vllm, "get_bundle_node_ip", return_value="10.0.0.5"),
+            mock.patch.object(dynamo_vllm, "get_free_port_in_bundle", return_value=24567),
+        ):
+            dynamo_vllm.launch_replicas(
+                model_config,
+                base_env={"ETCD_ENDPOINTS": "http://10.0.0.5:2379", "NATS_SERVER": "nats://10.0.0.5:4222"},
+                namespace="curator",
+                request_plane="nats",
+                event_plane="nats",
+                runtime_dir="/tmp/rt",  # noqa: S108
+                actor_name_prefix="dynamo_default_abcd1234",
+                router_mode=router_mode,
+                router_kv_events=router_kv_events,
+                topology=topology,
+            )
+
+    def test_single_node_disables_kv_events_by_default(self, captured_spawn: list[dict[str, Any]]) -> None:
+        mc = DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B", num_replicas=1)
+        self._launch(mc, topology=_SINGLE_NODE_1GPU)
+
+        assert len(captured_spawn) == 1
+        python_args = captured_spawn[0]["python_args"]
+        kv_cfg = json.loads(python_args[python_args.index("--kv-events-config") + 1])
+        assert kv_cfg == {"enable_kv_cache_events": False}
+        assert "--headless" not in python_args
+        assert "--nnodes" not in python_args
+
+    def test_kv_router_enables_exact_kv_events(self, captured_spawn: list[dict[str, Any]]) -> None:
+        mc = DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B", num_replicas=1)
+        self._launch(mc, topology=_SINGLE_NODE_1GPU, router_mode="kv", router_kv_events=True)
+
+        python_args = captured_spawn[0]["python_args"]
+        kv_cfg = json.loads(python_args[python_args.index("--kv-events-config") + 1])
+        assert kv_cfg == {
+            "enable_kv_cache_events": True,
+            "endpoint": "tcp://*:24567",
+            "publisher": "zmq",
+            "topic": "kv-events",
+        }
+
+    def test_multi_node_rank0_adds_nnodes_and_master(self, captured_spawn: list[dict[str, Any]]) -> None:
+        mc = DynamoVLLMModelConfig(
+            model_identifier="Qwen/Qwen3-0.6B",
+            engine_kwargs={"tensor_parallel_size": 8},
+            num_replicas=1,
+        )
+        # Two 4-GPU nodes force the planner to pick STRICT_SPREAD with nnodes=2.
+        self._launch(mc, topology=_TWO_NODES_4GPU)
+        assert len(captured_spawn) == 2
+
+        rank0 = captured_spawn[0]["python_args"]
+        assert rank0[rank0.index("--nnodes") + 1] == "2"
+        assert rank0[rank0.index("--node-rank") + 1] == "0"
+        assert rank0[rank0.index("--master-addr") + 1] == "10.0.0.5"
+        assert "--headless" not in rank0
+
+        # rank >0 runs headless (no scheduler => kv events always off on that rank).
+        headless = captured_spawn[1]["python_args"]
+        assert "--headless" in headless
+        assert headless[headless.index("--node-rank") + 1] == "1"
+        assert headless[headless.index("--master-addr") + 1] == "10.0.0.5"
+        kv_cfg = json.loads(headless[headless.index("--kv-events-config") + 1])
+        assert kv_cfg["enable_kv_cache_events"] is False
+
+    def test_dynamo_kwargs_are_appended_as_cli_flags(self, captured_spawn: list[dict[str, Any]]) -> None:
+        mc = DynamoVLLMModelConfig(
+            model_identifier="Qwen/Qwen3-0.6B",
+            dynamo_kwargs={"tool_call_parser": "hermes", "reasoning_parser": "deepseek-r1"},
+            num_replicas=1,
+        )
+        self._launch(mc, topology=_SINGLE_NODE_1GPU)
+
+        python_args = captured_spawn[0]["python_args"]
+        assert python_args[python_args.index("--tool-call-parser") + 1] == "hermes"
+        assert python_args[python_args.index("--reasoning-parser") + 1] == "deepseek-r1"
+
+    def test_num_replicas_fans_out_worker_spawns(self, captured_spawn: list[dict[str, Any]]) -> None:
+        mc = DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B", num_replicas=3)
+        self._launch(mc, topology=_SINGLE_NODE_8GPU)
+
+        assert [c["label"] for c in captured_spawn] == [
+            "Dynamo_DP0_Qwen3-0.6B",
+            "Dynamo_DP1_Qwen3-0.6B",
+            "Dynamo_DP2_Qwen3-0.6B",
+        ]

--- a/tests/core/serve/integration/__init__.py
+++ b/tests/core/serve/integration/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/core/serve/integration/test_dynamo.py
+++ b/tests/core/serve/integration/test_dynamo.py
@@ -31,9 +31,8 @@ from nemo_curator.core.serve import (
 INTEGRATION_TEST_MODEL = "HuggingFaceTB/SmolLM2-135M-Instruct"  # pragma: allowlist secret
 
 
-@pytest.fixture(scope="class")
-def dynamo_aggregated_server(shared_ray_cluster: str) -> InferenceServer:  # noqa: ARG001
-    """Start a single-model aggregated Dynamo server for the class.
+def _make_aggregated_server() -> InferenceServer:
+    """Build a single-model aggregated Dynamo server used by the GPU integration tests.
 
     ``enforce_eager=True`` skips torch.compile + CUDA graph capture so the
     worker becomes ready in roughly the same window as the Ray Serve
@@ -48,11 +47,16 @@ def dynamo_aggregated_server(shared_ray_cluster: str) -> InferenceServer:  # noq
         },
         num_replicas=1,
     )
-    server = InferenceServer(
+    return InferenceServer(
         models=[model],
         backend=DynamoServerConfig(),
         health_check_timeout_s=600,
     )
+
+
+@pytest.fixture(scope="class")
+def dynamo_aggregated_server(shared_ray_cluster: str) -> InferenceServer:  # noqa: ARG001
+    server = _make_aggregated_server()
     server.start()
     try:
         yield server
@@ -86,29 +90,26 @@ class TestDynamoAggregatedSingleNode:
         assert response.choices
         assert response.choices[0].message.content
 
-    def test_restart_after_stop(self, dynamo_aggregated_server: InferenceServer) -> None:
-        """A new Dynamo server starts cleanly after the previous one is stopped.
 
-        Exercises the orphan-PG and orphan-actor sweeps in ``start()``:
-        tearing the first server down releases the named PGs, and a fresh
-        ``start()`` must not see stale bundles or actors from the prior
-        session.
-        """
+@pytest.mark.gpu
+class TestDynamoRestartAfterStop:
+    """Exercises the orphan-PG and orphan-actor sweeps by stopping and restarting.
+
+    This lives in its own class (with its own stop-early-own server) so it does
+    not mutate the class-scoped fixture shared by ``TestDynamoAggregatedSingleNode``.
+    Test-ordering randomizers (e.g. ``pytest-randomly``) would otherwise leave the
+    shared server stopped before other tests run.
+    """
+
+    def test_restart_after_stop(self, shared_ray_cluster: str) -> None:
         from openai import OpenAI
 
-        dynamo_aggregated_server.stop()
+        server = _make_aggregated_server()
+        server.start()
+        server.stop()
         assert not is_inference_server_active()
 
-        model = DynamoVLLMModelConfig(
-            model_identifier=INTEGRATION_TEST_MODEL,
-            engine_kwargs={"tensor_parallel_size": 1, "max_model_len": 512, "enforce_eager": True},
-            num_replicas=1,
-        )
-        server2 = InferenceServer(
-            models=[model],
-            backend=DynamoServerConfig(),
-            health_check_timeout_s=600,
-        )
+        server2 = _make_aggregated_server()
         server2.start()
         try:
             client = OpenAI(base_url=server2.endpoint, api_key="na")

--- a/tests/core/serve/integration/test_dynamo.py
+++ b/tests/core/serve/integration/test_dynamo.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU integration tests for the Dynamo backend (aggregated path only).
+
+Disaggregated serving and the cross-model validator coverage land in PR 5.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_curator.core.serve import (
+    DynamoServerConfig,
+    DynamoVLLMModelConfig,
+    InferenceServer,
+    is_inference_server_active,
+)
+
+INTEGRATION_TEST_MODEL = "HuggingFaceTB/SmolLM2-135M-Instruct"  # pragma: allowlist secret
+
+
+@pytest.fixture(scope="class")
+def dynamo_aggregated_server(shared_ray_cluster: str) -> InferenceServer:  # noqa: ARG001
+    """Start a single-model aggregated Dynamo server for the class.
+
+    ``enforce_eager=True`` skips torch.compile + CUDA graph capture so the
+    worker becomes ready in roughly the same window as the Ray Serve
+    integration test.
+    """
+    model = DynamoVLLMModelConfig(
+        model_identifier=INTEGRATION_TEST_MODEL,
+        engine_kwargs={
+            "tensor_parallel_size": 1,
+            "max_model_len": 512,
+            "enforce_eager": True,
+        },
+        num_replicas=1,
+    )
+    server = InferenceServer(
+        models=[model],
+        backend=DynamoServerConfig(),
+        health_check_timeout_s=600,
+    )
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+@pytest.mark.gpu
+@pytest.mark.usefixtures("dynamo_aggregated_server")
+class TestDynamoAggregatedSingleNode:
+    """End-to-end: real Dynamo frontend + etcd + NATS + one vLLM worker."""
+
+    def test_is_active_and_queryable(self, dynamo_aggregated_server: InferenceServer) -> None:
+        """Server is active, lists the registered model, and answers chat completions."""
+        from openai import OpenAI
+
+        assert is_inference_server_active()
+        assert dynamo_aggregated_server._started is True
+
+        client = OpenAI(base_url=dynamo_aggregated_server.endpoint, api_key="na")
+
+        model_ids = {m.id for m in client.models.list()}
+        assert INTEGRATION_TEST_MODEL in model_ids
+
+        response = client.chat.completions.create(
+            model=INTEGRATION_TEST_MODEL,
+            messages=[{"role": "user", "content": "Say hello in one word."}],
+            max_tokens=16,
+            temperature=0.0,
+        )
+        assert response.choices
+        assert response.choices[0].message.content
+
+    def test_restart_after_stop(self, dynamo_aggregated_server: InferenceServer) -> None:
+        """A new Dynamo server starts cleanly after the previous one is stopped.
+
+        Exercises the orphan-PG and orphan-actor sweeps in ``start()``:
+        tearing the first server down releases the named PGs, and a fresh
+        ``start()`` must not see stale bundles or actors from the prior
+        session.
+        """
+        from openai import OpenAI
+
+        dynamo_aggregated_server.stop()
+        assert not is_inference_server_active()
+
+        model = DynamoVLLMModelConfig(
+            model_identifier=INTEGRATION_TEST_MODEL,
+            engine_kwargs={"tensor_parallel_size": 1, "max_model_len": 512, "enforce_eager": True},
+            num_replicas=1,
+        )
+        server2 = InferenceServer(
+            models=[model],
+            backend=DynamoServerConfig(),
+            health_check_timeout_s=600,
+        )
+        server2.start()
+        try:
+            client = OpenAI(base_url=server2.endpoint, api_key="na")
+            assert INTEGRATION_TEST_MODEL in {m.id for m in client.models.list()}
+        finally:
+            server2.stop()
+
+
+@pytest.mark.gpu
+class TestDynamoRejectsDisagg:
+    """PR 4 ships aggregated-only; disagg must raise cleanly until PR 5 wires it up."""
+
+    def test_disagg_mode_raises_notimplemented(self, shared_ray_cluster: str) -> None:
+        from nemo_curator.core.serve import DynamoRoleConfig
+
+        model = DynamoVLLMModelConfig(
+            model_identifier=INTEGRATION_TEST_MODEL,
+            mode="disagg",
+            prefill=DynamoRoleConfig(num_replicas=1),
+            decode=DynamoRoleConfig(num_replicas=1),
+        )
+        server = InferenceServer(models=[model], backend=DynamoServerConfig())
+        with pytest.raises(NotImplementedError, match="Disaggregated serving"):
+            server.start()
+        assert not is_inference_server_active()

--- a/tests/core/serve/test_runtime_env.py
+++ b/tests/core/serve/test_runtime_env.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime-env merging behaviour exposed through the Dynamo backend.
+
+These tests live at the serve-package level (not the dynamo subpackage)
+because ``runtime_env`` is a user-facing promise of ``BaseModelConfig``:
+Curator-owned defaults (e.g. ``ai-dynamo[vllm]``) must not clobber a
+user's ``env_vars``, ``pip``, ``uv``, or ``working_dir``.
+"""
+
+from __future__ import annotations
+
+from nemo_curator.core.serve import DynamoVLLMModelConfig
+from nemo_curator.core.serve.dynamo.vllm import (
+    DYNAMO_VLLM_RUNTIME_ENV,
+    dynamo_runtime_env,
+    merge_model_runtime_envs,
+)
+
+
+class TestDynamoRuntimeEnv:
+    def test_default_runtime_env_only(self) -> None:
+        mc = DynamoVLLMModelConfig(model_identifier="Qwen/Qwen3-0.6B")
+        env = dynamo_runtime_env(mc)
+        assert env == DYNAMO_VLLM_RUNTIME_ENV
+
+    def test_user_runtime_env_merges_uv_packages(self) -> None:
+        mc = DynamoVLLMModelConfig(
+            model_identifier="Qwen/Qwen3-0.6B",
+            runtime_env={"uv": ["mypkg==1.0"]},
+        )
+        env = dynamo_runtime_env(mc)
+        assert env["uv"] == ["ai-dynamo[vllm]", "mypkg==1.0"]
+
+    def test_user_env_vars_are_preserved(self) -> None:
+        mc = DynamoVLLMModelConfig(
+            model_identifier="Qwen/Qwen3-0.6B",
+            runtime_env={"env_vars": {"HF_TOKEN": "abc", "TRANSFORMERS_OFFLINE": "1"}},
+        )
+        env = dynamo_runtime_env(mc)
+        assert env["uv"] == ["ai-dynamo[vllm]"]
+        assert env["env_vars"] == {"HF_TOKEN": "abc", "TRANSFORMERS_OFFLINE": "1"}
+
+    def test_working_dir_is_passed_through(self) -> None:
+        mc = DynamoVLLMModelConfig(
+            model_identifier="Qwen/Qwen3-0.6B",
+            runtime_env={"working_dir": "/workspace"},
+        )
+        env = dynamo_runtime_env(mc)
+        assert env["working_dir"] == "/workspace"
+
+
+class TestMergeModelRuntimeEnvs:
+    def test_no_models_yields_default_env(self) -> None:
+        assert merge_model_runtime_envs([]) == DYNAMO_VLLM_RUNTIME_ENV
+
+    def test_merges_env_vars_across_models(self) -> None:
+        models = [
+            DynamoVLLMModelConfig(
+                model_identifier="m1",
+                runtime_env={"env_vars": {"A": "1"}},
+            ),
+            DynamoVLLMModelConfig(
+                model_identifier="m2",
+                runtime_env={"env_vars": {"B": "2"}, "uv": ["userpkg"]},
+            ),
+        ]
+        env = merge_model_runtime_envs(models)
+        assert env["env_vars"] == {"A": "1", "B": "2"}
+        assert env["uv"] == ["ai-dynamo[vllm]", "userpkg"]
+
+    def test_later_model_env_var_overrides_earlier(self) -> None:
+        models = [
+            DynamoVLLMModelConfig(
+                model_identifier="m1",
+                runtime_env={"env_vars": {"HF_HOME": "/cache/v1"}},
+            ),
+            DynamoVLLMModelConfig(
+                model_identifier="m2",
+                runtime_env={"env_vars": {"HF_HOME": "/cache/v2"}},
+            ),
+        ]
+        env = merge_model_runtime_envs(models)
+        assert env["env_vars"]["HF_HOME"] == "/cache/v2"
+
+    def test_ignores_models_with_empty_runtime_env(self) -> None:
+        models = [
+            DynamoVLLMModelConfig(model_identifier="m1"),
+            DynamoVLLMModelConfig(
+                model_identifier="m2",
+                runtime_env={"env_vars": {"A": "1"}},
+            ),
+        ]
+        env = merge_model_runtime_envs(models)
+        assert env["env_vars"] == {"A": "1"}

--- a/tests/core/serve/test_subprocess_mgr.py
+++ b/tests/core/serve/test_subprocess_mgr.py
@@ -15,9 +15,14 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import re
+import subprocess
+import sys
+import time
 
+import psutil
 import pytest
 
 from nemo_curator.core.serve.placement import (
@@ -26,7 +31,11 @@ from nemo_curator.core.serve.placement import (
     get_free_port_in_bundle,
     plan_replica_bundle_shape,
 )
-from nemo_curator.core.serve.subprocess_mgr import ManagedSubprocess, _define_subprocess_actor
+from nemo_curator.core.serve.subprocess_mgr import (
+    ManagedSubprocess,
+    _define_subprocess_actor,
+    _stop_subprocess,
+)
 
 
 @pytest.mark.gpu
@@ -73,7 +82,8 @@ class TestReplicaLifecycle:
                         "bash",
                         "-c",
                         f"echo CUDA=$CUDA_VISIBLE_DEVICES; echo PATH=$PATH; "
-                        f"echo etcd=$ETCD_ENDPOINTS; echo post_init=${{{sentinel}:-MISSING}}",
+                        f"echo etcd=$ETCD_ENDPOINTS; echo post_init=${{{sentinel}:-MISSING}}; "
+                        "echo marker=${CURATOR_SUBPROC_MARKER:-MISSING}",
                     ],
                     runtime_dir=str(tmp_path),
                     actor_name_prefix=f"test_{os.getpid()}",
@@ -93,12 +103,128 @@ class TestReplicaLifecycle:
             assert "post_init=MISSING" in log, (
                 f"driver os.environ mutations set AFTER ray.init() must NOT leak to the actor:\n{log}"
             )
+            assert "marker=MISSING" in log, f"cleanup marker should not be injected into the subprocess env:\n{log}"
 
             # 4. Graceful stop reaps the subprocess without raising.
             proc.stop()
         finally:
             with contextlib.suppress(Exception):
                 ray.util.remove_placement_group(pg)
+
+
+def test_stop_subprocess_reaps_spawned_multiprocessing_children(tmp_path: os.PathLike) -> None:
+    """Children launched through Python multiprocessing spawn must die with the parent group."""
+    helper = os.path.join(tmp_path, "spawn_tree.py")
+    helper_src = """
+import json
+import multiprocessing
+import os
+import time
+
+def child_main():
+    time.sleep(300)
+
+if __name__ == '__main__':
+    ctx = multiprocessing.get_context('spawn')
+    child = ctx.Process(target=child_main, name='spawn-child')
+    child.start()
+    print(json.dumps({
+        'outer_pid': os.getpid(),
+        'outer_pgid': os.getpgid(0),
+        'child_pid': child.pid,
+        'child_pgid': os.getpgid(child.pid),
+    }), flush=True)
+    time.sleep(300)
+"""
+    with open(helper, "w") as f:
+        f.write(helper_src)
+
+    parent = subprocess.Popen(  # noqa: S603
+        [sys.executable, helper],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        assert parent.stdout is not None
+        info = json.loads(parent.stdout.readline())
+        tracked_pids = [parent.pid, info["child_pid"]]
+        assert info["child_pgid"] == info["outer_pgid"]
+
+        _stop_subprocess(parent, sigterm_wait=2)
+
+        for _ in range(20):
+            if not any(psutil.pid_exists(pid) for pid in tracked_pids):
+                break
+            time.sleep(0.1)
+        assert not any(psutil.pid_exists(pid) for pid in tracked_pids), "spawned child process tree was not reaped"
+    finally:
+        with contextlib.suppress(Exception):
+            if parent.poll() is None:
+                parent.kill()
+
+
+def test_stop_subprocess_reaps_same_group_child_after_launcher_exit(tmp_path: os.PathLike) -> None:
+    """Even if the launcher already exited, ``killpg(proc.pid)`` must reap the remaining group."""
+    helper = os.path.join(tmp_path, "same_group_orphan.py")
+    helper_src = """
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+if __name__ == '__main__' and len(sys.argv) > 1 and sys.argv[1] == '--child':
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    time.sleep(300)
+elif __name__ == '__main__':
+    child = subprocess.Popen([sys.executable, __file__, '--child'])
+    print(json.dumps({
+        'parent_pid': os.getpid(),
+        'parent_pgid': os.getpgid(0),
+        'child_pid': child.pid,
+        'child_pgid': os.getpgid(child.pid),
+    }), flush=True)
+"""
+    with open(helper, "w") as f:
+        f.write(helper_src)
+
+    parent = subprocess.Popen(  # noqa: S603
+        [sys.executable, helper],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    child_pid: int | None = None
+    try:
+        assert parent.stdout is not None
+        info = json.loads(parent.stdout.readline())
+        child_pid = info["child_pid"]
+
+        parent.wait(timeout=5)
+        assert parent.poll() is not None
+        assert info["parent_pid"] == parent.pid
+        assert info["parent_pgid"] == parent.pid
+        assert info["child_pgid"] == parent.pid
+        assert psutil.pid_exists(child_pid), "same-process-group child should still be alive before cleanup"
+
+        _stop_subprocess(parent, sigterm_wait=1)
+
+        for _ in range(20):
+            if not psutil.pid_exists(child_pid):
+                break
+            time.sleep(0.1)
+        assert not psutil.pid_exists(child_pid), "same-process-group child survived after launcher exit"
+    finally:
+        with contextlib.suppress(Exception):
+            if parent.poll() is None:
+                parent.kill()
+        with contextlib.suppress(Exception):
+            if child_pid is not None and psutil.pid_exists(child_pid):
+                psutil.Process(child_pid).kill()
 
 
 @pytest.mark.gpu

--- a/tests/core/serve/test_subprocess_mgr.py
+++ b/tests/core/serve/test_subprocess_mgr.py
@@ -15,240 +15,342 @@
 from __future__ import annotations
 
 import contextlib
-import json
 import os
 import re
-import subprocess
-import sys
-import time
+import socket
+from typing import TYPE_CHECKING
+from unittest import mock
 
 import psutil
 import pytest
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from nemo_curator.core.serve.constants import PLACEMENT_GROUP_READY_TIMEOUT_S
 from nemo_curator.core.serve.placement import (
+    build_pg,
     build_replica_pg,
-    get_bundle_node_ip,
     get_free_port_in_bundle,
     plan_replica_bundle_shape,
 )
 from nemo_curator.core.serve.subprocess_mgr import (
     ManagedSubprocess,
+    _check_binary,
     _define_subprocess_actor,
-    _stop_subprocess,
+    _wait_for_port,
+    graceful_stop_actors,
+    reacquire_detached_actor_handles,
+    sweep_orphan_actors_by_prefix,
 )
 
 
 @pytest.mark.gpu
-@pytest.mark.usefixtures("shared_ray_client")
-class TestReplicaLifecycle:
-    """Exercise the PG + actor + subprocess lifecycle end-to-end.
+class TestManagedSubprocess:
+    """End-to-end ManagedSubprocess lifecycle against a live GPU replica.
 
-    Collapses what were previously ~10 independent GPU tests (PG readiness,
-    bundle IP/port lookup, actor spawn, CUDA env propagation, subprocess env
-    semantics, graceful stop) into one run that shares a single replica PG
-    and subprocess actor. A per-test PG costs ~10s on this box; keeping a
-    single shared lifecycle keeps the GPU slice bounded.
+    A class-scoped fixture spawns one GPU-pinned subprocess whose bash
+    command emits env markers to the log and backgrounds a ``sleep`` in
+    the same process group. Tests operate on the live ``self.proc``
+    (``read_log_tail``, etc.) and the live ``self.pg``. The final test
+    ``test_stop_reaps_tree`` is destructive: it calls ``stop()`` and
+    asserts the whole subprocess tree was reaped. It must run last
+    (pytest's definition order) because it destroys shared fixture state.
+    Cross-session handle refresh is covered by ``TestCrossSessionTeardown``.
     """
 
-    def test_end_to_end(self, tmp_path: os.PathLike) -> None:
+    proc: ManagedSubprocess = None  # type: ignore[assignment]
+    pg = None
+
+    @pytest.fixture(scope="class", autouse=True)
+    def _spawn(self, request: pytest.FixtureRequest, tmp_path_factory: pytest.TempPathFactory) -> None:
         import ray
 
+        tag = os.getpid()
+        namespace = f"test_managed_{tag}"
+        pg_name = f"test_managed_pg_{tag}"
+        actor_name_prefix = f"test_managed_{tag}"
+        sentinel = f"CURATOR_SENTINEL_{tag}"
+
+        # Own the ``ray.init`` lifecycle: ``shared_ray_client`` is
+        # function-scoped and would tear the driver down between methods,
+        # invalidating the class-scoped ``pg`` and actor handles.
+        if ray.is_initialized():
+            ray.shutdown()
+        ray.init(namespace=namespace, ignore_reinit_error=True)
+
         spec = plan_replica_bundle_shape(tp_size=1, _topology=[{"node_id": "n", "num_gpus": 1, "is_head": False}])
-        pg_name = f"test_replica_lifecycle_{os.getpid()}"
         pg = build_replica_pg(spec, name=pg_name)
+
+        tmp_path = tmp_path_factory.mktemp("managed_subprocess")
+        os.environ[sentinel] = "hello_from_driver"
         try:
-            # 1. PG is ready and retrievable by name.
-            assert ray.util.get_placement_group(pg_name) is not None
+            proc = ManagedSubprocess.spawn(
+                "replica_lifecycle",
+                pg,
+                0,
+                num_gpus=1,
+                command=[
+                    "bash",
+                    "-c",
+                    f"echo CUDA=$CUDA_VISIBLE_DEVICES; echo PATH=$PATH; "
+                    f"echo etcd=$ETCD_ENDPOINTS; echo post_init=${{{sentinel}:-MISSING}}; "
+                    "sleep 300 & echo child_pid=$!; wait",
+                ],
+                runtime_dir=str(tmp_path),
+                actor_name_prefix=actor_name_prefix,
+                subprocess_env={"ETCD_ENDPOINTS": "http://10.0.0.1:2379"},
+            )
+            assert proc.is_alive(), "ManagedSubprocess failed to start"
+        finally:
+            os.environ.pop(sentinel, None)
 
-            # 2. Bundle-scoped helpers resolve against a real Ray node.
-            ip = get_bundle_node_ip(pg, 0)
-            assert re.match(r"^\d+\.\d+\.\d+\.\d+$", ip), f"unexpected ip: {ip!r}"
-            port = get_free_port_in_bundle(pg, 0, 30000)
-            assert 30000 <= port < 65536
+        request.cls.proc = proc
+        request.cls.pg = pg
 
-            # 3. ManagedSubprocess.spawn: CUDA_VISIBLE_DEVICES is sourced
-            #    from Ray-assigned accelerator IDs and written into the
-            #    subprocess env; targeted env overrides reach the
-            #    subprocess; pre-existing PATH is inherited from the raylet.
-            sentinel = f"CURATOR_SENTINEL_{os.getpid()}"
-            os.environ[sentinel] = "hello_from_driver"
-            try:
-                proc = ManagedSubprocess.spawn(
-                    "replica_lifecycle",
+        yield
+
+        # Cleanup. ``test_stop_reaps_tree`` has already reaped the
+        # subprocess + actor, so ``sweep`` finds 0 and we just drop the
+        # PG + driver. If a test failed earlier and left state behind,
+        # let the resulting cleanup error surface.
+        sweep_orphan_actors_by_prefix(prefix=actor_name_prefix, namespace=namespace)
+        ray.util.remove_placement_group(pg)
+        ray.shutdown()
+
+    def test_env_vars_propagated(self) -> None:
+        """CUDA sourced from Ray accelerator IDs, PATH inherited from the
+        raylet, ``subprocess_env`` overrides reach the subprocess, and
+        driver ``os.environ`` mutations set after ``ray.init()`` do NOT
+        leak into the actor's env."""
+        log = self.proc.read_log_tail()
+        cuda_match = re.search(r"CUDA=(\S+)", log)
+        assert cuda_match is not None, f"CUDA line missing in log:\n{log}"
+        for token in cuda_match.group(1).split(","):
+            assert token.strip().isdigit(), f"non-numeric CUDA id: {token!r}"
+        assert "PATH=/" in log, f"PATH should be inherited from raylet:\n{log}"
+        assert "etcd=http://10.0.0.1:2379" in log, f"subprocess_env override missing:\n{log}"
+        assert "post_init=MISSING" in log, f"driver env leak after ray.init():\n{log}"
+
+    def test_name_qualname(self) -> None:
+        """``_define_subprocess_actor`` labels the underlying class so the
+        Ray dashboard shows a descriptive name (e.g. ``Dynamo_DP0_Qwen3-0.6B``)."""
+        label = "Dynamo_DP0_Qwen3-0.6B"
+        cls = _define_subprocess_actor(label)
+        assert cls.__ray_metadata__.modified_class.__name__ == label
+        assert label in repr(cls)
+
+    def test_port(self) -> None:
+        """``get_free_port_in_bundle`` resolves to a usable port inside the bundle."""
+        port = get_free_port_in_bundle(self.pg, bundle_index=0, start_port=30000)
+        assert 30000 <= port < 65536
+
+    def test_ray_wait_resolves_on_actor_kill(self) -> None:
+        """``DynamoBackend`` polls ``ray.wait(run_refs, timeout=0)`` to detect
+        crashed subprocesses; killing an actor must make its run ref resolve.
+
+        Uses its own throwaway actor so the shared ``self.proc`` stays alive
+        for the destructive ``test_stop_reaps_tree`` below.
+        """
+        import ray
+
+        actor_cls = _define_subprocess_actor()
+        actor = actor_cls.options(
+            name=f"test_death_{os.getpid()}",
+            lifetime="detached",
+            num_gpus=0,
+        ).remote()
+        try:
+            ray.get(actor.initialize.remote(["sleep", "60"], {}, None), timeout=30)
+            run_ref = actor.run.remote()
+            ray.kill(actor, no_restart=True)
+            ready, _ = ray.wait([run_ref], timeout=30)
+            assert len(ready) == 1
+        finally:
+            # Idempotent: no-op if ``ray.kill`` above already ran;
+            # reaps the actor if an earlier step failed.
+            ray.kill(actor, no_restart=True)
+
+    # --- destructive: must stay the last test method (definition order) ---
+
+    def test_stop_reaps_tree(self) -> None:
+        """``ManagedSubprocess.stop()`` reaps the whole process group via
+        ``killpg`` -- both the bash launcher and the backgrounded ``sleep``
+        (which shares the launcher's ``pgid``).
+
+        Destroys shared fixture state; must run last in the class.
+        """
+        log = self.proc.read_log_tail()
+        match = re.search(r"child_pid=(\d+)", log)
+        assert match is not None, f"backgrounded child pid not found in log:\n{log}"
+        child_pid = int(match.group(1))
+
+        self.proc.stop(timeout_s=15)
+        with contextlib.suppress(psutil.NoSuchProcess):
+            psutil.Process(child_pid).wait(timeout=5)
+        assert not psutil.pid_exists(child_pid), f"subprocess-tree child (pid={child_pid}) survived proc.stop()"
+
+
+class TestCrossSessionTeardown:
+    """``with ray.init()`` attach/detach teardown cycle.
+
+    Exercises detached-actor survival across a driver disconnect, stale
+    ``ActorHandle`` dispatch failure, ``reacquire_detached_actor_handles``
+    refreshing + filtering, ``ManagedSubprocess.stop`` reaping via the
+    refreshed handle, and ``sweep_orphan_actors_by_prefix`` as the
+    safety-net path. CPU-only (``sleep`` subprocess on a ``num_gpus=0``
+    bundle).
+    """
+
+    def test_end_to_end(self, tmp_path: Path) -> None:
+        import ray
+
+        tag = os.getpid()
+        namespace = f"test_cross_session_{tag}"
+        pg_name = f"test_cross_session_pg_{tag}"
+        actor_name_prefix = f"test_xs_{tag}"
+        live_label = "real_target"
+        missing_label = "never_existed"
+        subprocess_pid: int | None = None
+
+        # ``ray.init(ignore_reinit_error=True)`` is a no-op on an already-
+        # initialized driver and would silently reuse its namespace.
+        # Reset so the namespace below takes effect.
+        if ray.is_initialized():
+            ray.shutdown()
+
+        try:
+            with ray.init(namespace=namespace, ignore_reinit_error=True):
+                pg = build_pg(
+                    bundles=[{"CPU": 1}],
+                    strategy="STRICT_PACK",
+                    name=pg_name,
+                    bundle_label_selector=None,
+                    ready_timeout_s=PLACEMENT_GROUP_READY_TIMEOUT_S,
+                )
+                stored_proc = ManagedSubprocess.spawn(
+                    live_label,
                     pg,
                     0,
-                    num_gpus=1,
-                    command=[
-                        "bash",
-                        "-c",
-                        f"echo CUDA=$CUDA_VISIBLE_DEVICES; echo PATH=$PATH; "
-                        f"echo etcd=$ETCD_ENDPOINTS; echo post_init=${{{sentinel}:-MISSING}}; "
-                        "echo marker=${CURATOR_SUBPROC_MARKER:-MISSING}",
-                    ],
+                    num_gpus=0,
+                    command=["sleep", "3600"],
                     runtime_dir=str(tmp_path),
-                    actor_name_prefix=f"test_{os.getpid()}",
-                    subprocess_env={"ETCD_ENDPOINTS": "http://10.0.0.1:2379"},
+                    actor_name_prefix=actor_name_prefix,
                 )
-                proc.wait(timeout=30)
-                log = proc.read_log_tail()
-            finally:
-                os.environ.pop(sentinel, None)
+                subprocess_pid = stored_proc.pid()
+                assert psutil.pid_exists(subprocess_pid)
+                stale_actor = stored_proc.actor  # pinned to this driver's job id
 
-            cuda_match = re.search(r"CUDA=(\S+)", log)
-            assert cuda_match is not None, f"CUDA line missing in log:\n{log}"
-            for token in cuda_match.group(1).split(","):
-                assert token.strip().isdigit(), f"non-numeric CUDA id: {token!r}"
-            assert "PATH=/" in log, f"PATH should be inherited from raylet:\n{log}"
-            assert "etcd=http://10.0.0.1:2379" in log, f"subprocess_env override missing:\n{log}"
-            assert "post_init=MISSING" in log, (
-                f"driver os.environ mutations set AFTER ray.init() must NOT leak to the actor:\n{log}"
-            )
-            assert "marker=MISSING" in log, f"cleanup marker should not be injected into the subprocess env:\n{log}"
+            assert psutil.pid_exists(subprocess_pid), "detached actor's subprocess must survive a driver disconnect"
 
-            # 4. Graceful stop reaps the subprocess without raising.
-            proc.stop()
+            with ray.init(namespace=namespace, ignore_reinit_error=True):
+                # Stale handle from the previous driver session cannot dispatch.
+                # Exact exception varies (``ActorHandleNotFoundError`` at dispatch
+                # vs. a delivered-error ref), so the match is broad.
+                with pytest.raises(Exception):  # noqa: B017, PT011
+                    ray.get(stale_actor.is_alive.remote(), timeout=5)
+
+                # A bogus entry must be filtered so callers don't have to
+                # defend against ``None`` actor handles downstream.
+                bogus = ManagedSubprocess(label=missing_label, actor=stale_actor)
+                refreshed = reacquire_detached_actor_handles(
+                    [stored_proc, bogus],
+                    actor_name_prefix=actor_name_prefix,
+                    namespace=namespace,
+                )
+                assert [p.label for p in refreshed] == [live_label]
+                assert refreshed[0] is stored_proc
+                assert stored_proc.actor is not stale_actor
+                assert ray.get(stored_proc.actor.is_alive.remote(), timeout=10) is True
+
+                # Refreshed handle drives the full reap path.
+                stored_proc.stop(timeout_s=15)
+                with contextlib.suppress(psutil.NoSuchProcess):
+                    psutil.Process(subprocess_pid).wait(timeout=5)
+                assert not psutil.pid_exists(subprocess_pid), (
+                    "subprocess must be reaped via the refreshed actor handle"
+                )
+
+                # After a clean stop nothing should match the prefix.
+                assert sweep_orphan_actors_by_prefix(prefix=actor_name_prefix, namespace=namespace) == 0
         finally:
-            with contextlib.suppress(Exception):
-                ray.util.remove_placement_group(pg)
+            # The happy path's ``with ray.init()`` context has already
+            # exited; re-attach to clean up the PG + drain any actors
+            # left behind by an earlier assertion failure.
+            if not ray.is_initialized():
+                ray.init(namespace=namespace, ignore_reinit_error=True)
+            sweep_orphan_actors_by_prefix(prefix=actor_name_prefix, namespace=namespace)
+            # PG may be absent: test failed before creating it, or it was
+            # already removed. ``ray.util.get_placement_group`` raises
+            # ``ValueError`` in that case.
+            with contextlib.suppress(ValueError):
+                ray.util.remove_placement_group(ray.util.get_placement_group(pg_name))
+            ray.shutdown()
+            if subprocess_pid is not None:
+                with contextlib.suppress(psutil.NoSuchProcess):
+                    psutil.Process(subprocess_pid).kill()
 
 
-def test_stop_subprocess_reaps_spawned_multiprocessing_children(tmp_path: os.PathLike) -> None:
-    """Children launched through Python multiprocessing spawn must die with the parent group."""
-    helper = os.path.join(tmp_path, "spawn_tree.py")
-    helper_src = """
-import json
-import multiprocessing
-import os
-import time
+class TestSubprocessUtils:
+    """Standalone helpers in ``subprocess_mgr`` not reached by the
+    ``TestManagedSubprocess`` / ``TestCrossSessionTeardown`` paths."""
 
-def child_main():
-    time.sleep(300)
+    def test_check_binary(self) -> None:
+        _check_binary("bash")
+        with pytest.raises(FileNotFoundError, match="not found on"):
+            _check_binary("definitely-not-a-real-binary-xyz-12345")
 
-if __name__ == '__main__':
-    ctx = multiprocessing.get_context('spawn')
-    child = ctx.Process(target=child_main, name='spawn-child')
-    child.start()
-    print(json.dumps({
-        'outer_pid': os.getpid(),
-        'outer_pgid': os.getpgid(0),
-        'child_pid': child.pid,
-        'child_pgid': os.getpgid(child.pid),
-    }), flush=True)
-    time.sleep(300)
-"""
-    with open(helper, "w") as f:
-        f.write(helper_src)
+    def test_graceful_stop_actors_tolerates_dispatch_failure(self) -> None:
+        import sys
+        from types import ModuleType
 
-    parent = subprocess.Popen(  # noqa: S603
-        [sys.executable, helper],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        start_new_session=True,
-    )
-    try:
-        assert parent.stdout is not None
-        info = json.loads(parent.stdout.readline())
-        tracked_pids = [parent.pid, info["child_pid"]]
-        assert info["child_pgid"] == info["outer_pgid"]
+        wait_calls: list[tuple[list[object], int, float | None]] = []
+        kill_calls: list[tuple[object, bool]] = []
 
-        _stop_subprocess(parent, sigterm_wait=2)
+        fake_ray = ModuleType("ray")
 
-        for _ in range(20):
-            if not any(psutil.pid_exists(pid) for pid in tracked_pids):
-                break
-            time.sleep(0.1)
-        assert not any(psutil.pid_exists(pid) for pid in tracked_pids), "spawned child process tree was not reaped"
-    finally:
-        with contextlib.suppress(Exception):
-            if parent.poll() is None:
-                parent.kill()
+        def _wait(refs: list[object], *, num_returns: int, timeout: float | None) -> tuple[list[object], list[object]]:
+            refs_copy = list(refs)
+            wait_calls.append((refs_copy, num_returns, timeout))
+            return refs_copy, []
 
+        def _get(ref: object, timeout: float | None = None) -> object:
+            _ = timeout
+            return ref
 
-def test_stop_subprocess_reaps_same_group_child_after_launcher_exit(tmp_path: os.PathLike) -> None:
-    """Even if the launcher already exited, ``killpg(proc.pid)`` must reap the remaining group."""
-    helper = os.path.join(tmp_path, "same_group_orphan.py")
-    helper_src = """
-import json
-import os
-import signal
-import subprocess
-import sys
-import time
+        def _kill(actor: object, *, no_restart: bool = True) -> None:
+            kill_calls.append((actor, no_restart))
 
-if __name__ == '__main__' and len(sys.argv) > 1 and sys.argv[1] == '--child':
-    signal.signal(signal.SIGTERM, signal.SIG_IGN)
-    time.sleep(300)
-elif __name__ == '__main__':
-    child = subprocess.Popen([sys.executable, __file__, '--child'])
-    print(json.dumps({
-        'parent_pid': os.getpid(),
-        'parent_pgid': os.getpgid(0),
-        'child_pid': child.pid,
-        'child_pgid': os.getpgid(child.pid),
-    }), flush=True)
-"""
-    with open(helper, "w") as f:
-        f.write(helper_src)
+        fake_ray.wait = _wait
+        fake_ray.get = _get
+        fake_ray.kill = _kill
 
-    parent = subprocess.Popen(  # noqa: S603
-        [sys.executable, helper],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        start_new_session=True,
-    )
-    child_pid: int | None = None
-    try:
-        assert parent.stdout is not None
-        info = json.loads(parent.stdout.readline())
-        child_pid = info["child_pid"]
+        healthy = mock.Mock()
+        healthy.stop.remote.return_value = "healthy-stop"
 
-        parent.wait(timeout=5)
-        assert parent.poll() is not None
-        assert info["parent_pid"] == parent.pid
-        assert info["parent_pgid"] == parent.pid
-        assert info["child_pgid"] == parent.pid
-        assert psutil.pid_exists(child_pid), "same-process-group child should still be alive before cleanup"
+        stale = mock.Mock()
+        stale.stop.remote.side_effect = RuntimeError("stale handle")
+        stale.force_sigkill_subprocess.remote.return_value = "stale-sigkill"
 
-        _stop_subprocess(parent, sigterm_wait=1)
+        with mock.patch.dict(sys.modules, {"ray": fake_ray}):
+            graceful_stop_actors([("healthy", healthy), ("stale", stale)], timeout_s=7)
 
-        for _ in range(20):
-            if not psutil.pid_exists(child_pid):
-                break
-            time.sleep(0.1)
-        assert not psutil.pid_exists(child_pid), "same-process-group child survived after launcher exit"
-    finally:
-        with contextlib.suppress(Exception):
-            if parent.poll() is None:
-                parent.kill()
-        with contextlib.suppress(Exception):
-            if child_pid is not None and psutil.pid_exists(child_pid):
-                psutil.Process(child_pid).kill()
+        assert wait_calls == [(["healthy-stop"], 1, 7)]
+        healthy.force_sigkill_subprocess.remote.assert_not_called()
+        stale.force_sigkill_subprocess.remote.assert_called_once_with()
+        assert kill_calls == [(healthy, True), (stale, True)]
 
+    def test_wait_for_port(self) -> None:
+        # Timeout path: bind then close so the port is guaranteed unreachable.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            closed_port = probe.getsockname()[1]
+        with pytest.raises(TimeoutError, match="did not become reachable"):
+            _wait_for_port("127.0.0.1", closed_port, timeout_s=0.5, label="closed")
 
-@pytest.mark.gpu
-@pytest.mark.usefixtures("shared_ray_client")
-def test_actor_death_surfaces_via_run_ref() -> None:
-    """Hard-killing the actor makes its run ref resolve in ray.wait().
-
-    This is the signal DynamoBackend uses to detect a crashed subprocess
-    (``ray.wait(run_refs, timeout=0)``).
-    """
-    import ray
-
-    actor_cls = _define_subprocess_actor()
-    actor_name = f"test_liveness_death_{os.getpid()}"
-    actor = actor_cls.options(name=actor_name, lifetime="detached").remote()
-    ray.get(actor.initialize.remote(["sleep", "3600"], {}, None), timeout=30)
-    run_ref = actor.run.remote()
-    proc = ManagedSubprocess(label="death", actor=actor, run_ref=run_ref)
-    try:
-        assert proc.is_alive()
-        ray.kill(proc.actor, no_restart=True)
-        ready, _ = ray.wait([proc.run_ref], timeout=30)
-        assert len(ready) == 1
-    except Exception:
-        with contextlib.suppress(Exception):
-            ray.kill(proc.actor, no_restart=True)
-        raise
+        # Success path: listen, then probe.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+            server.bind(("127.0.0.1", 0))
+            server.listen(1)
+            open_port = server.getsockname()[1]
+            _wait_for_port("127.0.0.1", open_port, timeout_s=2, label="open")

--- a/tests/gpu_test_groups.json
+++ b/tests/gpu_test_groups.json
@@ -20,6 +20,7 @@
     "paths": [
       "tests/stages/synthetic",
       "tests/core/serve/ray_serve/test_integration.py",
+      "tests/core/serve/integration/test_dynamo.py",
       "tests/core/serve/test_placement.py",
       "tests/core/serve/test_subprocess_mgr.py"
     ]


### PR DESCRIPTION
> **Reviewer tip:** the diff in `nemo_curator/core/serve/dynamo/backend.py` (lifecycle / infra / frontend / health) and the new `nemo_curator/core/serve/dynamo/vllm.py` (worker launch) are where the real work lives. Everything else is tests, small constants.

## Description

- PR 4/5 of the inference-server restack
- replace the #1820 `DynamoBackend` placeholder with a real backend for **aggregated serving** — single-node TP and multi-node TP — built on the placement-group API landed in #1833
- split worker-launch concerns out of `dynamo/backend.py` into a new `dynamo/vllm.py` so lifecycle (start/stop, infra, frontend, health) and vLLM-specific worker assembly stay separately reviewable
- promote a few repeated strings and indexes to typed constants in `dynamo/constants.py`: actor labels (`ETCD_ACTOR_LABEL`, `NATS_ACTOR_LABEL`, `FRONTEND_ACTOR_LABEL`) and infra-bundle layout (`INFRA_ETCD_BUNDLE`, `INFRA_NATS_BUNDLE`, `INFRA_FRONTEND_BUNDLE`, `INFRA_NUM_BUNDLES`)
- `mode=\"disagg\"` raises `NotImplementedError` here; disagg + cross-model validators + full router-flag translation ship in the final PR

## Design callouts

- **Single frontend per server, not per model.** The Dynamo frontend auto-discovers every registered model via etcd, so one `--http-port` on the infra PG serves all models. The full per-key router-flag merge across models is PR 5's job; this PR wires only `--router-mode` plus `router_kwargs` passthrough.
- **Explicit `--kv-events-config` on every worker.** Without this, Dynamo's `args.py` auto-creates a `KVEventsConfig` bound to `tcp://*:20080` when `prefix_caching` is enabled (vLLM ≥0.16 default), and every worker on the same node fights over the same port. Rank-0 workers publish ZMQ KV events only when the router is `mode=\"kv\"` with `kv_events=True`; every other case disables events explicitly so the default-port binding never happens.
- **One `_launch_vllm_worker` for rank-0 and headless ranks.** Rank-0 adds endpoint / discovery / planes / optional KV-events publisher; rank-N adds `--headless` and forces KV events off. Multi-node TP resolves `--master-addr` post-`pg.ready()` via `get_bundle_node_ip(pg, 0)`.
- **Orphan sweeps in `start()`.** `remove_named_pgs_with_prefix` reaps stale PGs, but PG removal force-kills scheduled actors and bypasses their `atexit` hook — which would orphan the subprocess tree. A `list_actors(state=\"ALIVE\")` sweep filtered by the PG name prefix runs *first* so `graceful_stop_actors` can SIGTERM the process groups cleanly (with SIGKILL escalation from PR 3 as the fallback).
- **Typed `self._models` narrowed once in `__init__`.** `server.models: list[BaseModelConfig]` carries no Dynamo-specific fields; `InferenceServer._validate_model_configs` already enforces that every entry is a `DynamoVLLMModelConfig`, so we `cast` once and every backend method gets `.num_replicas` / `.mode` / `.engine_kwargs` autocomplete.

## Usage

```python
from nemo_curator.core.serve import (
    DynamoRouterConfig,
    DynamoServerConfig,
    DynamoVLLMModelConfig,
    InferenceServer,
)

model = DynamoVLLMModelConfig(
    model_identifier=\"Qwen/Qwen3-0.6B\",
    num_replicas=2,
    engine_kwargs={\"tensor_parallel_size\": 1, \"enforce_eager\": True},
    # `dynamo_kwargs` is a dict pass-through for any `python -m dynamo.vllm` flag
    # Curator doesn't type yet (e.g. tool_call_parser, reasoning_parser, ...).
    dynamo_kwargs={\"tool_call_parser\": \"hermes\"},
)
backend_cfg = DynamoServerConfig(
    router=DynamoRouterConfig(mode=\"kv\", kv_events=True),
)
with InferenceServer(models=[model], backend=backend_cfg) as server:
    print(server.endpoint)  # http://<infra-node-ip>:<port>/v1
```

## What's intentionally NOT in this PR

- **disaggregated serving** (`mode=\"disagg\"`): raises `NotImplementedError` with a pointer to PR 5
- **cross-model validators**: `_validate_frontend_config` (coherent namespace/planes/router across models), `_validate_unique_model_names`, and the disagg-TP-fit branch of `_validate_gpu_requirements`
- **full router-flag translation**: `_resolve_frontend_router_config` per-key fallback + `--router-kv-events` / `--router-temperature` / `--router-ttl-secs` / etc. — PR 5 promotes whatever needs typed fields; everything else stays on `router_kwargs`
- **Ray Serve backend changes**: this PR touches only the Dynamo subpackage

## Verification

- `ruff check nemo_curator/core/serve/ tests/core/serve/` — clean
- `pytest tests/core/serve/ -m \"not gpu\"` — 67 passed (~43s)
- `CUDA_VISIBLE_DEVICES=2,3 pytest tests/core/serve/integration/test_dynamo.py -m gpu` — 3 passed (~3m49s)
  - `TestDynamoAggregatedSingleNode::test_is_active_and_queryable` — full Dynamo frontend + etcd + NATS + vLLM worker answers OpenAI chat completions
  - `TestDynamoAggregatedSingleNode::test_restart_after_stop` — exercises the orphan-PG + orphan-actor sweeps
  - `TestDynamoRejectsDisagg::test_disagg_mode_raises_notimplemented` — verifies the PR 5 deferral

## Checklist

- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.