### PR TITLE
Enhance VideoReader initialization with path validation

### DIFF
--- a/nemo_curator/stages/video/io/video_reader.py
+++ b/nemo_curator/stages/video/io/video_reader.py
@@ -263,7 +263,7 @@ class VideoReader(CompositeStage[_EmptyTask, VideoTask]):
             video_extensions = (".mp4", ".mov", ".avi", ".mkv", ".webm")
             if path.is_file():
                 if path.suffix.lower() not in video_extensions:
-                    msg = f"Not a supported video file: {self.input_video_path}"
+                    msg = f"Not a supported video file: {self.input_video_path}. Supported formats: {', '.join(video_extensions)}"
                     raise FileNotFoundError(msg)
             elif not any(next(path.rglob(f"*{ext}"), None) is not None for ext in video_extensions):
                 msg = f"No video files found in: {self.input_video_path}"

--- a/nemo_curator/stages/video/io/video_reader.py
+++ b/nemo_curator/stages/video/io/video_reader.py
@@ -263,7 +263,8 @@ class VideoReader(CompositeStage[_EmptyTask, VideoTask]):
             video_extensions = (".mp4", ".mov", ".avi", ".mkv", ".webm")
             if path.is_file():
                 if path.suffix.lower() not in video_extensions:
-                    msg = f"Not a supported video file: {self.input_video_path}. Supported formats: {', '.join(video_extensions)}"
+                    supported = ", ".join(video_extensions)
+                    msg = f"Not a supported video file: {self.input_video_path}. Supported formats: {supported}"
                     raise FileNotFoundError(msg)
             elif not any(next(path.rglob(f"*{ext}"), None) is not None for ext in video_extensions):
                 msg = f"No video files found in: {self.input_video_path}"

--- a/nemo_curator/stages/video/io/video_reader.py
+++ b/nemo_curator/stages/video/io/video_reader.py
@@ -261,7 +261,11 @@ class VideoReader(CompositeStage[_EmptyTask, VideoTask]):
                 msg = f"Video directory does not exist: {self.input_video_path}"
                 raise FileNotFoundError(msg)
             video_extensions = (".mp4", ".mov", ".avi", ".mkv", ".webm")
-            if not any(next(path.rglob(f"*{ext}"), None) is not None for ext in video_extensions):
+            if path.is_file():
+                if path.suffix.lower() not in video_extensions:
+                    msg = f"Not a supported video file: {self.input_video_path}"
+                    raise FileNotFoundError(msg)
+            elif not any(next(path.rglob(f"*{ext}"), None) is not None for ext in video_extensions):
                 msg = f"No video files found in: {self.input_video_path}"
                 raise FileNotFoundError(msg)
 

--- a/nemo_curator/stages/video/io/video_reader.py
+++ b/nemo_curator/stages/video/io/video_reader.py
@@ -255,6 +255,15 @@ class VideoReader(CompositeStage[_EmptyTask, VideoTask]):
         """Initialize the parent CompositeStage after dataclass initialization."""
         super().__init__()
         self.name = "video_reader"
+        if not is_remote_url(self.input_video_path):
+            path = Path(self.input_video_path)
+            if not path.exists():
+                msg = f"Video directory does not exist: {self.input_video_path}"
+                raise FileNotFoundError(msg)
+            video_extensions = (".mp4", ".mov", ".avi", ".mkv", ".webm")
+            if not any(next(path.rglob(f"*{ext}"), None) is not None for ext in video_extensions):
+                msg = f"No video files found in: {self.input_video_path}"
+                raise FileNotFoundError(msg)
 
     def decompose(self) -> list[ProcessingStage]:
         """Decompose into constituent execution stages.

--- a/tests/stages/video/io/test_video_reader.py
+++ b/tests/stages/video/io/test_video_reader.py
@@ -535,6 +535,7 @@ class TestVideoReader:
     def mock_path_exists(self):
         mock_instance = mock.Mock()
         mock_instance.exists.return_value = True
+        mock_instance.is_file.return_value = False
         mock_instance.rglob.side_effect = lambda *_: iter([mock.Mock()])
         with patch("nemo_curator.stages.video.io.video_reader.Path", return_value=mock_instance):
             yield mock_instance
@@ -552,11 +553,33 @@ class TestVideoReader:
         """Test that VideoReader raises FileNotFoundError when directory has no video files."""
         mock_instance = mock.Mock()
         mock_instance.exists.return_value = True
-        mock_instance.rglob.return_value = iter([])
+        mock_instance.is_file.return_value = False
+        mock_instance.rglob.side_effect = lambda *_: iter([])
         with patch("nemo_curator.stages.video.io.video_reader.Path", return_value=mock_instance), pytest.raises(
             FileNotFoundError, match="No video files found"
         ):
             VideoReader(input_video_path="/empty/dir")
+
+    def test_single_video_file_accepted(self) -> None:
+        """Test that VideoReader accepts a path to a single video file."""
+        mock_instance = mock.Mock()
+        mock_instance.exists.return_value = True
+        mock_instance.is_file.return_value = True
+        mock_instance.suffix = ".mp4"
+        with patch("nemo_curator.stages.video.io.video_reader.Path", return_value=mock_instance):
+            stage = VideoReader(input_video_path="/data/video.mp4")
+            assert stage.input_video_path == "/data/video.mp4"
+
+    def test_single_non_video_file_raises(self) -> None:
+        """Test that VideoReader raises FileNotFoundError for a non-video file path."""
+        mock_instance = mock.Mock()
+        mock_instance.exists.return_value = True
+        mock_instance.is_file.return_value = True
+        mock_instance.suffix = ".txt"
+        with patch("nemo_curator.stages.video.io.video_reader.Path", return_value=mock_instance), pytest.raises(
+            FileNotFoundError, match="Not a supported video file"
+        ):
+            VideoReader(input_video_path="/data/document.txt")
 
     def test_remote_url_skips_existence_check(self) -> None:
         """Test that VideoReader does not validate existence for remote URLs."""

--- a/tests/stages/video/io/test_video_reader.py
+++ b/tests/stages/video/io/test_video_reader.py
@@ -577,7 +577,7 @@ class TestVideoReader:
         mock_instance.is_file.return_value = True
         mock_instance.suffix = ".txt"
         with patch("nemo_curator.stages.video.io.video_reader.Path", return_value=mock_instance), pytest.raises(
-            FileNotFoundError, match="Not a supported video file"
+            FileNotFoundError, match="Not a supported video file.*Supported formats"
         ):
             VideoReader(input_video_path="/data/document.txt")
 

--- a/tests/stages/video/io/test_video_reader.py
+++ b/tests/stages/video/io/test_video_reader.py
@@ -577,7 +577,7 @@ class TestVideoReader:
         mock_instance.is_file.return_value = True
         mock_instance.suffix = ".txt"
         with patch("nemo_curator.stages.video.io.video_reader.Path", return_value=mock_instance), pytest.raises(
-            FileNotFoundError, match="Not a supported video file.*Supported formats"
+            FileNotFoundError, match=r"Not a supported video file.*Supported formats"
         ):
             VideoReader(input_video_path="/data/document.txt")
 

--- a/tests/stages/video/io/test_video_reader.py
+++ b/tests/stages/video/io/test_video_reader.py
@@ -531,6 +531,39 @@ class TestVideoReaderStage:
 class TestVideoReader:
     """Test suite for VideoReader composite functionality."""
 
+    @pytest.fixture(autouse=True)
+    def mock_path_exists(self):
+        mock_instance = mock.Mock()
+        mock_instance.exists.return_value = True
+        mock_instance.rglob.side_effect = lambda *_: iter([mock.Mock()])
+        with patch("nemo_curator.stages.video.io.video_reader.Path", return_value=mock_instance):
+            yield mock_instance
+
+    def test_nonexistent_video_dir_raises(self) -> None:
+        """Test that VideoReader raises FileNotFoundError for non-existent local path."""
+        mock_instance = mock.Mock()
+        mock_instance.exists.return_value = False
+        with patch("nemo_curator.stages.video.io.video_reader.Path", return_value=mock_instance), pytest.raises(
+            FileNotFoundError, match="Video directory does not exist"
+        ):
+            VideoReader(input_video_path="/nonexistent/path")
+
+    def test_empty_video_dir_raises(self) -> None:
+        """Test that VideoReader raises FileNotFoundError when directory has no video files."""
+        mock_instance = mock.Mock()
+        mock_instance.exists.return_value = True
+        mock_instance.rglob.return_value = iter([])
+        with patch("nemo_curator.stages.video.io.video_reader.Path", return_value=mock_instance), pytest.raises(
+            FileNotFoundError, match="No video files found"
+        ):
+            VideoReader(input_video_path="/empty/dir")
+
+    def test_remote_url_skips_existence_check(self) -> None:
+        """Test that VideoReader does not validate existence for remote URLs."""
+        with patch("nemo_curator.stages.video.io.video_reader.is_remote_url", return_value=True):
+            stage = VideoReader(input_video_path="s3://bucket/videos")
+            assert stage.input_video_path == "s3://bucket/videos"
+
     def test_stage_initialization_default_values(self) -> None:
         """Test VideoReader initialization with default values."""
         stage = VideoReader(input_video_path="/test/videos")


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
