### PR TITLE
Add multilingual verbatim transcription prompt for Qwen3-Omni

### DIFF
--- a/examples/audio/qwen_omni_inprocess/prompts/ml_qwen3_omni_disfluency_asr.md
+++ b/examples/audio/qwen_omni_inprocess/prompts/ml_qwen3_omni_disfluency_asr.md
@@ -1,0 +1,1 @@
+Transcribe the {language} audio into text exactly as the speaker says it. Write numbers as spoken words.

--- a/examples/audio/qwen_omni_inprocess/run_pipeline.py
+++ b/examples/audio/qwen_omni_inprocess/run_pipeline.py
@@ -73,7 +73,7 @@ from nemo_curator.stages.audio.text_filtering import (
 from nemo_curator.stages.resources import Resources
 
 
-def main() -> None:
+def main() -> None:  # noqa: PLR0915
     ap = argparse.ArgumentParser(description="QwenOmni in-process vLLM pipeline")
     ap.add_argument("--data_config", type=str, required=True, help="Granary YAML data config.")
     ap.add_argument("--corpus", type=str, nargs="*", default=None, help="Process only these corpora.")
@@ -91,6 +91,10 @@ def main() -> None:
     ap.add_argument("--max_num_seqs", type=int, default=16)
     ap.add_argument("--gpu_memory_utilization", type=float, default=0.95)
     ap.add_argument("--prep_workers", type=int, default=16, help="Thread pool size for audio preprocessing.")
+    ap.add_argument("--source_lang_key", type=str, default="source_lang",
+                    help="Manifest key holding per-sample language code. "
+                         "Used for prompt interpolation ({language} placeholder) and per-sample LID filtering. "
+                         "Set to empty string to disable.")
     ap.add_argument("--s3_endpoint_url", type=str, default=None)
     ap.add_argument("--execution_mode", type=str, default="streaming",
                     choices=["streaming", "batch"], help="Xenna execution mode.")
@@ -159,6 +163,7 @@ def main() -> None:
                 max_num_seqs=args.max_num_seqs,
                 gpu_memory_utilization=args.gpu_memory_utilization,
                 prep_workers=args.prep_workers,
+                source_lang_key=args.source_lang_key,
                 pred_text_key="qwen3_prediction_s1",
                 disfluency_text_key="qwen3_prediction_s2",
             ),
@@ -175,6 +180,7 @@ def main() -> None:
                 model_path=args.fasttext_model,
                 text_key="qwen3_prediction_s2" if followup_prompt else "qwen3_prediction_s1",
                 target_lang=args.target_lang,
+                source_lang_key=args.source_lang_key,
                 min_lang_prob=args.min_lang_prob,
             ),
             RegexSubstitutionStage(

--- a/nemo_curator/models/qwen_omni.py
+++ b/nemo_curator/models/qwen_omni.py
@@ -145,7 +145,7 @@ class QwenOmni(ModelInterface):
             import torch
 
             torch.cuda.empty_cache()
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001, S110
             pass
 
     # ------------------------------------------------------------------
@@ -161,29 +161,40 @@ class QwenOmni(ModelInterface):
 
         return librosa.resample(waveform, orig_sr=orig_sr, target_sr=target_sr)
 
-    def _build_messages(self, waveform: np.ndarray) -> list[dict[str, Any]]:
+    def _resolve_prompt(self, template: str, language: str | None) -> str:
+        """Replace ``{language}`` placeholder if *language* is provided."""
+        if language and "{language}" in template:
+            return template.replace("{language}", language)
+        return template
+
+    def _build_messages(self, waveform: np.ndarray, language: str | None = None) -> list[dict[str, Any]]:
         """Build Turn 1 chat messages with an in-memory waveform (numpy array at 16 kHz)."""
+        prompt = self._resolve_prompt(self.prompt_text, language)
         messages: list[dict[str, Any]] = []
         if self.system_prompt:
-            messages.append({"role": "system", "content": [{"type": "text", "text": self.system_prompt}]})
+            sys_prompt = self._resolve_prompt(self.system_prompt, language)
+            messages.append({"role": "system", "content": [{"type": "text", "text": sys_prompt}]})
         messages.append({
             "role": "user",
             "content": [
-                {"type": "text", "text": self.prompt_text},
+                {"type": "text", "text": prompt},
                 {"type": "audio", "audio": waveform},
             ],
         })
         return messages
 
-    def _build_turn2_messages(self, waveform: np.ndarray, pred_text: str) -> list[dict[str, Any]]:
-        """Build Turn 2 messages: full Turn 1 conversation history + follow-up promt."""
+    def _build_turn2_messages(self, waveform: np.ndarray, pred_text: str, language: str | None = None) -> list[dict[str, Any]]:
+        """Build Turn 2 messages: full Turn 1 conversation history + follow-up prompt."""
+        prompt = self._resolve_prompt(self.prompt_text, language)
+        followup = self._resolve_prompt(self.followup_prompt, language)
         messages: list[dict[str, Any]] = []
         if self.system_prompt:
-            messages.append({"role": "system", "content": [{"type": "text", "text": self.system_prompt}]})
+            sys_prompt = self._resolve_prompt(self.system_prompt, language)
+            messages.append({"role": "system", "content": [{"type": "text", "text": sys_prompt}]})
         messages.append({
             "role": "user",
             "content": [
-                {"type": "text", "text": self.prompt_text},
+                {"type": "text", "text": prompt},
                 {"type": "audio", "audio": waveform},
             ],
         })
@@ -191,22 +202,22 @@ class QwenOmni(ModelInterface):
         messages.append({
             "role": "user",
             "content": [
-                {"type": "text", "text": self.followup_prompt},
+                {"type": "text", "text": followup},
             ],
         })
         return messages
 
     def _prepare_single(
-        self, waveform: np.ndarray, sample_rate: int,
+        self, waveform: np.ndarray, sample_rate: int, language: str | None = None,
     ) -> tuple[dict[str, Any], np.ndarray] | None:
         from qwen_omni_utils import process_mm_info
 
         try:
             waveform_16k = self._resample(waveform, sample_rate)
-            messages = self._build_messages(waveform_16k)
+            messages = self._build_messages(waveform_16k, language)
             text = self._processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
             audios, images, videos = process_mm_info(messages, use_audio_in_video=False)
-        except Exception:
+        except Exception:  # noqa: BLE001
             logger.warning(f"Failed to preprocess audio, skipping (waveform shape={waveform.shape}, sr={sample_rate})")
             return None
 
@@ -227,21 +238,23 @@ class QwenOmni(ModelInterface):
         self,
         waveforms: list[np.ndarray],
         sample_rates: list[int],
+        languages: list[str | None] | None = None,
     ) -> list[tuple[dict[str, Any], np.ndarray] | None]:
+        langs = languages or [None] * len(waveforms)
         if self._prep_pool is None:
-            return [self._prepare_single(w, sr) for w, sr in zip(waveforms, sample_rates, strict=False)]
-        return list(self._prep_pool.map(self._prepare_single, waveforms, sample_rates))
+            return [self._prepare_single(w, sr, lang) for w, sr, lang in zip(waveforms, sample_rates, langs, strict=False)]
+        return list(self._prep_pool.map(self._prepare_single, waveforms, sample_rates, langs))
 
     def _prepare_turn2_single(
-        self, waveform_16k: np.ndarray, pred_text: str,
+        self, waveform_16k: np.ndarray, pred_text: str, language: str | None = None,
     ) -> dict[str, Any] | None:
         from qwen_omni_utils import process_mm_info
 
         try:
-            messages = self._build_turn2_messages(waveform_16k, pred_text)
+            messages = self._build_turn2_messages(waveform_16k, pred_text, language)
             text = self._processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
             audios, images, videos = process_mm_info(messages, use_audio_in_video=False)
-        except Exception:
+        except Exception:  # noqa: BLE001
             logger.warning(f"Failed to preprocess Turn 2 audio (shape={waveform_16k.shape})")
             return None
 
@@ -262,13 +275,15 @@ class QwenOmni(ModelInterface):
         self,
         waveforms_16k: list[np.ndarray],
         pred_texts: list[str],
+        languages: list[str | None] | None = None,
     ) -> list[dict[str, Any] | None]:
+        langs = languages or [None] * len(waveforms_16k)
         if self._prep_pool is None:
             return [
-                self._prepare_turn2_single(w, pt)
-                for w, pt in zip(waveforms_16k, pred_texts, strict=False)
+                self._prepare_turn2_single(w, pt, lang)
+                for w, pt, lang in zip(waveforms_16k, pred_texts, langs, strict=False)
             ]
-        return list(self._prep_pool.map(self._prepare_turn2_single, waveforms_16k, pred_texts))
+        return list(self._prep_pool.map(self._prepare_turn2_single, waveforms_16k, pred_texts, langs))
 
     # ------------------------------------------------------------------
     # Generation
@@ -278,6 +293,7 @@ class QwenOmni(ModelInterface):
         self,
         waveforms: list[np.ndarray],
         sample_rates: list[int],
+        languages: list[str | None] | None = None,
     ) -> tuple[list[str], list[str]]:
         """Run batched two-turn inference on in-memory audio waveforms.
 
@@ -285,9 +301,16 @@ class QwenOmni(ModelInterface):
         is set, Turn 2 re-listens with the full conversation history and
         a follow-up prompt (e.g. to add disfluencies / filler words).
 
+        Prompts may contain a ``{language}`` placeholder which is replaced
+        per-sample with the corresponding entry from *languages* (e.g.
+        ``"English"``).  When *languages* is ``None`` or an entry is
+        ``None``, prompts are used as-is.
+
         Args:
             waveforms: List of 1-D mono numpy float32 arrays.
             sample_rates: Corresponding sample rates for each waveform.
+            languages: Optional per-sample language names for prompt
+                interpolation.
 
         Returns:
             ``(pred_texts, disfluency_texts)`` — one string per input for
@@ -301,7 +324,7 @@ class QwenOmni(ModelInterface):
         n = len(waveforms)
 
         # -- Turn 1 ----------------------------------------------------------
-        prepared = self._prepare_batch(waveforms, sample_rates)
+        prepared = self._prepare_batch(waveforms, sample_rates, languages)
         valid_indices = [i for i, p in enumerate(prepared) if p is not None]
         valid_inputs = [prepared[i][0] for i in valid_indices]
         waveforms_16k: dict[int, np.ndarray] = {i: prepared[i][1] for i in valid_indices}
@@ -327,9 +350,11 @@ class QwenOmni(ModelInterface):
         if not t2_indices:
             return pred_texts, [""] * n
 
+        langs = languages or [None] * n
         t2_prepared = self._prepare_turn2_batch(
             [waveforms_16k[i] for i in t2_indices],
             [pred_texts[i] for i in t2_indices],
+            [langs[i] for i in t2_indices],
         )
 
         t2_valid = [(i, p) for i, p in zip(t2_indices, t2_prepared, strict=False) if p is not None]

--- a/nemo_curator/stages/audio/inference/qwen_omni.py
+++ b/nemo_curator/stages/audio/inference/qwen_omni.py
@@ -27,6 +27,22 @@ from nemo_curator.tasks import AudioTask
 if TYPE_CHECKING:
     from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 
+_LANG_CODE_TO_NAME: dict[str, str] = {
+    "en": "English", "de": "German", "es": "Spanish", "fr": "French",
+    "it": "Italian", "pt": "Portuguese", "nl": "Dutch", "ru": "Russian",
+    "pl": "Polish", "cs": "Czech", "ro": "Romanian", "hu": "Hungarian",
+    "el": "Greek", "fi": "Finnish", "da": "Danish", "sv": "Swedish",
+    "lt": "Lithuanian", "lv": "Latvian", "hr": "Croatian", "et": "Estonian",
+    "bg": "Bulgarian", "sk": "Slovak", "sl": "Slovenian", "mt": "Maltese",
+    "uk": "Ukrainian", "sr": "Serbian", "mk": "Macedonian", "no": "Norwegian",
+    "hi": "Hindi", "ta": "Tamil", "mr": "Marathi", "bn": "Bengali",
+    "kn": "Kannada", "te": "Telugu", "ml": "Malayalam", "gu": "Gujarati",
+    "ur": "Urdu", "pa": "Punjabi",
+    "zh": "Chinese", "ja": "Japanese", "ko": "Korean", "ar": "Arabic",
+    "he": "Hebrew", "id": "Indonesian", "vi": "Vietnamese", "th": "Thai",
+    "tr": "Turkish", "fil": "Filipino", "tl": "Tagalog", "fa": "Persian",
+}
+
 
 @dataclass
 class InferenceQwenOmniStage(ProcessingStage[AudioTask, AudioTask]):
@@ -71,6 +87,7 @@ class InferenceQwenOmniStage(ProcessingStage[AudioTask, AudioTask]):
     system_prompt: str | None = None
     waveform_key: str = "waveform"
     sample_rate_key: str = "sample_rate"
+    source_lang_key: str = "source_lang"
     pred_text_key: str = "qwen3_prediction_s1"
     disfluency_text_key: str = "qwen3_prediction_s2"
     max_model_len: int = 32768
@@ -165,8 +182,14 @@ class InferenceQwenOmniStage(ProcessingStage[AudioTask, AudioTask]):
 
         waveforms = [t.data[self.waveform_key] for t in tasks]
         sample_rates = [t.data[self.sample_rate_key] for t in tasks]
+        languages: list[str | None] | None = None
+        if self.source_lang_key:
+            languages = [
+                _LANG_CODE_TO_NAME.get(code, code) if code else None
+                for code in (t.data.get(self.source_lang_key) for t in tasks)
+            ]
 
-        pred_texts, disfluency_texts = self._model.generate(waveforms, sample_rates)
+        pred_texts, disfluency_texts = self._model.generate(waveforms, sample_rates, languages)
 
         for task, pred, disfl in zip(tasks, pred_texts, disfluency_texts, strict=True):
             task.data[self.pred_text_key] = pred

--- a/nemo_curator/stages/audio/text_filtering/fasttext_lid.py
+++ b/nemo_curator/stages/audio/text_filtering/fasttext_lid.py
@@ -51,6 +51,7 @@ class FastTextLIDStage(ProcessingStage[AudioTask, AudioTask]):
 
     model_path: str = ""
     target_lang: str = "en"
+    source_lang_key: str = ""
     min_lang_prob: float = 0.8
     text_key: str = "pred_text"
     skip_me_key: str = "skip_me"
@@ -82,7 +83,7 @@ class FastTextLIDStage(ProcessingStage[AudioTask, AudioTask]):
         )
         raise ValueError(msg)
 
-    def setup(self, worker_metadata: Any = None) -> None:
+    def setup(self, worker_metadata: object = None) -> None:  # noqa: ARG002
         from nemo_curator.stages.text.filters.fasttext.fasttext_filters import FastTextLangId
 
         resolved = self._resolve_model_path()
@@ -115,8 +116,11 @@ class FastTextLIDStage(ProcessingStage[AudioTask, AudioTask]):
         score_list = eval(result_str)  # noqa: S307  — output of our own FastText model
         prob = float(score_list[0])
         lang = str(score_list[1]).lower()
+        expected = self.target_lang
+        if self.source_lang_key and self.source_lang_key in task.data:
+            expected = task.data[self.source_lang_key]
         if not task.data[self.skip_me_key]:
-            if lang != self.target_lang.lower():
+            if lang != expected.lower():
                 task.data[self.skip_me_key] = "Wrong language"
             elif prob < self.min_lang_prob:
                 task.data[self.skip_me_key] = "Low probability of language"

--- a/nemo_curator/stages/audio/text_filtering/initialize_fields.py
+++ b/nemo_curator/stages/audio/text_filtering/initialize_fields.py
@@ -18,10 +18,8 @@ from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import AudioTask
 
-
 _DEFAULT_DROP_KEYS: list[str] = [
     "answer",
-    "source_lang",
     "target_lang",
     "decodercontext",
     "emotion",

--- a/tests/stages/audio/text_filtering/test_initialize_fields.py
+++ b/tests/stages/audio/text_filtering/test_initialize_fields.py
@@ -47,8 +47,9 @@ def test_drops_default_keys() -> None:
         }
     )
     result = stage.process(task)
-    for key in ("answer", "source_lang", "target_lang", "decodercontext", "emotion", "diarize"):
+    for key in ("answer", "target_lang", "decodercontext", "emotion", "diarize"):
         assert key not in result.data
+    assert result.data["source_lang"] == "en"
     assert result.data["duration"] == 3.5
     assert result.data["granary_v1_prediction"] == "t"
 


### PR DESCRIPTION
## Description

Language-agnostic single-turn prompt for non-English ASR pseudo labeling. Unlike the English flow (which uses a two-turn approach with a separate disfluency followup), this prompt combines transcription and verbatim fidelity into one instruction, making the followup turn unnecessary.

No code changes required — the existing pipeline already supports this via --prompt_file and --target_lang arguments.

##  Usage

```bash
  python run_pipeline.py \
      --data_config /path/to/granary_config.yaml \
      --prompt_file prompts/ml_qwen3_omni_disfluency_asr.md \
      --target_lang fr \
      --hall_phrases /path/to/hall_phrases_fr.txt \
      --regex_yaml /path/to/common_fr.yaml \
      --output /path/to/output_fr.jsonl