### PR TITLE
docs: Add real-world examples of Curator for Nemotron datasets and SE…

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -81,8 +81,8 @@ Learn about speech data curation, ASR inference, quality assessment, and audio-t
 
 NeMo Curator is the foundation for building advanced, open post-training datasets powering domain-specific LLMs such as Nemotron and Chemistry LLMs for scientific discovery.
 
-**LANL & NVIDIA Collaboration:**
-LANL and NVIDIA are collaborating on a multiphase process to develop a co-scientist for ICF fusion hypothesis generation. This showcases two agents being developed by Los Alamos National Laboratories (LANL) to address two of the toughest challenges in science today: inertial confinement fusion (ICF) hypothesis generation and cancer treatment. NeMo Curator is used for data curation in these workflows.
+**LANL and NVIDIA Collaboration:**
+Los Alamos National Laboratory (LANL) and NVIDIA are collaborating on a multiphase process to develop a co-scientist for ICF hypothesis generation. This showcases two agents LANL is developing to address two of the toughest challenges in science today: inertial confinement fusion (ICF) hypothesis generation and cancer treatment. NeMo Curator handles data curation for these workflows.
 
 **Nemotron & Synthetic Data:**
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -77,7 +77,7 @@ Learn about speech data curation, ASR inference, quality assessment, and audio-t
 
 ::::
 
-# Curator in Action: Nemotron & Scientific LLMs
+## Curator in Action: Nemotron and Scientific LLMs
 
 NeMo Curator is the foundation for building advanced, open post-training datasets powering domain-specific LLMs such as Nemotron and Chemistry LLMs for scientific discovery.
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -54,12 +54,27 @@ Explore the foundational concepts and terminology used across NeMo Curator.
 Learn about text data curation, covering data loading and processing (filtering, deduplication, classification).
 :::
 
-:::{grid-item-card} {octicon}`image;1.5em;sd-mr-1` Image Curation Concepts
+:link: about-concepts-image
+:link-type: ref
 
----
+Explore key concepts for image data curation, including scalable loading, processing (embedding, classification, filtering, deduplication), and dataset export.
+:::
 
+:::{grid-item-card} {octicon}`video;1.5em;sd-mr-1` Video Curation Concepts
+:link: about-concepts-video
+:link-type: ref
 
----
+Discover video data curation concepts, such as distributed processing, pipeline stages, execution modes, and efficient data flow.
+:::
+
+:::{grid-item-card} {octicon}`unmute;1.5em;sd-mr-1` Audio Curation Concepts
+:link: about-concepts-audio
+:link-type: ref
+
+Learn about speech data curation, ASR inference, quality assessment, and audio-text integration workflows.
+:::
+
+::::
 
 # Curator in Action: Nemotron & Scientific LLMs
 
@@ -78,8 +93,6 @@ NeMo Curator is used to build Nemotron datasets through advanced synthetic data 
 
 **SES AI Chemistry LLM:**
 To train their Chemistry LLM on 35B tokens from 17M scientific papers, SES AI used NVIDIA DGX Cloud with NeMo and NeMo Curator. To achieve higher model accuracy, the SES team used NeMo Curator features such as exact deduplication, numbers filter, word count filter, repeated lines filter, and non-alphanumeric filter. The outcome is a customized model that is more accurate than its base version in ranking molecules and providing actionable insights, accelerating discovery at an unprecedented rate.
-
----
 :link: about-concepts-image
 :link-type: ref
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -84,7 +84,7 @@ NeMo Curator is the foundation for building advanced, open post-training dataset
 **LANL and NVIDIA Collaboration:**
 Los Alamos National Laboratory (LANL) and NVIDIA are collaborating on a multiphase process to develop a co-scientist for ICF hypothesis generation. This showcases two agents LANL is developing to address two of the toughest challenges in science today: inertial confinement fusion (ICF) hypothesis generation and cancer treatment. NeMo Curator handles data curation for these workflows.
 
-**Nemotron & Synthetic Data:**
+**Nemotron and Synthetic Data:**
 
 NeMo Curator is used to build Nemotron datasets through advanced synthetic data generation pipelines (see [Nemotron-CC Pipelines](../curate-text/synthetic/nemotron-cc/index.md)). These pipelines enable:
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -28,7 +28,7 @@ NeMo Curator, part of the NVIDIA NeMo software suite for managing the AI agent l
 
 NeMo Curator speeds up data curation by using modern hardware and distributed computing frameworks. You can process data efficiently—from a single laptop to a multi-node GPU cluster. With modular pipelines, advanced filtering, and easy integration with machine learning operations (MLOps) tools, leading organizations trust NeMo Curator.
 
-- **Text Curation**: Uses a pipeline-based architecture with modular processing stages running on Ray. Data flows through data download, extraction, language detection, rule-based quality filtering, deduplication (exact, fuzzy and semantic) and model based quality filtering.
+- **Text Curation**: Uses a pipeline-based architecture with modular processing stages running on Ray. Data flows through data download, extraction, language detection, rule-based quality filtering, deduplication (exact, fuzzy, and semantic), and model-based quality filtering.
 - **Image Curation**: Uses pipeline-based architecture with modular stages for loading, embedding generation, classification (aesthetic, NSFW), filtering, and export workflows. Supports distributed processing with optional GPU acceleration.
 - **Video Curation**: Employs Ray-based pipelines to split long videos into clips using fixed stride or scene-change detection, with optional encoding, filtering, embedding generation, and deduplication for large-scale video processing.
 - **Audio Curation**: Provides ASR inference using models, quality assessment through Word Error Rate (WER) calculation, duration analysis, and integration with text curation workflows for speech data processing.

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -29,7 +29,7 @@ NeMo Curator, part of the NVIDIA NeMo software suite for managing the AI agent l
 NeMo Curator speeds up data curation by using modern hardware and distributed computing frameworks. You can process data efficiently—from a single laptop to a multi-node GPU cluster. With modular pipelines, advanced filtering, and easy integration with machine learning operations (MLOps) tools, leading organizations trust NeMo Curator.
 
 - **Text Curation**: Uses a pipeline-based architecture with modular processing stages running on Ray. Data flows through data download, extraction, language detection, rule-based quality filtering, deduplication (exact, fuzzy, and semantic), and model-based quality filtering.
-- **Image Curation**: Uses pipeline-based architecture with modular stages for loading, embedding generation, classification (aesthetic, NSFW), filtering, and export workflows. Supports distributed processing with optional GPU acceleration.
+- **Image Curation**: Uses a pipeline-based architecture with modular stages for loading, embedding generation, classification (aesthetic, NSFW), filtering, and export workflows. Supports distributed processing with optional GPU acceleration.
 - **Video Curation**: Employs Ray-based pipelines to split long videos into clips using fixed stride or scene-change detection, with optional encoding, filtering, embedding generation, and deduplication for large-scale video processing.
 - **Audio Curation**: Provides ASR inference using models, quality assessment through Word Error Rate (WER) calculation, duration analysis, and integration with text curation workflows for speech data processing.
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -55,6 +55,31 @@ Learn about text data curation, covering data loading and processing (filtering,
 :::
 
 :::{grid-item-card} {octicon}`image;1.5em;sd-mr-1` Image Curation Concepts
+
+---
+
+
+---
+
+# Curator in Action: Nemotron & Scientific LLMs
+
+NeMo Curator is the foundation for building advanced, open post-training datasets powering domain-specific LLMs such as Nemotron and Chemistry LLMs for scientific discovery.
+
+**LANL & NVIDIA Collaboration:**
+LANL and NVIDIA are collaborating on a multiphase process to develop a co-scientist for ICF fusion hypothesis generation. This showcases two agents being developed by Los Alamos National Laboratories (LANL) to address two of the toughest challenges in science today: inertial confinement fusion (ICF) hypothesis generation and cancer treatment. NeMo Curator is used for data curation in these workflows.
+
+**Nemotron & Synthetic Data:**
+
+NeMo Curator is used to build Nemotron datasets through advanced synthetic data generation pipelines (see [Nemotron-CC Pipelines](../curate-text/synthetic/nemotron-cc/index.md)). These pipelines enable:
+
+- Paraphrasing and improving noisy web data
+- Extracting structured knowledge and facts
+- Quality-based routing and transformation of scientific documents
+
+**SES AI Chemistry LLM:**
+To train their Chemistry LLM on 35B tokens from 17M scientific papers, SES AI used NVIDIA DGX Cloud with NeMo and NeMo Curator. To achieve higher model accuracy, the SES team used NeMo Curator features such as exact deduplication, numbers filter, word count filter, repeated lines filter, and non-alphanumeric filter. The outcome is a customized model that is more accurate than its base version in ranking molecules and providing actionable insights, accelerating discovery at an unprecedented rate.
+
+---
 :link: about-concepts-image
 :link-type: ref
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -54,6 +54,7 @@ Explore the foundational concepts and terminology used across NeMo Curator.
 Learn about text data curation, covering data loading and processing (filtering, deduplication, classification).
 :::
 
+:::{grid-item-card} {octicon}`image;1.5em;sd-mr-1` Image Curation Concepts
 :link: about-concepts-image
 :link-type: ref
 

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -55,6 +55,7 @@ Learn about text data curation, covering data loading and processing (filtering,
 :::
 
 :::{grid-item-card} {octicon}`image;1.5em;sd-mr-1` Image Curation Concepts
+:::{grid-item-card} {octicon}`image;1.5em;sd-mr-1` Image Curation Concepts
 :link: about-concepts-image
 :link-type: ref
 


### PR DESCRIPTION



## Description

Adds real-world examples to the documentation showing how NeMo Curator is used to build Nemotron datasets, including LANL/NVIDIA collaboration and SES AI Chemistry LLM use cases.
Closes #1548.

## Usage

# See docs/about/index.md for real-world usage scenarios and references.
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [Y ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [Y ] The documentation is up to date with these changes.

