### PR TITLE
[benchmarking] Adds support for fine-grained config overrides and global ray config

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -205,7 +205,45 @@ python benchmarking/run.py \
   --config machine_specific.yaml
 ```
 
-Files are merged in order. Later files override earlier ones for conflicting keys.
+Files are merged in order using a deep recursive merge, so later files can override or extend specific nested values without replacing entire top-level keys.
+
+**Merge behavior:**
+- **Scalar values** (strings, numbers, booleans): later file wins.
+- **Nested dicts**: merged recursively — only the keys present in the later file are updated.
+- **Lists of dicts** (e.g. `entries`, `requirements`, `sinks`): items are matched by their first key. If a matching item is found, it is merged recursively; if not, the item is appended.
+
+This makes it practical to write small override files that change only specific entries or requirements without duplicating the full configuration.
+
+**Example — overriding a single entry's timeout and requirements:**
+
+Base config (`nightly-benchmark.yaml`) defines many entries including:
+```yaml
+entries:
+  - name: domain_classification_xenna
+    timeout_s: 1400
+    requirements:
+      - metric: throughput_docs_per_sec
+        min_value: 3000
+```
+
+Override file (`my_overrides.yaml`) changes only that entry's timeout and requirement minimum:
+```yaml
+entries:
+  - name: domain_classification_xenna
+    timeout_s: 2000
+    requirements:
+      - metric: throughput_docs_per_sec
+        min_value: 2000
+```
+
+Running with both files:
+```bash
+python benchmarking/run.py \
+  --config nightly-benchmark.yaml \
+  --config my_overrides.yaml
+```
+
+Results in `domain_classification_xenna` using `timeout_s: 2000` and `min_value: 2000`, while all other entries remain unchanged.
 
 **Session naming:**
 

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -155,6 +155,12 @@ sinks:
     drive_folder_id: ${GDRIVE_FOLDER_ID}
     service_account_file: ${GDRIVE_SERVICE_ACCOUNT_FILE}
 
+# Optional: Global Ray settings inherited by all entries; per-entry ray sections override these values
+ray:
+  num_cpus: 64
+  num_gpus: 4
+  enable_object_spilling: false
+
 # Optional: Define datasets for template substitution
 datasets:
   - name: common_crawl
@@ -322,13 +328,22 @@ requirements:
     max_value: 64
 ```
 
-**ray**: Configures Ray resources for the entry:
+**ray**: Configures Ray resources. A global `ray` section can be defined at the top level of the configuration to set defaults inherited by all entries. Per-entry `ray` sections override individual keys from the global defaults.
 
+Global defaults (applies to all entries unless overridden):
 ```yaml
 ray:
   num_cpus: 64
   num_gpus: 4
-  enable_object_spilling: false  # Disable object spilling to local disk
+  enable_object_spilling: false
+```
+
+Per-entry override (only the differing keys need to be specified):
+```yaml
+entries:
+  - name: my_benchmark
+    ray:
+      num_gpus: 0  # overrides global num_gpus; num_cpus and enable_object_spilling inherit global values
 ```
 
 ---

--- a/benchmarking/nightly-benchmark.yaml
+++ b/benchmarking/nightly-benchmark.yaml
@@ -115,6 +115,12 @@ delete_scratch: true
 # for "ray start" to determine object store size.
 object_store_size: 536870912000  # 500GB
 
+# Global ray settings inherited by all entries. Per-entry ray sections override these values.
+ray:
+  num_cpus: 64
+  num_gpus: 4
+  enable_object_spilling: false
+
 entries:
   - name: domain_classification_raydata
     enabled: true
@@ -135,10 +141,7 @@ entries:
           - number_of_domains_predicted
         ping_on_failure:
           - U022P8CDX40  # Sarah Yurick
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       # Observed throughput of 2700 docs/sec so we allow a 5% buffer to account for variability
       - metric: throughput_docs_per_sec
@@ -169,10 +172,7 @@ entries:
           - number_of_domains_predicted
         ping_on_failure:
           - U022P8CDX40  # Sarah Yurick
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       # Observed throughput of 2900 docs/sec so we allow a 5% buffer to account for variability
       - metric: throughput_docs_per_sec
@@ -205,10 +205,7 @@ entries:
         ping_on_failure:
           - U022P8CDX40  # Sarah Yurick
           - U07JL5K0L10  # Praateek Mahajan
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       # Observed throughput of 3945 docs/sec so we allow a 5% buffer to account for variability
       - metric: throughput_docs_per_sec
@@ -235,10 +232,7 @@ entries:
         ping_on_failure:
           - U022P8CDX40  # Sarah Yurick
           - U07JL5K0L10  # Praateek Mahajan
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       # Observed throughput of 4923 docs/sec so we allow a 5% buffer to account for variability
       - metric: throughput_docs_per_sec
@@ -261,10 +255,7 @@ entries:
           - "num_duplicates"
         ping_on_failure:
           - UBDSVEQPL  # Ayush Dattagupta
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       - metric: num_duplicates
         exact_value: 64292856
@@ -291,10 +282,7 @@ entries:
           - connected_components_percent_time
         ping_on_failure:
           - UBDSVEQPL  # Ayush Dattagupta
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       - metric: num_duplicates
         # 59,226,133 is expected, ensure +/- 1%
@@ -332,10 +320,7 @@ entries:
           - pairwise_percent_time
         ping_on_failure:
           - U07JL5K0L10  # Praateek Mahajan
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       - metric: num_documents_processed
         exact_value: 312458951
@@ -368,9 +353,7 @@ entries:
           - UBDSVEQPL  # Ayush Dattagupta
           - U07JL5K0L10  # Praateek Mahajan
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
     requirements:
       - metric: num_duplicates_removed
         exact_value: 59226133
@@ -400,9 +383,7 @@ entries:
           - UBDSVEQPL  # Ayush Dattagupta
           - U07JL5K0L10  # Praateek Mahajan
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
     requirements:
       - metric: num_duplicates_removed
         exact_value: 59226133
@@ -428,9 +409,7 @@ entries:
         ping_on_failure:
           - U022P8CDX40  # Sarah Yurick
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
     requirements:
       # ensure the total number of documents processed is correct
       - metric: num_documents_processed
@@ -461,9 +440,7 @@ entries:
         ping_on_failure:
           - U022P8CDX40  # Sarah Yurick
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
     requirements:
       # ensure the total number of documents processed is correct
       - metric: num_documents_processed
@@ -496,9 +473,7 @@ entries:
         ping_on_failure:
           - U022P8CDX40  # Sarah Yurick
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
 
   - name: fasttext_filter_xenna
     enabled: true
@@ -521,9 +496,7 @@ entries:
         ping_on_failure:
           - U022P8CDX40  # Sarah Yurick
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
 
   - name: modifier_raydata
     enabled: true
@@ -541,9 +514,7 @@ entries:
         ping_on_failure:
           - U022P8CDX40  # Sarah Yurick
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
 
   - name: modifier_xenna
     enabled: true
@@ -561,9 +532,7 @@ entries:
         ping_on_failure:
           - U022P8CDX40  # Sarah Yurick
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
 
   - name: image_curation_raydata
     enabled: true
@@ -587,10 +556,7 @@ entries:
           - throughput_images_per_sec
         ping_on_failure:
           - U020C9VC05N  # Ao Tang
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       # ensure the total number of documents processed is correct
       - metric: num_images_processed
@@ -620,10 +586,7 @@ entries:
           - throughput_images_per_sec
         ping_on_failure:
           - U020C9VC05N  # Ao Tang
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       # ensure the total number of documents processed is correct
       - metric: num_images_processed
@@ -670,10 +633,7 @@ entries:
       --split=train
       --wer-threshold=5.5
       --gpus=1
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     sink_data:
       - name: slack
         # time_taken_s intentionally omitted: FLEURS includes dataset download
@@ -700,10 +660,7 @@ entries:
       --wer-threshold=5.5
       --gpus=1
       --executor=ray_data
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     sink_data:
       - name: slack
         # time_taken_s intentionally omitted: FLEURS includes dataset download
@@ -738,8 +695,6 @@ entries:
           - UGFRT88RE  # Vibhu Jawa
     ray:
       num_cpus: 16
-      num_gpus: 4
-      enable_object_spilling: false
     requirements:
       # Data integrity checks
       - metric: num_tar_files
@@ -769,8 +724,6 @@ entries:
           - UGFRT88RE  # Vibhu Jawa
     ray:
       num_cpus: 16
-      num_gpus: 4
-      enable_object_spilling: false
     requirements:
       # Data integrity checks
       - metric: num_tar_files
@@ -795,10 +748,7 @@ entries:
       - name: slack
         ping_on_failure:
           - U082G3E46R0  # Abhinav Garg
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       # ensure the total number of documents processed is correct
       - metric: num_clips_generated
@@ -822,9 +772,7 @@ entries:
         ping_on_failure:
           - U082G3E46R0  # Abhinav Garg
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
     requirements:
       # ensure the total number of documents processed is correct
       - metric: num_clips_generated
@@ -850,10 +798,7 @@ entries:
       - name: slack
         ping_on_failure:
           - U082G3E46R0  # Abhinav Garg
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       # ensure the total number of documents processed is correct
       - metric: num_clips_generated
@@ -876,8 +821,6 @@ entries:
     timeout_s: 700
     ray:
       num_cpus: 16
-      num_gpus: 4
-      enable_object_spilling: false
     sink_data:
       - name: slack
         additional_metrics:
@@ -910,10 +853,7 @@ entries:
       - name: slack
         ping_on_failure:
           - U082G3E46R0  # Abhinav Garg
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       # ensure the total number of documents processed is correct
       - metric: num_clips_generated
@@ -944,9 +884,7 @@ entries:
         ping_on_failure:
           - UGFRT88RE  # Vibhu Jawa
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
 
   - name: multimodal_mint1t_xenna_materialize
     enabled: false
@@ -971,9 +909,7 @@ entries:
         ping_on_failure:
           - UGFRT88RE  # Vibhu Jawa
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
 
   - name: interleaved_filter_xenna
     enabled: false
@@ -998,10 +934,7 @@ entries:
           - materialize_error_count
         ping_on_failure:
           - UGFRT88RE
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
 
   - name: interleaved_filter_xenna_materialize
     enabled: false
@@ -1026,10 +959,7 @@ entries:
           - materialize_error_count
         ping_on_failure:
           - UGFRT88RE
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
 
   - name: alm_pipeline_xenna
     enabled: true
@@ -1058,7 +988,6 @@ entries:
     ray:
       num_cpus: 8
       num_gpus: 0
-      enable_object_spilling: false
     requirements:
       - metric: is_success
         exact_value: true
@@ -1094,7 +1023,6 @@ entries:
     ray:
       num_cpus: 8
       num_gpus: 0
-      enable_object_spilling: false
     requirements:
       - metric: is_success
         exact_value: true
@@ -1122,9 +1050,7 @@ entries:
           - U07AZ1HPL1X  # Ranjit Rajan
           - U0849HBGCLD  # Sukrit Rao
     ray:
-      num_cpus: 64
       num_gpus: 0
-      enable_object_spilling: false
     requirements:
       - metric: num_input_documents
         exact_value: 1300
@@ -1150,10 +1076,7 @@ entries:
         ping_on_failure:
           - U07AZ1HPL1X  # Ranjit Rajan
           - U0849HBGCLD  # Sukrit Rao
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       - metric: num_input_documents
         exact_value: 1300
@@ -1183,10 +1106,7 @@ entries:
         ping_on_failure:
           - U07AZ1HPL1X  # Ranjit Rajan
           - U0849HBGCLD  # Sukrit Rao
-    ray:
-      num_cpus: 64
-      num_gpus: 4
-      enable_object_spilling: false
+
     requirements:
       - metric: num_input_documents
         exact_value: 1300
@@ -1214,9 +1134,7 @@ entries:
           - U07AZ1HPL1X  # Ranjit Rajan
           - U0849HBGCLD  # Sukrit Rao
     ray:
-      num_cpus: 64
       num_gpus: 8
-      enable_object_spilling: false
     requirements:
       - metric: total_matched_rows
         exact_value: 2384

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -120,7 +120,8 @@ def merge_config_files(config_files: list[Path]) -> dict:
     for config_file in config_files:
         with open(config_file) as f:
             for new_dict in yaml.full_load_all(f):
-                update_config(config_dict, new_dict)
+                if new_dict is not None:
+                    update_config(config_dict, new_dict)
     return config_dict
 
 

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -103,6 +103,9 @@ def update_config(config_dict: dict, new_dict: dict) -> None:
                         else:
                             # If no matching dict, append the new dict to the list
                             config_dict[key].append(sub_val)
+                    else:
+                        # If not a dict, append the new value to the list
+                        config_dict[key].append(sub_val)
             else:
                 # If types differ, or not a dict/list, replace value in config_dict
                 config_dict[key] = value

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: ERA001
+
 import argparse
 import json
 import os
@@ -58,6 +60,65 @@ from runner.utils import (
     remove_disabled_blocks,
     resolve_env_vars,
 )
+
+
+def update_config(config_dict: dict, new_dict: dict) -> None:
+    """Update a config dictionary with values from another."""
+
+    # Iterate through all key-value pairs in the dictionary to merge in
+    for key, value in new_dict.items():
+        if key in config_dict:
+            # Recursively handle nested dicts
+            if isinstance(config_dict[key], dict) and isinstance(value, dict):
+                update_config(config_dict[key], value)
+
+            # Handle list merging/updating on an item-by-item basis
+            # For example, the YAML:
+            #     entries:
+            #      - name: domain_classification_raydata
+            #        requirements:
+            #          - metric: throughput_docs_per_sec
+            #            min_value: 2677
+            # results in:
+            #     config_dict['entries'] = [{'name': 'domain_classification_raydata',
+            #                                'requirements': [{'metric': 'throughput_docs_per_sec', 'min_value': 2677}]
+            #                              }]
+            #
+            # so be sure to update the config_dict list items that match the new_dict list items by matching based on the first key
+            elif isinstance(config_dict[key], list) and isinstance(value, list):
+                for sub_val in value:
+                    # Handle dicts in the list by matching based on the first key
+                    if isinstance(sub_val, dict) and sub_val:
+                        first_key = next(iter(sub_val.keys()))
+                        for config_sub_val in config_dict[key]:
+                            if (
+                                isinstance(config_sub_val, dict)
+                                and config_sub_val
+                                and next(iter(config_sub_val.keys())) == first_key
+                                and config_sub_val[first_key] == sub_val[first_key]
+                            ):
+                                # If matching dict found (based on first key), recursively update it
+                                update_config(config_sub_val, sub_val)
+                                break
+                        else:
+                            # If no matching dict, append the new dict to the list
+                            config_dict[key].append(sub_val)
+            else:
+                # If types differ, or not a dict/list, replace value in config_dict
+                config_dict[key] = value
+        else:
+            # If key doesn't exist, add it to config_dict
+            config_dict[key] = value
+
+
+def merge_config_files(config_files: list[Path]) -> dict:
+    """Merge multiple config files into a single dictionary."""
+    config_dict = {}
+    for config_file in config_files:
+        with open(config_file) as f:
+            for new_dict in yaml.full_load_all(f):
+                update_config(config_dict, new_dict)
+    return config_dict
 
 
 def ensure_dir(dir_path: Path) -> None:
@@ -268,7 +329,7 @@ def run_entry(
             shutil.rmtree(scratch_path, ignore_errors=True)
 
 
-def main() -> int:  # noqa: C901, PLR0912, PLR0915
+def main() -> int:  # noqa: C901
     parser = argparse.ArgumentParser(description="Runs the benchmarking application")
     parser.add_argument(
         "--config",
@@ -303,12 +364,8 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
     args = parser.parse_args()
 
     # Consolidate the configuration from all YAML files into a single dict
-    config_dict = {}
-    for yml_file in args.config:
-        with open(yml_file) as f:
-            config_dicts = yaml.full_load_all(f)
-            for d in config_dicts:
-                config_dict.update(d)
+    config_dict = merge_config_files(args.config)
+
     # Preprocess the config dict prior to creating objects from it
     try:
         Session.assert_valid_config_dict(config_dict)

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -378,6 +378,7 @@ def main() -> int:  # noqa: C901
         logger.error(f"Invalid configuration: {e}")
         return 1
 
+    # Now that all YAML config files have been read, merged, and processed, create the Session object.
     session = Session.from_dict(config_dict, args.entries)
 
     if args.list:

--- a/benchmarking/runner/session.py
+++ b/benchmarking/runner/session.py
@@ -46,6 +46,8 @@ class Session:
     object_store_size: int | float | str | None = 0.5
     # Whether to delete the entry's scratch directory after completion by default
     delete_scratch: bool = True
+    # Global ray settings inherited by all entries; per-entry ray sections override these values.
+    ray: dict = field(default_factory=dict)
     path_resolver: PathResolver = None
     dataset_resolver: DatasetResolver = None
 
@@ -75,6 +77,10 @@ class Session:
         for entry in self.entries:
             if entry.object_store_size is None:
                 entry.object_store_size = self.object_store_size
+
+        # Apply global ray defaults to each entry, with per-entry ray values taking precedence.
+        for entry in self.entries:
+            entry.ray = {**self.ray, **entry.ray}
 
     @classmethod
     def assert_valid_config_dict(cls, data: dict) -> None:


### PR DESCRIPTION
* Adds support for fine-grained config overrides, which are needed for use cases such as per-machine config files that only override specific values unique to the machine.
* Also adds a global `ray` configuration which is inherited by each entry. Entries can override the global ray config by providing their own `ray` section.

These changes make it practical to write small override files that change only specific entries or requirements without duplicating the full configuration. For example:

Base config (`nightly-benchmark.yaml`) defines many entries including:
```yaml
entries:
  - name: domain_classification_xenna
    timeout_s: 1400
    requirements:
      - metric: throughput_docs_per_sec
        min_value: 3000
```

Override file (`my_overrides.yaml`) changes only that entry's timeout and requirement minimum:
```yaml
entries:
  - name: domain_classification_xenna
    timeout_s: 2000
    requirements:
      - metric: throughput_docs_per_sec
        min_value: 2000
```

Running with both files:
```bash
python benchmarking/run.py \
  --config nightly-benchmark.yaml \
  --config my_overrides.yaml
```

Results in `domain_classification_xenna` using `timeout_s: 2000` and `min_value: 2000`, while all other entries remain unchanged.

The previous implementation performed a shallow copy, which would mean the entire `entries` list would be overridden by the content above and every entry specified in previously-read YAMLs (eg. `nightly-benchmark.yaml`) would not be present in the final config.

The global `ray` section eliminates a significant amount of repeated YAML from `nightly-benchmark.yaml`
