### PR TITLE
fix: escape hyphen in URL regex character class (#1601)

### DIFF
--- a/nemo_curator/stages/text/utils/constants.py
+++ b/nemo_curator/stages/text/utils/constants.py
@@ -72,6 +72,6 @@ bullet_list = {
 regex_alpha = regex.compile("[[:alpha:]]")
 regex_digit = regex.compile("[[:digit:]]")
 regex_alphanum = re.compile("[a-zA-Z0-9\n?!,.]")
-regex_url = re.compile("http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
+regex_url = re.compile(r"http[s]?://(?:[a-zA-Z]|[0-9]|[$\-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
 regex_paren = re.compile(r"{|}|⟨|⟩|\[|\]|\(|\)")
 regex_hash = re.compile("#+")


### PR DESCRIPTION
## Bug Description

The unescaped hyphen in `[$-_@.&+]` within the URL regex created an unintended character range from `$` (ASCII 36) to `_` (ASCII 95). This made the regex overly permissive, matching characters like `<`, `>`, `{`, `}`, `|`, `\`, `^`, and others that should not be valid in URLs.

## Fix

- Escaped the hyphen with a backslash: `[$\-_@.&+]`
- Switched to a raw string literal (`r'...'`) for cleaner, more maintainable escaping

## Before
```python
regex_url = re.compile("http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
```

The character class `[$-_@.&+]` matches ASCII 36-95 plus `@`, `.`, and `&`, which includes many invalid URL characters.

## After
```python
regex_url = re.compile(r"http[s]?://(?:[a-zA-Z]|[0-9]|[$\-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+")
```

The character class `[$\-_@.&+]` now matches only the literal characters `$`, `-`, `_`, `@`, `.`, `&`, and `+` as intended.

## Impact

This fix prevents the URL regex from incorrectly matching strings containing characters like `<`, `>`, `{`, `}`, `|`, etc. as part of URLs, improving the accuracy of URL detection in text processing pipelines.

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Fixes #1601
- [x] Minimal change — one line modified
- [x] Raw string improves readability

---

Closes #1601