### PR TITLE
Add shard-level checkpointing with .done markers

### DIFF
--- a/examples/audio/qwen_omni_inprocess/run_pipeline.py
+++ b/examples/audio/qwen_omni_inprocess/run_pipeline.py
@@ -61,7 +61,7 @@ from loguru import logger
 
 from nemo_curator.backends.xenna import XennaExecutor
 from nemo_curator.pipeline import Pipeline
-from nemo_curator.stages.audio.alm.alm_manifest_writer import ALMManifestWriterStage
+from nemo_curator.stages.audio.alm.sharded_manifest_writer import ShardedManifestWriterStage
 from nemo_curator.stages.audio.inference.qwen_omni import InferenceQwenOmniStage
 from nemo_curator.stages.audio.io.nemo_tarred_reader import NemoTarredAudioReader
 from nemo_curator.stages.audio.text_filtering import (
@@ -77,7 +77,7 @@ def main():
     ap = argparse.ArgumentParser(description="QwenOmni in-process vLLM pipeline")
     ap.add_argument("--data_config", type=str, required=True, help="Granary YAML data config.")
     ap.add_argument("--corpus", type=str, nargs="*", default=None, help="Process only these corpora.")
-    ap.add_argument("--output", type=str, required=True, help="Output JSONL path.")
+    ap.add_argument("--output_dir", type=str, required=True, help="Output directory for per-shard manifests.")
     ap.add_argument("--model_id", type=str, default="Qwen/Qwen3-Omni-30B-A3B-Instruct")
     ap.add_argument("--prompt", type=str, default="Transcribe the audio.")
     ap.add_argument("--prompt_file", type=str, default=None, help="Read prompt from file.")
@@ -144,6 +144,7 @@ def main():
                 yaml_path=args.data_config,
                 corpus_filter=args.corpus,
                 s3_endpoint_url=args.s3_endpoint_url,
+                output_dir=args.output_dir,
             ).with_({"nemo_tar_shard_reader": {"resources": Resources(cpus=4.0)}}),
             InitializeFieldsStage(),
             InferenceQwenOmniStage(
@@ -181,13 +182,13 @@ def main():
                 text_key="qwen3_prediction_s2" if followup_prompt else "qwen3_prediction_s1",
                 output_text_key="cleaned_text",
             ),
-            ALMManifestWriterStage(
-                output_path=args.output,
+            ShardedManifestWriterStage(
+                output_dir=args.output_dir,
             ),
         ],
     )
 
-    logger.info("Pipeline: %s", pipeline.describe())
+    logger.info(f"Pipeline: {pipeline.describe()}")
 
     executor = XennaExecutor(config={
         "execution_mode": args.execution_mode,
@@ -196,7 +197,7 @@ def main():
     t0 = time.time()
     pipeline.run(executor=executor)
     elapsed = time.time() - t0
-    logger.info("Pipeline finished in %.1f min. Output: %s", elapsed / 60, args.output)
+    logger.info(f"Pipeline finished in {elapsed / 60:.1f} min. Output: {args.output_dir}")
 
 
 if __name__ == "__main__":

--- a/examples/audio/qwen_omni_inprocess/run_pipeline.py
+++ b/examples/audio/qwen_omni_inprocess/run_pipeline.py
@@ -73,7 +73,7 @@ from nemo_curator.stages.audio.text_filtering import (
 from nemo_curator.stages.resources import Resources
 
 
-def main():
+def main() -> None:
     ap = argparse.ArgumentParser(description="QwenOmni in-process vLLM pipeline")
     ap.add_argument("--data_config", type=str, required=True, help="Granary YAML data config.")
     ap.add_argument("--corpus", type=str, nargs="*", default=None, help="Process only these corpora.")

--- a/nemo_curator/models/qwen_omni.py
+++ b/nemo_curator/models/qwen_omni.py
@@ -102,8 +102,7 @@ class QwenOmni(ModelInterface):
         tp_size = self.tensor_parallel_size or get_gpu_count()
 
         logger.info(
-            "Loading QwenOmni model=%s  tp=%d  max_model_len=%d  max_num_seqs=%d",
-            self.model_id, tp_size, self.max_model_len, self.max_num_seqs,
+            f"Loading QwenOmni model={self.model_id}  tp={tp_size}  max_model_len={self.max_model_len}  max_num_seqs={self.max_num_seqs}"
         )
 
         self._llm = LLM(
@@ -206,7 +205,7 @@ class QwenOmni(ModelInterface):
             text = self._processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
             audios, images, videos = process_mm_info(messages, use_audio_in_video=False)
         except Exception:
-            logger.warning("Failed to preprocess audio, skipping (waveform shape=%s, sr=%d)", waveform.shape, sample_rate)
+            logger.warning(f"Failed to preprocess audio, skipping (waveform shape={waveform.shape}, sr={sample_rate})")
             return None
 
         inputs: dict[str, Any] = {
@@ -241,7 +240,7 @@ class QwenOmni(ModelInterface):
             text = self._processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
             audios, images, videos = process_mm_info(messages, use_audio_in_video=False)
         except Exception:
-            logger.warning("Failed to preprocess Turn 2 audio (shape=%s)", waveform_16k.shape)
+            logger.warning(f"Failed to preprocess Turn 2 audio (shape={waveform_16k.shape})")
             return None
 
         inputs: dict[str, Any] = {
@@ -306,11 +305,11 @@ class QwenOmni(ModelInterface):
         waveforms_16k: dict[int, np.ndarray] = {i: prepared[i][1] for i in valid_indices}
 
         if not valid_inputs:
-            logger.warning("All %d audio samples in batch failed preprocessing", n)
+            logger.warning(f"All {n} audio samples in batch failed preprocessing")
             return [""] * n, [""] * n
 
         if len(valid_inputs) < n:
-            logger.warning("Skipped %d/%d corrupt audio samples", n - len(valid_inputs), n)
+            logger.warning(f"Skipped {n - len(valid_inputs)}/{n} corrupt audio samples")
 
         t1_outputs = self._llm.generate(valid_inputs, sampling_params=self._sampling_params, use_tqdm=False)
 

--- a/nemo_curator/models/qwen_omni.py
+++ b/nemo_curator/models/qwen_omni.py
@@ -16,13 +16,15 @@ from __future__ import annotations
 
 import gc
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import numpy as np
 from loguru import logger
 
 from nemo_curator.models.base import ModelInterface
 from nemo_curator.utils.gpu_utils import get_gpu_count
+
+if TYPE_CHECKING:
+    import numpy as np
 
 try:
     from vllm import LLM, SamplingParams
@@ -227,7 +229,7 @@ class QwenOmni(ModelInterface):
         sample_rates: list[int],
     ) -> list[tuple[dict[str, Any], np.ndarray] | None]:
         if self._prep_pool is None:
-            return [self._prepare_single(w, sr) for w, sr in zip(waveforms, sample_rates)]
+            return [self._prepare_single(w, sr) for w, sr in zip(waveforms, sample_rates, strict=False)]
         return list(self._prep_pool.map(self._prepare_single, waveforms, sample_rates))
 
     def _prepare_turn2_single(
@@ -264,7 +266,7 @@ class QwenOmni(ModelInterface):
         if self._prep_pool is None:
             return [
                 self._prepare_turn2_single(w, pt)
-                for w, pt in zip(waveforms_16k, pred_texts)
+                for w, pt in zip(waveforms_16k, pred_texts, strict=False)
             ]
         return list(self._prep_pool.map(self._prepare_turn2_single, waveforms_16k, pred_texts))
 
@@ -314,7 +316,7 @@ class QwenOmni(ModelInterface):
         t1_outputs = self._llm.generate(valid_inputs, sampling_params=self._sampling_params, use_tqdm=False)
 
         pred_texts: list[str] = [""] * n
-        for idx, out in zip(valid_indices, t1_outputs):
+        for idx, out in zip(valid_indices, t1_outputs, strict=False):
             pred_texts[idx] = out.outputs[0].text.strip()
 
         # -- Turn 2 (disfluency refinement) -----------------------------------
@@ -330,7 +332,7 @@ class QwenOmni(ModelInterface):
             [pred_texts[i] for i in t2_indices],
         )
 
-        t2_valid = [(i, p) for i, p in zip(t2_indices, t2_prepared) if p is not None]
+        t2_valid = [(i, p) for i, p in zip(t2_indices, t2_prepared, strict=False) if p is not None]
         if not t2_valid:
             logger.warning("All Turn 2 samples failed preprocessing")
             return pred_texts, [""] * n
@@ -340,7 +342,7 @@ class QwenOmni(ModelInterface):
         )
 
         disfluency_texts: list[str] = [""] * n
-        for (idx, _), out in zip(t2_valid, t2_outputs):
+        for (idx, _), out in zip(t2_valid, t2_outputs, strict=False):
             disfluency_texts[idx] = out.outputs[0].text.strip()
 
         return pred_texts, disfluency_texts

--- a/nemo_curator/stages/audio/__init__.py
+++ b/nemo_curator/stages/audio/__init__.py
@@ -30,19 +30,19 @@ __all__ = [
     "ALMDataOverlapStage",
     "AudioDataFilterStage",
     "BandFilterStage",
+    "FastTextLIDStage",
+    "FinalizeFieldsStage",
     "GetAudioDurationStage",
+    "InitializeFieldsStage",
     "MonoConversionStage",
     "PreserveByValueStage",
+    "RegexSubstitutionStage",
     "SIGMOSFilterStage",
     "SegmentConcatenationStage",
     "SpeakerSeparationStage",
     "TimestampMapperStage",
     "UTMOSFilterStage",
     "VADSegmentationStage",
-    "FastTextLIDStage",
-    "FinalizeFieldsStage",
-    "InitializeFieldsStage",
-    "RegexSubstitutionStage",
     "WhisperHallucinationStage",
 ]
 
@@ -68,9 +68,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
 }
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> type:
     if name in _LAZY_IMPORTS:
         module_path, attr = _LAZY_IMPORTS[name]
         module = _importlib.import_module(module_path)
         return getattr(module, attr)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/nemo_curator/stages/audio/alm/sharded_manifest_writer.py
+++ b/nemo_curator/stages/audio/alm/sharded_manifest_writer.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sharded Manifest Writer -- writes per-corpus/shard JSONL with .done markers."""
+
+import json
+import os
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+from nemo_curator.backends.base import NodeInfo, WorkerMetadata
+from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.tasks import AudioTask, FileGroupTask
+
+
+@dataclass
+class ShardedManifestWriterStage(ProcessingStage[AudioTask, FileGroupTask]):
+    """Write AudioTasks to per-corpus/shard JSONL files with .done markers.
+
+    Output structure::
+
+        output_dir/
+          {corpus}/
+            {shard_id}.jsonl
+            {shard_id}.done    # written after all utterances in the shard
+
+    On resume, shards with ``.done`` files are skipped by the discovery stage.
+    Partial shards (no ``.done``) are deleted and re-processed.
+
+    The shard key is extracted from ``task._metadata["_shard_key"]``
+    which is set by ``NemoTarShardReaderStage`` as ``{corpus}_{shard_idx}``.
+
+    Args:
+        output_dir: Root directory for output manifests.
+    """
+
+    name: str = "sharded_manifest_writer"
+    output_dir: str = ""
+    _shard_counts: dict[str, int] = field(default_factory=lambda: defaultdict(int), repr=False)
+    _shard_expected: dict[str, int] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.output_dir:
+            msg = "output_dir is required for ShardedManifestWriterStage"
+            raise ValueError(msg)
+
+    def setup_on_node(
+        self,
+        _node_info: NodeInfo | None = None,
+        _worker_metadata: WorkerMetadata | None = None,
+    ) -> None:
+        os.makedirs(self.output_dir, exist_ok=True)
+        logger.info(f"ShardedManifestWriterStage: output_dir={self.output_dir}")
+
+    def _get_shard_info(self, task: AudioTask) -> tuple[str, str]:
+        """Extract corpus and shard_id from task metadata."""
+        shard_key = task._metadata.get("_shard_key", "")
+        if "_" in shard_key:
+            parts = shard_key.rsplit("_", 1)
+            return parts[0], parts[1]
+        corpus = task.data.get("corpus", task.dataset_name or "unknown")
+        shard_id = str(task.data.get("shard_id", "0"))
+        return corpus, shard_id
+
+    def process(self, task: AudioTask) -> FileGroupTask:
+        corpus, shard_id = self._get_shard_info(task)
+        shard_key = f"{corpus}_{shard_id}"
+
+        corpus_dir = os.path.join(self.output_dir, corpus)
+        os.makedirs(corpus_dir, exist_ok=True)
+
+        out_path = os.path.join(corpus_dir, f"{shard_id}.jsonl")
+        with open(out_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(task.data, ensure_ascii=False) + "\n")
+
+        self._shard_counts[shard_key] += 1
+
+        shard_total = task._metadata.get("_shard_total", 0)
+        if shard_total > 0 and self._shard_counts[shard_key] >= shard_total:
+            done_path = os.path.join(corpus_dir, f"{shard_id}.jsonl.done")
+            with open(done_path, "w") as f:
+                f.write(f"{self._shard_counts[shard_key]}\n")
+            logger.info(f"Shard {shard_key} complete: {self._shard_counts[shard_key]} utterances, wrote {done_path}")
+
+        return FileGroupTask(
+            task_id=task.task_id,
+            dataset_name=task.dataset_name,
+            data=[out_path],
+            _metadata=task._metadata,
+            _stage_perf=task._stage_perf,
+        )
+
+    def process_batch(self, tasks: list[AudioTask]) -> list[FileGroupTask]:
+        results = []
+        for task in tasks:
+            results.append(self.process(task))
+
+        completed = set()
+        for task in tasks:
+            corpus, shard_id = self._get_shard_info(task)
+            shard_key = f"{corpus}_{shard_id}"
+            if shard_key not in completed:
+                completed.add(shard_key)
+
+        return results
+
+    def teardown(self) -> None:
+        total = sum(self._shard_counts.values())
+        done = sum(1 for k in self._shard_counts if os.path.exists(
+            os.path.join(self.output_dir, k.rsplit("_", 1)[0], f"{k.rsplit('_', 1)[1]}.jsonl.done")
+        ) if "_" in k)
+        logger.info(f"ShardedManifestWriter: {total} utterances across {len(self._shard_counts)} shards, {done} completed with .done")
+
+    def num_workers(self) -> int | None:
+        return 1
+
+    def xenna_stage_spec(self) -> dict[str, Any]:
+        return {"num_workers": 1}

--- a/nemo_curator/stages/audio/alm/sharded_manifest_writer.py
+++ b/nemo_curator/stages/audio/alm/sharded_manifest_writer.py
@@ -105,24 +105,13 @@ class ShardedManifestWriterStage(ProcessingStage[AudioTask, FileGroupTask]):
         )
 
     def process_batch(self, tasks: list[AudioTask]) -> list[FileGroupTask]:
-        results = []
-        for task in tasks:
-            results.append(self.process(task))
-
-        completed = set()
-        for task in tasks:
-            corpus, shard_id = self._get_shard_info(task)
-            shard_key = f"{corpus}_{shard_id}"
-            if shard_key not in completed:
-                completed.add(shard_key)
-
-        return results
+        return [self.process(task) for task in tasks]
 
     def teardown(self) -> None:
         total = sum(self._shard_counts.values())
-        done = sum(1 for k in self._shard_counts if os.path.exists(
+        done = sum(1 for k in self._shard_counts if "_" in k and os.path.exists(
             os.path.join(self.output_dir, k.rsplit("_", 1)[0], f"{k.rsplit('_', 1)[1]}.jsonl.done")
-        ) if "_" in k)
+        ))
         logger.info(f"ShardedManifestWriter: {total} utterances across {len(self._shard_counts)} shards, {done} completed with .done")
 
     def num_workers(self) -> int | None:

--- a/nemo_curator/stages/audio/alm/sharded_manifest_writer.py
+++ b/nemo_curator/stages/audio/alm/sharded_manifest_writer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Sharded Manifest Writer -- writes per-corpus/shard JSONL with .done markers."""
+"""Sharded Manifest Writer -- writes per-shard JSONL files mirroring input paths with .done markers."""
 
 import json
 import os
@@ -29,20 +29,17 @@ from nemo_curator.tasks import AudioTask, FileGroupTask
 
 @dataclass
 class ShardedManifestWriterStage(ProcessingStage[AudioTask, FileGroupTask]):
-    """Write AudioTasks to per-corpus/shard JSONL files with .done markers.
+    """Write AudioTasks to per-shard JSONL files mirroring the input manifest path structure.
 
-    Output structure::
+    Output structure mirrors the input manifest paths::
 
         output_dir/
-          {corpus}/
-            {shard_id}.jsonl
-            {shard_id}.done    # written after all utterances in the shard
-
-    On resume, shards with ``.done`` files are skipped by the discovery stage.
-    Partial shards (no ``.done``) are deleted and re-processed.
+          yodas/0_from_captions/en/sharded_manifests/manifest_42.jsonl
+          yodas/0_from_captions/en/sharded_manifests/manifest_42.jsonl.done
 
     The shard key is extracted from ``task._metadata["_shard_key"]``
-    which is set by ``NemoTarShardReaderStage`` as ``{corpus}_{shard_idx}``.
+    which is set by ``NemoTarShardReaderStage`` as a relative path
+    (e.g. ``yodas/0_from_captions/en/sharded_manifests/manifest_42``).
 
     Args:
         output_dir: Root directory for output manifests.
@@ -51,7 +48,6 @@ class ShardedManifestWriterStage(ProcessingStage[AudioTask, FileGroupTask]):
     name: str = "sharded_manifest_writer"
     output_dir: str = ""
     _shard_counts: dict[str, int] = field(default_factory=lambda: defaultdict(int), repr=False)
-    _shard_expected: dict[str, int] = field(default_factory=dict, repr=False)
 
     def __post_init__(self) -> None:
         if not self.output_dir:
@@ -66,24 +62,12 @@ class ShardedManifestWriterStage(ProcessingStage[AudioTask, FileGroupTask]):
         os.makedirs(self.output_dir, exist_ok=True)
         logger.info(f"ShardedManifestWriterStage: output_dir={self.output_dir}")
 
-    def _get_shard_info(self, task: AudioTask) -> tuple[str, str]:
-        """Extract corpus and shard_id from task metadata."""
-        shard_key = task._metadata.get("_shard_key", "")
-        if "_" in shard_key:
-            parts = shard_key.rsplit("_", 1)
-            return parts[0], parts[1]
-        corpus = task.data.get("corpus", task.dataset_name or "unknown")
-        shard_id = str(task.data.get("shard_id", "0"))
-        return corpus, shard_id
-
     def process(self, task: AudioTask) -> FileGroupTask:
-        corpus, shard_id = self._get_shard_info(task)
-        shard_key = f"{corpus}_{shard_id}"
+        shard_key = task._metadata.get("_shard_key", "unknown/shard_0")
 
-        corpus_dir = os.path.join(self.output_dir, corpus)
-        os.makedirs(corpus_dir, exist_ok=True)
+        out_path = os.path.join(self.output_dir, f"{shard_key}.jsonl")
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
 
-        out_path = os.path.join(corpus_dir, f"{shard_id}.jsonl")
         with open(out_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(task.data, ensure_ascii=False) + "\n")
 
@@ -91,7 +75,7 @@ class ShardedManifestWriterStage(ProcessingStage[AudioTask, FileGroupTask]):
 
         shard_total = task._metadata.get("_shard_total", 0)
         if shard_total > 0 and self._shard_counts[shard_key] >= shard_total:
-            done_path = os.path.join(corpus_dir, f"{shard_id}.jsonl.done")
+            done_path = os.path.join(self.output_dir, f"{shard_key}.jsonl.done")
             with open(done_path, "w") as f:
                 f.write(f"{self._shard_counts[shard_key]}\n")
             logger.info(f"Shard {shard_key} complete: {self._shard_counts[shard_key]} utterances, wrote {done_path}")
@@ -109,9 +93,10 @@ class ShardedManifestWriterStage(ProcessingStage[AudioTask, FileGroupTask]):
 
     def teardown(self) -> None:
         total = sum(self._shard_counts.values())
-        done = sum(1 for k in self._shard_counts if "_" in k and os.path.exists(
-            os.path.join(self.output_dir, k.rsplit("_", 1)[0], f"{k.rsplit('_', 1)[1]}.jsonl.done")
-        ))
+        done = sum(
+            1 for k in self._shard_counts
+            if os.path.exists(os.path.join(self.output_dir, f"{k}.jsonl.done"))
+        )
         logger.info(f"ShardedManifestWriter: {total} utterances across {len(self._shard_counts)} shards, {done} completed with .done")
 
     def num_workers(self) -> int | None:

--- a/nemo_curator/stages/audio/inference/qwen_omni.py
+++ b/nemo_curator/stages/audio/inference/qwen_omni.py
@@ -171,5 +171,5 @@ class InferenceQwenOmniStage(ProcessingStage[AudioTask, AudioTask]):
                 task.data[self.disfluency_text_key] = disfl
             task.data.pop(self.waveform_key, None)
 
-        logger.info("QwenOmni: generated %d predictions (turn2=%s)", len(pred_texts), bool(self.followup_prompt))
+        logger.info(f"QwenOmni: generated {len(pred_texts)} predictions (turn2={bool(self.followup_prompt)})")
         return tasks

--- a/nemo_curator/stages/audio/inference/qwen_omni.py
+++ b/nemo_curator/stages/audio/inference/qwen_omni.py
@@ -15,14 +15,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from loguru import logger
 
-from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.models.qwen_omni import QwenOmni
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import AudioTask
+
+if TYPE_CHECKING:
+    from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 
 
 @dataclass

--- a/nemo_curator/stages/audio/io/nemo_tarred_reader.py
+++ b/nemo_curator/stages/audio/io/nemo_tarred_reader.py
@@ -157,20 +157,22 @@ class NemoTarShardDiscoveryStage(ProcessingStage[_EmptyTask, FileGroupTask]):
         The ``.jsonl`` extension is stripped so it can be used as a shard key.
         """
         parts = manifest_path.replace("\\", "/").split("/")
-        count = parts.count(corpus)
-        if count == 0:
+        parts_lower = [p.lower() for p in parts]
+        corpus_lower = corpus.lower()
+        matches = [i for i, p in enumerate(parts_lower) if p == corpus_lower]
+        if len(matches) == 0:
             msg = (
                 f"Corpus name '{corpus}' not found in manifest path: {manifest_path}. "
-                f"The YAML 'corpus' field must appear exactly once as a directory component in the manifest path."
+                f"The YAML 'corpus' field must match a directory component in the manifest path (case-insensitive)."
             )
             raise ValueError(msg)
-        if count > 1:
+        if len(matches) > 1:
             msg = (
-                f"Corpus name '{corpus}' appears {count} times in manifest path: {manifest_path}. "
-                f"It must appear exactly once as a directory component for unambiguous path extraction."
+                f"Corpus name '{corpus}' appears {len(matches)} times in manifest path: {manifest_path}. "
+                f"It must appear exactly once for unambiguous path extraction."
             )
             raise ValueError(msg)
-        idx = parts.index(corpus)
+        idx = matches[0]
         rel = "/".join(parts[idx:])
         if rel.endswith(".jsonl"):
             rel = rel[:-len(".jsonl")]

--- a/nemo_curator/stages/audio/io/nemo_tarred_reader.py
+++ b/nemo_curator/stages/audio/io/nemo_tarred_reader.py
@@ -26,11 +26,10 @@ import json
 import os
 import re
 import tarfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from io import BytesIO
 from typing import Any
 
-import numpy as np
 import soundfile as sf
 from loguru import logger
 
@@ -40,7 +39,6 @@ except ModuleNotFoundError:
     RayStageSpecKeys = None
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.tasks import AudioTask, FileGroupTask, _EmptyTask
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -111,6 +109,7 @@ class NemoTarShardDiscoveryStage(ProcessingStage[_EmptyTask, FileGroupTask]):
     name: str = "nemo_tar_shard_discovery"
     yaml_path: str = ""
     corpus_filter: list[str] | None = None
+    output_dir: str | None = None
 
     def __post_init__(self) -> None:
         if not self.yaml_path:
@@ -126,42 +125,75 @@ class NemoTarShardDiscoveryStage(ProcessingStage[_EmptyTask, FileGroupTask]):
     def xenna_stage_spec(self) -> dict[str, Any]:
         return {"num_workers_per_node": 1}
 
+    def _scan_completed_shards(self) -> set[str]:
+        """Scan output_dir for .done marker files and return completed shard keys."""
+        if not self.output_dir:
+            return set()
+        completed: set[str] = set()
+        if not os.path.isdir(self.output_dir):
+            return completed
+        for corpus_dir in os.listdir(self.output_dir):
+            corpus_path = os.path.join(self.output_dir, corpus_dir)
+            if not os.path.isdir(corpus_path):
+                continue
+            for fname in os.listdir(corpus_path):
+                if fname.endswith(".jsonl.done"):
+                    shard_id = fname[:-len(".jsonl.done")]
+                    completed.add(f"{corpus_dir}_{shard_id}")
+        return completed
+
     def process(self, _task: _EmptyTask) -> list[FileGroupTask]:
         import yaml
+
+        completed = self._scan_completed_shards()
+        if completed:
+            logger.info(f"Checkpoint: {len(completed)} shards already completed, will skip them")
+            logger.info(f"Completed shard keys (first 10): {sorted(completed)[:10]}")
 
         with open(self.yaml_path) as f:
             config = yaml.safe_load(f)
 
         tasks: list[FileGroupTask] = []
+        skipped = 0
         for group in config:
             for cfg in group.get("input_cfg", []):
                 corpus = cfg.get("corpus", "unknown")
                 if self.corpus_filter and corpus not in self.corpus_filter:
                     continue
                 if cfg.get("type", "nemo_tarred") != "nemo_tarred":
-                    logger.warning("Skipping non-nemo_tarred corpus %s (type=%s)", corpus, cfg.get("type"))
+                    logger.warning(f"Skipping non-nemo_tarred corpus {corpus} (type={cfg.get('type')})")
                     continue
+                corpus_id = cfg.get("corpus_id", corpus)
                 manifest_paths = _expand_nemo_path(cfg["manifest_filepath"])
                 tar_paths = _expand_nemo_path(cfg["tarred_audio_filepaths"])
                 if len(manifest_paths) != len(tar_paths):
                     msg = (
-                        f"Manifest/tar count mismatch for corpus={corpus}: "
+                        f"Manifest/tar count mismatch for corpus={corpus_id}: "
                         f"{len(manifest_paths)} manifests vs {len(tar_paths)} tars"
                     )
                     raise ValueError(msg)
                 for i, (mp, tp) in enumerate(zip(manifest_paths, tar_paths)):
+                    shard_key = f"{corpus_id}_{i}"
+                    if shard_key in completed:
+                        skipped += 1
+                        continue
+                    # Delete partial output if exists (no .done = incomplete)
+                    if self.output_dir:
+                        partial = os.path.join(self.output_dir, corpus_id, f"{i}.jsonl")
+                        if os.path.exists(partial):
+                            os.remove(partial)
+                            logger.info(f"Removed partial output for {shard_key}")
                     tasks.append(
                         FileGroupTask(
-                            task_id=f"{corpus}_{i}",
-                            dataset_name=corpus,
+                            task_id=f"{corpus_id}_{i}",
+                            dataset_name=corpus_id,
                             data=[mp, tp],
-                            reader_config={"corpus": corpus, "shard_idx": i},
+                            reader_config={"corpus": corpus_id, "shard_idx": i},
                         )
                     )
 
         logger.info(
-            "NemoTarShardDiscoveryStage: found %d shards (corpus_filter=%s)",
-            len(tasks), self.corpus_filter,
+            f"NemoTarShardDiscoveryStage: found {len(tasks)} shards, skipped {skipped} completed (corpus_filter={self.corpus_filter})"
         )
         return tasks
 
@@ -198,7 +230,7 @@ class NemoTarShardReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
         return ["data"], []
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        return ["data"], ["waveform", "sample_rate"]
+        return ["data"], ["waveform", "sample_rate", "corpus", "num_channels"]
 
     def ray_stage_spec(self) -> dict[str, Any]:
         if RayStageSpecKeys is not None:
@@ -223,7 +255,7 @@ class NemoTarShardReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
 
         manifest = self._read_manifest(manifest_path)
 
-        logger.info("Reading shard %s: %s (%d manifest entries)", shard_key, tar_path, len(manifest))
+        logger.info(f"Reading shard {shard_key}: {tar_path} ({len(manifest)} manifest entries)")
 
         tar = _open_tar(tar_path, self.s3_endpoint_url)
         results: list[AudioTask] = []
@@ -237,8 +269,10 @@ class NemoTarShardReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
             try:
                 audio, sample_rate = sf.read(BytesIO(raw_audio), dtype="float32")
             except Exception:
-                logger.warning("Skipping corrupt audio %s in %s", tar_info.name, tar_path)
+                logger.warning(f"Skipping corrupt audio {tar_info.name} in {tar_path}")
                 continue
+
+            num_channels = audio.shape[1] if audio.ndim > 1 else 1
 
             # Convert to mono 1-D array
             if audio.ndim > 1:
@@ -247,6 +281,8 @@ class NemoTarShardReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
             entry = dict(manifest[tar_info.name])
             entry["waveform"] = audio
             entry["sample_rate"] = sample_rate
+            entry["num_channels"] = num_channels
+            entry["corpus"] = corpus
 
             results.append(
                 AudioTask(
@@ -259,7 +295,12 @@ class NemoTarShardReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
             )
 
         tar.close()
-        logger.info("Shard %s: emitted %d AudioTasks", shard_key, len(results))
+
+        shard_total = len(results)
+        for result_task in results:
+            result_task._metadata["_shard_total"] = shard_total
+
+        logger.info(f"Shard {shard_key}: emitted {shard_total} AudioTasks")
         return results
 
 
@@ -290,6 +331,7 @@ class NemoTarredAudioReader(CompositeStage[_EmptyTask, AudioTask]):
     corpus_filter: list[str] | None = None
     filepath_key: str = "audio_filepath"
     s3_endpoint_url: str | None = None
+    output_dir: str | None = None
 
     def __post_init__(self) -> None:
         super().__init__()
@@ -301,6 +343,7 @@ class NemoTarredAudioReader(CompositeStage[_EmptyTask, AudioTask]):
             NemoTarShardDiscoveryStage(
                 yaml_path=self.yaml_path,
                 corpus_filter=self.corpus_filter,
+                output_dir=self.output_dir,
             ),
             NemoTarShardReaderStage(
                 filepath_key=self.filepath_key,

--- a/nemo_curator/stages/audio/io/nemo_tarred_reader.py
+++ b/nemo_curator/stages/audio/io/nemo_tarred_reader.py
@@ -127,21 +127,56 @@ class NemoTarShardDiscoveryStage(ProcessingStage[_EmptyTask, FileGroupTask]):
         return {"num_workers_per_node": 1}
 
     def _scan_completed_shards(self) -> set[str]:
-        """Scan output_dir for .done marker files and return completed shard keys."""
+        """Scan output_dir recursively for .done marker files and return completed shard keys.
+
+        Keys are relative paths like ``yodas/0_from_captions/en/sharded_manifests/manifest_42``.
+        """
         if not self.output_dir:
             return set()
         completed: set[str] = set()
         if not os.path.isdir(self.output_dir):
             return completed
-        for corpus_dir in os.listdir(self.output_dir):
-            corpus_path = os.path.join(self.output_dir, corpus_dir)
-            if not os.path.isdir(corpus_path):
-                continue
-            for fname in os.listdir(corpus_path):
+        for root, _dirs, files in os.walk(self.output_dir):
+            for fname in files:
                 if fname.endswith(".jsonl.done"):
-                    shard_id = fname[:-len(".jsonl.done")]
-                    completed.add(f"{corpus_dir}_{shard_id}")
+                    rel = os.path.relpath(os.path.join(root, fname), self.output_dir)
+                    shard_key = rel[:-len(".jsonl.done")]
+                    completed.add(shard_key)
         return completed
+
+    @staticmethod
+    def _manifest_to_rel_path(manifest_path: str, corpus: str) -> str:
+        """Extract relative output path from a manifest path, starting at the corpus name.
+
+        Example::
+
+            manifest_path = "/data/yodas/0_from_captions/en/sharded_manifests/manifest_42.jsonl"
+            corpus = "yodas"
+            → "yodas/0_from_captions/en/sharded_manifests/manifest_42"
+
+        The ``.jsonl`` extension is stripped so it can be used as a shard key.
+        """
+        parts = manifest_path.replace("\\", "/").split("/")
+        count = parts.count(corpus)
+        if count == 0:
+            msg = (
+                f"Corpus name '{corpus}' not found in manifest path: {manifest_path}. "
+                f"The YAML 'corpus' field must appear exactly once as a directory component in the manifest path."
+            )
+            raise ValueError(msg)
+        if count > 1:
+            msg = (
+                f"Corpus name '{corpus}' appears {count} times in manifest path: {manifest_path}. "
+                f"It must appear exactly once as a directory component for unambiguous path extraction."
+            )
+            raise ValueError(msg)
+        idx = parts.index(corpus)
+        rel = "/".join(parts[idx:])
+        if rel.endswith(".jsonl"):
+            rel = rel[:-len(".jsonl")]
+        elif rel.endswith(".json"):
+            rel = rel[:-len(".json")]
+        return rel
 
     def process(self, _task: _EmptyTask) -> list[FileGroupTask]:
         import yaml
@@ -164,32 +199,30 @@ class NemoTarShardDiscoveryStage(ProcessingStage[_EmptyTask, FileGroupTask]):
                 if cfg.get("type", "nemo_tarred") != "nemo_tarred":
                     logger.warning(f"Skipping non-nemo_tarred corpus {corpus} (type={cfg.get('type')})")
                     continue
-                corpus_id = cfg.get("corpus_id", corpus)
                 manifest_paths = _expand_nemo_path(cfg["manifest_filepath"])
                 tar_paths = _expand_nemo_path(cfg["tarred_audio_filepaths"])
                 if len(manifest_paths) != len(tar_paths):
                     msg = (
-                        f"Manifest/tar count mismatch for corpus={corpus_id}: "
+                        f"Manifest/tar count mismatch for corpus={corpus}: "
                         f"{len(manifest_paths)} manifests vs {len(tar_paths)} tars"
                     )
                     raise ValueError(msg)
-                for i, (mp, tp) in enumerate(zip(manifest_paths, tar_paths, strict=False)):
-                    shard_key = f"{corpus_id}_{i}"
+                for mp, tp in zip(manifest_paths, tar_paths, strict=False):
+                    shard_key = self._manifest_to_rel_path(mp, corpus)
                     if shard_key in completed:
                         skipped += 1
                         continue
-                    # Delete partial output if exists (no .done = incomplete)
                     if self.output_dir:
-                        partial = os.path.join(self.output_dir, corpus_id, f"{i}.jsonl")
+                        partial = os.path.join(self.output_dir, f"{shard_key}.jsonl")
                         if os.path.exists(partial):
                             os.remove(partial)
                             logger.info(f"Removed partial output for {shard_key}")
                     tasks.append(
                         FileGroupTask(
-                            task_id=f"{corpus_id}_{i}",
-                            dataset_name=corpus_id,
+                            task_id=shard_key,
+                            dataset_name=corpus,
                             data=[mp, tp],
-                            reader_config={"corpus": corpus_id, "shard_idx": i},
+                            reader_config={"corpus": corpus, "shard_key": shard_key},
                         )
                     )
 
@@ -251,8 +284,7 @@ class NemoTarShardReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
     def process(self, task: FileGroupTask) -> list[AudioTask]:
         manifest_path, tar_path = task.data[0], task.data[1]
         corpus = task.reader_config.get("corpus", "unknown")
-        shard_idx = task.reader_config.get("shard_idx", 0)
-        shard_key = f"{corpus}_{shard_idx}"
+        shard_key = task.reader_config.get("shard_key", task.task_id)
 
         manifest = self._read_manifest(manifest_path)
 

--- a/nemo_curator/stages/audio/io/nemo_tarred_reader.py
+++ b/nemo_curator/stages/audio/io/nemo_tarred_reader.py
@@ -85,7 +85,8 @@ def _open_tar(tar_path: str, s3_endpoint_url: str | None = None) -> tarfile.TarF
         fileobj = open_best(pipe_path, mode="rb")
     else:
         if not os.path.exists(tar_path):
-            raise FileNotFoundError(f"Tar file not found: {tar_path}")
+            msg = f"Tar file not found: {tar_path}"
+            raise FileNotFoundError(msg)
         fileobj = open_best(tar_path, mode="rb")
     return tarfile.open(fileobj=fileobj, mode="r|*")
 
@@ -172,7 +173,7 @@ class NemoTarShardDiscoveryStage(ProcessingStage[_EmptyTask, FileGroupTask]):
                         f"{len(manifest_paths)} manifests vs {len(tar_paths)} tars"
                     )
                     raise ValueError(msg)
-                for i, (mp, tp) in enumerate(zip(manifest_paths, tar_paths)):
+                for i, (mp, tp) in enumerate(zip(manifest_paths, tar_paths, strict=False)):
                     shard_key = f"{corpus_id}_{i}"
                     if shard_key in completed:
                         skipped += 1


### PR DESCRIPTION
Summary
- Add `ShardedManifestWriterStage`: writes per-corpus/shard JSONL files with `.done `markers written immediately when a shard completes
- Add checkpoint resume: `NemoTarShardDiscoveryStage` scans for `.done` files and skips completed shards on restart
- Support `corpus_id` field in YAML for unique shard naming when same corpus appears multiple times, prevents overriding
- Add `corpus`, `num_channels`, `sample_rate` metadata to `AudioTask` output
- Fix `loguru` formatting: use `f-strings` instead of `%s/%d`
- Delete partial `.jsonl` files (no `.done`) on resume to avoid corruption