### PR TITLE
docs: warn users of Python 3.10 support removal in 26.06

### DIFF
--- a/fern/versions/v26.04/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.04/pages/about/release-notes/index.mdx
@@ -10,6 +10,10 @@ modality: "universal"
 
 # NeMo Curator Release Notes: 26.04
 
+<Warning>
+**Python 3.10 support will be removed in NeMo Curator 26.06.** The 26.04 release is the last release to support Python 3.10. Plan to upgrade your environments to Python 3.11 or 3.12 before installing 26.06. See [Deprecations](#deprecations) for details.
+</Warning>
+
 ## What's New in 26.04
 
 ### vLLM and Sentence Transformers Embedding Support (PR #1346)
@@ -296,6 +300,18 @@ Fixed a `deepcopy`/pickle crash in `MathContentExtractor` caused by unpickleable
 ### CommonCrawlWARCReader Serialization for Ray (PR #1604)
 
 Added `__getstate__`/`__setstate__` to `CommonCrawlWARCReader` for pickle compatibility with Ray executors. The `threading.Lock`, `requests.Session`, and boto3 S3 client are stripped during serialization and lazily reinitialized after deserialization.
+
+## Deprecations
+
+### Python 3.10 Support Will Be Removed in 26.06
+
+NeMo Curator 26.04 is the last release that supports Python 3.10. Beginning with **26.06**, Python 3.10 will no longer be a supported runtime, and install extras will target Python 3.11 and 3.12 only.
+
+- **Action required**: Upgrade your environments to Python 3.11 or 3.12 before installing 26.06.
+- **Affected surfaces**: PyPI install extras, the NeMo Curator container, and all Python APIs.
+- **Why**: Python 3.10 reaches end-of-life in October 2026, and several upstream dependencies (notably in the GPU and inference stacks) are dropping 3.10 support.
+
+If you are pinning a Python version in CI, Dockerfiles, or `uv` projects, update those pins now so you are ready for the 26.06 release.
 
 ## Breaking Changes
 

--- a/fern/versions/v26.04/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.04/pages/about/release-notes/index.mdx
@@ -11,7 +11,7 @@ modality: "universal"
 # NeMo Curator Release Notes: 26.04
 
 <Warning>
-**Python 3.10 support will be removed in NeMo Curator 26.06.** The 26.04 release is the last release to support Python 3.10. Plan to upgrade your environments to Python 3.11 or 3.12 before installing 26.06. See [Deprecations](#deprecations) for details.
+**Python 3.10 support will be removed in NeMo Curator 26.06.** The 26.04 release is the last release to support Python 3.10. Plan to upgrade your environments to a newer supported Python version (3.11+) before installing 26.06. See [Deprecations](#deprecations) for details.
 </Warning>
 
 ## What's New in 26.04
@@ -305,9 +305,9 @@ Added `__getstate__`/`__setstate__` to `CommonCrawlWARCReader` for pickle compat
 
 ### Python 3.10 Support Will Be Removed in 26.06
 
-NeMo Curator 26.04 is the last release that supports Python 3.10. Beginning with **26.06**, Python 3.10 will no longer be a supported runtime, and install extras will target Python 3.11 and 3.12 only.
+NeMo Curator 26.04 is the last release that supports Python 3.10. Beginning with **26.06**, Python 3.10 will no longer be a supported runtime, and install extras will target newer Python versions (3.11+).
 
-- **Action required**: Upgrade your environments to Python 3.11 or 3.12 before installing 26.06.
+- **Action required**: Upgrade your environments to a newer supported Python version (3.11+) before installing 26.06.
 - **Affected surfaces**: PyPI install extras, the NeMo Curator container, and all Python APIs.
 - **Why**: Python 3.10 reaches end-of-life in October 2026, and several upstream dependencies (notably in the GPU and inference stacks) are dropping 3.10 support.
 

--- a/fern/versions/v26.04/pages/admin/deployment/index.mdx
+++ b/fern/versions/v26.04/pages/admin/deployment/index.mdx
@@ -22,4 +22,8 @@ Before deploying NeMo Curator in a production environment, review the comprehens
 - **Software**: Ray (distributed computing framework), container runtime
 - **Infrastructure**: High-bandwidth networking, storage for datasets
 
+<Warning>
+**Python 3.10 support will be removed in NeMo Curator 26.06.** Standardize new production environments on Python 3.11 or 3.12 to avoid a forced upgrade when moving to 26.06. See the [26.04 release notes](/about/release-notes).
+</Warning>
+
 For detailed system, hardware, and software requirements, see [Production Deployment Requirements](/admin/deployment/requirements).

--- a/fern/versions/v26.04/pages/admin/deployment/index.mdx
+++ b/fern/versions/v26.04/pages/admin/deployment/index.mdx
@@ -23,7 +23,7 @@ Before deploying NeMo Curator in a production environment, review the comprehens
 - **Infrastructure**: High-bandwidth networking, storage for datasets
 
 <Warning>
-**Python 3.10 support will be removed in NeMo Curator 26.06.** Standardize new production environments on Python 3.11 or 3.12 to avoid a forced upgrade when moving to 26.06. See the [26.04 release notes](/about/release-notes).
+**Python 3.10 support will be removed in NeMo Curator 26.06.** Standardize new production environments on a newer supported Python version (3.11+) to avoid a forced upgrade when moving to 26.06. See the [26.04 release notes](/about/release-notes).
 </Warning>
 
 For detailed system, hardware, and software requirements, see [Production Deployment Requirements](/admin/deployment/requirements).

--- a/fern/versions/v26.04/pages/admin/deployment/requirements.mdx
+++ b/fern/versions/v26.04/pages/admin/deployment/requirements.mdx
@@ -18,6 +18,10 @@ This page details the comprehensive system, hardware, and software requirements 
 - **Python**: Python 3.10, 3.11, or 3.12
   - packaging &gt;= 22.0
 
+<Warning>
+**Python 3.10 support will be removed in NeMo Curator 26.06.** 26.04 is the last release to support Python 3.10. Standardize production environments on Python 3.11 or 3.12 before upgrading to 26.06. See the [26.04 release notes](/about/release-notes) for details.
+</Warning>
+
 ## Hardware Requirements
 
 ### CPU Requirements

--- a/fern/versions/v26.04/pages/admin/deployment/requirements.mdx
+++ b/fern/versions/v26.04/pages/admin/deployment/requirements.mdx
@@ -19,7 +19,7 @@ This page details the comprehensive system, hardware, and software requirements 
   - packaging &gt;= 22.0
 
 <Warning>
-**Python 3.10 support will be removed in NeMo Curator 26.06.** 26.04 is the last release to support Python 3.10. Standardize production environments on Python 3.11 or 3.12 before upgrading to 26.06. See the [26.04 release notes](/about/release-notes) for details.
+**Python 3.10 support will be removed in NeMo Curator 26.06.** 26.04 is the last release to support Python 3.10. Standardize production environments on a newer supported Python version (3.11+) before upgrading to 26.06. See the [26.04 release notes](/about/release-notes) for details.
 </Warning>
 
 ## Hardware Requirements

--- a/fern/versions/v26.04/pages/admin/installation.mdx
+++ b/fern/versions/v26.04/pages/admin/installation.mdx
@@ -27,7 +27,7 @@ For comprehensive system requirements and production deployment specifications, 
 - **CUDA 12** (required for `audio_cuda12`, `video_cuda12`, `image_cuda12`, and `text_cuda12` extras)
 
 <Warning>
-**Python 3.10 support will be removed in NeMo Curator 26.06.** 26.04 is the last release to support Python 3.10. If you are setting up a new environment, install Python 3.11 or 3.12 so you do not need to upgrade when moving to 26.06. See the [26.04 release notes](/about/release-notes) for details.
+**Python 3.10 support will be removed in NeMo Curator 26.06.** 26.04 is the last release to support Python 3.10. If you are setting up a new environment, install a newer supported Python version (3.11+) so you do not need to upgrade when moving to 26.06. See the [26.04 release notes](/about/release-notes) for details.
 </Warning>
 
 ### Development vs Production

--- a/fern/versions/v26.04/pages/admin/installation.mdx
+++ b/fern/versions/v26.04/pages/admin/installation.mdx
@@ -26,6 +26,10 @@ For comprehensive system requirements and production deployment specifications, 
 - **GPU** (optional): NVIDIA GPU with 16GB+ VRAM for acceleration
 - **CUDA 12** (required for `audio_cuda12`, `video_cuda12`, `image_cuda12`, and `text_cuda12` extras)
 
+<Warning>
+**Python 3.10 support will be removed in NeMo Curator 26.06.** 26.04 is the last release to support Python 3.10. If you are setting up a new environment, install Python 3.11 or 3.12 so you do not need to upgrade when moving to 26.06. See the [26.04 release notes](/about/release-notes) for details.
+</Warning>
+
 ### Development vs Production
 
 | Use Case | Requirements | See |


### PR DESCRIPTION
## Description

Adds a deprecation notice across the 26.04 docs warning users that Python 3.10 support will be removed in NeMo Curator 26.06, so they can plan environment upgrades to Python 3.11 or 3.12. The notice appears as a prominent banner on the 26.04 release notes (plus a new **Deprecations** section with rationale), and as warnings in the installation guide, production deployment requirements, and deployment overview — each linking back to the release notes for details.

## Usage

N/A — documentation-only change.

## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.