### PR TITLE
docs: add OTEL_SDK_DISABLED workaround for NVBUG 6078008 SIGSEGV

### DIFF
--- a/tutorials/audio/README.md
+++ b/tutorials/audio/README.md
@@ -23,7 +23,7 @@ Hands-on tutorials for curating audio data with NeMo Curator. Complete working e
 
 ## Known Issues
 
-### SIGSEGV in Ray StageWorker during model loading (NVBUG 6078008)
+### SIGSEGV in Ray StageWorker during model loading
 
 In some environments, and under certain timing conditions, Ray workers may crash with a `SIGSEGV` during GPU model initialization. This is not a NeMo Curator code issue: it comes from a thread-safety problem in the gRPC version bundled with Ray. Any GPU pipeline (audio, text, image, or video) that loads models through Ray actors can hit the same failure.
 

--- a/tutorials/audio/README.md
+++ b/tutorials/audio/README.md
@@ -21,6 +21,24 @@ Hands-on tutorials for curating audio data with NeMo Curator. Complete working e
 | **Concepts** | [Architecture](https://docs.nvidia.com/nemo/curator/latest/about/concepts/index.html) • [Data Loading](https://docs.nvidia.com/nemo/curator/latest/about/concepts/text/data-loading-concepts.html) |
 | **Advanced** | [Custom Pipelines](https://docs.nvidia.com/nemo/curator/latest/reference/index.html) • [Execution Backends](https://docs.nvidia.com/nemo/curator/latest/reference/infrastructure/execution-backends.html) • [NeMo ASR Integration](https://docs.nvidia.com/nemo/curator/latest/about/key-features.html) |
 
+## Known Issues
+
+### SIGSEGV in Ray StageWorker during model loading (NVBUG 6078008)
+
+In some environments, and under certain timing conditions, Ray workers may crash with a `SIGSEGV` during GPU model initialization. This is not a NeMo Curator code issue: it comes from a thread-safety problem in the gRPC version bundled with Ray. Any GPU pipeline (audio, text, image, or video) that loads models through Ray actors can hit the same failure.
+
+The OpenTelemetry SDK starts a `PeriodicExportingMetricReader` background thread that periodically calls `OtlpGrpcMetricExporter::Export()` over gRPC; a `getenv()` call on that path can race with NeMo/PyTorch model initialization in another thread. **Disabling OpenTelemetry for the process** prevents Ray’s OpenTelemetry background exporter from starting and removes that race. NeMo Curator does not use OpenTelemetry for its own functionality, so disabling it has no functional impact on Curator workflows.
+
+**Container scope:** This has been observed with the `nemo-curator:26.04.rc0` image (and similar 26.04-era builds). The race was [fixed upstream in gRPC ≥ 1.60](https://github.com/grpc/grpc/pull/33508); it should stop being relevant once the bundled gRPC in the container is upgraded accordingly.
+
+**Workaround:** Set these environment variables before running the pipeline:
+
+```bash
+export OTEL_SDK_DISABLED=true
+export OTEL_METRICS_EXPORTER=none
+export OTEL_TRACES_EXPORTER=none
+```
+
 ## Support
 
 **Documentation**: [Main Docs](https://docs.nvidia.com/nemo/curator/latest/) • [API Reference](https://docs.nvidia.com/nemo/curator/latest/apidocs/index.html) • [GitHub Discussions](https://github.com/NVIDIA-NeMo/Curator/discussions)

--- a/tutorials/audio/alm/README.md
+++ b/tutorials/audio/alm/README.md
@@ -522,6 +522,10 @@ tests/stages/audio/alm/
 
 ## Troubleshooting
 
+| Issue | Solution |
+|-------|----------|
+| SIGSEGV / actor crash during model load | See [Known Issues](../README.md#known-issues) — set `OTEL_SDK_DISABLED=true` |
+
 ### No Windows Generated
 
 - Check that `audio_sample_rate >= min_sample_rate`

--- a/tutorials/audio/callhome_diar/README.md
+++ b/tutorials/audio/callhome_diar/README.md
@@ -111,6 +111,12 @@ pipeline = Pipeline(
 results = pipeline.run(executor=XennaExecutor())
 ```
 
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| SIGSEGV / actor crash during model load | See [Known Issues](../README.md#known-issues) — set `OTEL_SDK_DISABLED=true` |
+
 ## Model limitations
 
 - Maximum 4 speakers per recording

--- a/tutorials/audio/fleurs/README.md
+++ b/tutorials/audio/fleurs/README.md
@@ -128,3 +128,9 @@ Both the Python and YAML flows compose the same stages:
 - Convert to document format and write JSONL
 
 After running, inspect `${raw_data_dir}/result` to explore your curated manifest(s).
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| SIGSEGV / actor crash during model load | See [Known Issues](../README.md#known-issues) — set `OTEL_SDK_DISABLED=true` |

--- a/tutorials/audio/readspeech/README.md
+++ b/tutorials/audio/readspeech/README.md
@@ -245,20 +245,6 @@ The script also generates an `extraction_summary.json` with statistics including
 
 **Storage**: ~11 GB (4.88 GB download + 6.3 GB extracted WAV files; archive is deleted after extraction).
 
-## Known Issues
-
-### SIGSEGV in Ray StageWorker during model loading (NVBUG 6078008)
-
-On certain hardware configurations, Ray actors may crash with a `SIGSEGV` during GPU model initialization due to a thread-safety issue in Ray's bundled gRPC library. This is not a Curator code issue.
-
-**Workaround**: Set these environment variables before running the pipeline:
-
-```bash
-export OTEL_SDK_DISABLED=true
-export OTEL_METRICS_EXPORTER=none
-export OTEL_TRACES_EXPORTER=none
-```
-
 ## Troubleshooting
 
 | Issue | Solution |
@@ -267,7 +253,7 @@ export OTEL_TRACES_EXPORTER=none
 | `AF_UNIX path length` error | `export RAY_TMPDIR=/tmp` |
 | CUDA out of memory | Disable some filters or use `--max-samples` |
 | Download interrupted | Re-run pipeline; it skips already-downloaded files |
-| SIGSEGV / actor crash during model load | See [Known Issues](#known-issues) above — set `OTEL_SDK_DISABLED=true` |
+| SIGSEGV / actor crash during model load | See [Known Issues](../README.md#known-issues) — set `OTEL_SDK_DISABLED=true` |
 
 ## Citation
 

--- a/tutorials/audio/readspeech/README.md
+++ b/tutorials/audio/readspeech/README.md
@@ -245,6 +245,20 @@ The script also generates an `extraction_summary.json` with statistics including
 
 **Storage**: ~11 GB (4.88 GB download + 6.3 GB extracted WAV files; archive is deleted after extraction).
 
+## Known Issues
+
+### SIGSEGV in Ray StageWorker during model loading (NVBUG 6078008)
+
+On certain hardware configurations, Ray actors may crash with a `SIGSEGV` during GPU model initialization due to a thread-safety issue in Ray's bundled gRPC library. This is not a Curator code issue.
+
+**Workaround**: Set these environment variables before running the pipeline:
+
+```bash
+export OTEL_SDK_DISABLED=true
+export OTEL_METRICS_EXPORTER=none
+export OTEL_TRACES_EXPORTER=none
+```
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -253,6 +267,7 @@ The script also generates an `extraction_summary.json` with statistics including
 | `AF_UNIX path length` error | `export RAY_TMPDIR=/tmp` |
 | CUDA out of memory | Disable some filters or use `--max-samples` |
 | Download interrupted | Re-run pipeline; it skips already-downloaded files |
+| SIGSEGV / actor crash during model load | See [Known Issues](#known-issues) above — set `OTEL_SDK_DISABLED=true` |
 
 ## Citation
 

--- a/tutorials/audio/single_speaker_filter/README.md
+++ b/tutorials/audio/single_speaker_filter/README.md
@@ -78,6 +78,12 @@ python tutorials/audio/single_speaker_filter/run.py \
 
 `<output-dir>/checkpoints/` — per-stage checkpoint directories for resume support.
 
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| SIGSEGV / actor crash during model load | See [Known Issues](../README.md#known-issues) — set `OTEL_SDK_DISABLED=true` |
+
 ## Streaming configuration
 
 All frame values are in 80ms units. See the [callhome_diar tutorial](../callhome_diar/README.md) for latency trade-off configurations.


### PR DESCRIPTION
## Summary

- Adds a Known Issues section to the ReadSpeech tutorial README documenting the `OTEL_SDK_DISABLED=true` workaround for NVBUG 6078008
- Adds a troubleshooting entry linking to the Known Issues section

## Problem

On certain hardware configurations, Ray StageWorker actors crash with a `SIGSEGV` during GPU model initialization. The root cause is a thread-safety issue in Ray's internally-bundled gRPC library — a background OpenTelemetry exporter thread calls `getenv()` concurrently with PyTorch/CUDA calling `setenv()` during model init. This is not a Curator code issue and can affect any GPU pipeline (audio, text, image, video) that loads models through Ray actors.

## Workaround

Setting `OTEL_SDK_DISABLED=true` prevents Ray's OpenTelemetry background thread from starting, eliminating the race condition. Curator does not use OpenTelemetry, so disabling it has no functional impact.

## Test Plan

- [x] Verified pipeline runs to completion with `OTEL_SDK_DISABLED=true` on A100 GPU
- [x] Verified pipeline runs to completion without the env var on A100-SXM4 (race is hardware-timing dependent)
- [x] README renders correctly with new Known Issues section

## References

- [NVBUG 6078008](https://nvbugspro.nvidia.com/bug/6078008)
- Upstream gRPC fix: grpc/grpc#33508