### PR TITLE
ci: add base_sha to codecov/codecov-action upload step

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -315,6 +315,11 @@ jobs:
       matrix:
         flag: [unit-test, e2e]
     steps:
+      - name: Get PR info
+        id: get-pr-info
+        if: startsWith(github.ref, 'refs/heads/pull-request/')
+        uses: nv-gha-runners/get-pr-info@main
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -348,6 +353,7 @@ jobs:
           verbose: true
           flags: ${{ matrix.flag }}
           fail_ci_if_error: true
+          base_sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').base.sha }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Summary

- Added a `Get PR info` step (`nv-gha-runners/get-pr-info@main`, guarded by `startsWith(github.ref, 'refs/heads/pull-request/')`) to the `Coverage` job
- Passes `base_sha` to `codecov/codecov-action@v5` so Codecov can correctly compute the coverage diff against the PR's base commit

</details>
