### PR TITLE
Remove experimental for ray actor and ray data

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -50,6 +50,11 @@ redirects:
     destination: "/nemo/curator/v26.04/:path*"
   - source: "/nemo/curator/:path*.html"
     destination: "/nemo/curator/:path*"
+  # Ray executors: old /experimental slug → /ray-executors
+  - source: "/nemo/curator/latest/api-reference/executors/experimental"
+    destination: "/nemo/curator/latest/api-reference/executors/ray-executors"
+  - source: "/nemo/curator/v26.02/api-reference/executors/experimental"
+    destination: "/nemo/curator/v26.02/api-reference/executors/ray-executors"
   # Audio concepts: legacy nested nav URLs → flat slugs (aligned with Sphinx filenames)
   - source: "/about/concepts/audio/curation/pipeline"
     destination: "/about/concepts/audio/curation-pipeline"

--- a/fern/versions/v26.02.yml
+++ b/fern/versions/v26.02.yml
@@ -558,9 +558,9 @@ navigation:
               - page: XennaExecutor
                 path: ./v26.02/pages/api-reference/executors/xenna-executor.mdx
                 slug: xenna-executor
-              - page: Experimental
-                path: ./v26.02/pages/api-reference/executors/experimental.mdx
-                slug: experimental
+              - page: Ray Executors
+                path: ./v26.02/pages/api-reference/executors/ray-executors.mdx
+                slug: ray-executors
           - page: Resources
             path: ./v26.02/pages/api-reference/resources.mdx
             slug: resources

--- a/fern/versions/v26.02/pages/about/release-notes/index.mdx
+++ b/fern/versions/v26.02/pages/about/release-notes/index.mdx
@@ -27,11 +27,11 @@ New comprehensive benchmarking framework for performance monitoring and optimiza
 
 ### Ray Actor Pool Executor Improvements
 
-Enhanced features for the experimental Ray Actor Pool execution backend:
+Enhanced features for the Ray Actor Pool execution backend:
 
 - **Progress Bars**: New visual feedback for long-running actor pool operations, making it easier to monitor pipeline execution
 - **Improved Load Balancing**: Better worker distribution and task scheduling
-- **Enhanced Stability**: Continued refinements to the experimental executor
+- **Enhanced Stability**: Continued refinements to the Ray Actor Pool executor
 
 Learn more in the [Execution Backends documentation](/reference/infra/execution-backends).
 

--- a/fern/versions/v26.02/pages/api-reference/executors/ray-executors.mdx
+++ b/fern/versions/v26.02/pages/api-reference/executors/ray-executors.mdx
@@ -1,13 +1,9 @@
 ---
-title: Experimental Executors
-description: "API reference for experimental executors including Ray-based backends"
+title: Ray Executors
+description: "API reference for Ray-based execution backends: RayDataExecutor and RayActorPoolExecutor"
 ---
 
-NeMo Curator provides experimental executors for alternative execution backends. These are located in `nemo_curator.backends.experimental`.
-
-<Warning>
-Experimental executors are subject to change and may not have full feature parity with `XennaExecutor`.
-</Warning>
+NeMo Curator provides Ray-based executors for scalable distributed execution. These are located in `nemo_curator.backends.ray_data` and `nemo_curator.backends.ray_actor_pool`.
 
 ## RayDataExecutor
 
@@ -16,7 +12,7 @@ Uses Ray Data for distributed execution.
 ### Import
 
 ```python
-from nemo_curator.backends.experimental import RayDataExecutor
+from nemo_curator.backends.ray_data import RayDataExecutor
 ```
 
 ### Usage
@@ -46,7 +42,7 @@ Uses Ray Actor Pool for distributed execution.
 ### Import
 
 ```python
-from nemo_curator.backends.experimental import RayActorPoolExecutor
+from nemo_curator.backends.ray_actor_pool import RayActorPoolExecutor
 ```
 
 ### Usage
@@ -149,9 +145,10 @@ class MyCustomExecutor(BaseExecutor):
 | Executor | Best For | Considerations |
 |----------|----------|----------------|
 | `XennaExecutor` | Production workloads | Default choice, most stable |
-| `RayDataExecutor` | Ray-native environments | Experimental |
-| `RayActorPoolExecutor` | Fine-grained actor control | Experimental |
+| `RayDataExecutor` | Ray-native environments | Stable |
+| `RayActorPoolExecutor` | Fine-grained actor control | Stable |
 
 ## Source Code
 
-[View source on GitHub](https://github.com/NVIDIA-NeMo/Curator/blob/main/nemo_curator/backends/experimental/)
+- [RayDataExecutor](https://github.com/NVIDIA-NeMo/Curator/blob/main/nemo_curator/backends/ray_data/)
+- [RayActorPoolExecutor](https://github.com/NVIDIA-NeMo/Curator/blob/main/nemo_curator/backends/ray_actor_pool/)

--- a/fern/versions/v26.02/pages/api-reference/index.mdx
+++ b/fern/versions/v26.02/pages/api-reference/index.mdx
@@ -42,8 +42,8 @@ This section provides API reference documentation for NeMo Curator's core classe
   <Card title="XennaExecutor" href="/api/reference/api-reference/executors/xenna-executor">
     Production executor using Cosmos-Xenna for distributed execution.
   </Card>
-  <Card title="Experimental Executors" href="/api/reference/api-reference/executors/experimental">
-    Ray-based experimental executors.
+  <Card title="Ray Executors" href="/api/reference/api-reference/executors/ray-executors">
+    Ray-based execution backends: RayDataExecutor and RayActorPoolExecutor.
   </Card>
 </Cards>
 

--- a/fern/versions/v26.02/pages/curate-text/process-data/deduplication/semdedup.mdx
+++ b/fern/versions/v26.02/pages/curate-text/process-data/deduplication/semdedup.mdx
@@ -51,7 +51,7 @@ Get started with semantic deduplication using the following example of identifyi
 
 ```python
 from nemo_curator.stages.text.deduplication.semantic import TextSemanticDeduplicationWorkflow
-from nemo_curator.backends.experimental.ray_data import RayDataExecutor
+from nemo_curator.backends.ray_data import RayDataExecutor
 
 workflow = TextSemanticDeduplicationWorkflow(
     input_path="input_data/",

--- a/fern/versions/v26.02/pages/curate-text/process-data/quality-assessment/heuristic.mdx
+++ b/fern/versions/v26.02/pages/curate-text/process-data/quality-assessment/heuristic.mdx
@@ -427,7 +427,7 @@ pipeline.add_stage(JsonlWriter(path="filtered_output/"))
 pipeline.run()
 
 # Or use Ray for distributed processing (see Performance Tuning section)
-# from nemo_curator.backends.experimental.ray_data import RayDataExecutor
+# from nemo_curator.backends.ray_data import RayDataExecutor
 # pipeline.run(RayDataExecutor(ignore_head_node=True))
 ```
 </Tab>
@@ -457,11 +457,11 @@ results = pipeline.run(executor)
 If no executor is specified, `pipeline.run()` uses `XennaExecutor` with default settings.
 </Tab>
 
-<Tab title="RayDataExecutor (Experimental)">
+<Tab title="RayDataExecutor">
 `RayDataExecutor` provides distributed processing using Ray Data. It has shown performance improvements for filtering workloads compared to the default executor.
 
 ```python
-from nemo_curator.backends.experimental.ray_data import RayDataExecutor
+from nemo_curator.backends.ray_data import RayDataExecutor
 
 executor = RayDataExecutor(
     config={"ignore_failures": False},

--- a/fern/versions/v26.02/pages/reference/infrastructure/execution-backends.mdx
+++ b/fern/versions/v26.02/pages/reference/infrastructure/execution-backends.mdx
@@ -147,7 +147,7 @@ For more details, refer to [Text Deduplication ](/curate-text/process-data/dedup
 - **Scalable transformations**: Efficient map-batch operations across distributed workers
 
 ```python
-from nemo_curator.backends.experimental.ray_data import RayDataExecutor
+from nemo_curator.backends.ray_data import RayDataExecutor
 
 executor = RayDataExecutor()
 results = pipeline.run(executor)


### PR DESCRIPTION
## Promote `RayDataExecutor` and `RayActorPoolExecutor` from experimental

`RayDataExecutor` and `RayActorPoolExecutor` are now stable, first-class backends. The `nemo_curator.backends.experimental` subpackage no longer exists — both executors live at `nemo_curator.backends.ray_data` and `nemo_curator.backends.ray_actor_pool` respectively. This PR updates the docs to reflect that.

**Changes:**
- Renamed `api-reference/executors/experimental.mdx` → `ray-executors.mdx`; removed the experimental warning, updated the page title and all import paths
- Updated the nav entry (`Experimental` → `Ray Executors`) and the API reference index card
- Fixed stale `nemo_curator.backends.experimental.*` import paths in `execution-backends.mdx`, `heuristic.mdx`, and `semdedup.mdx`
- Removed "(Experimental)" label from the `RayDataExecutor` tab in heuristic filtering docs
- Scrubbed "experimental" language from release notes
- Added redirects in `docs.yml` so old `/executors/experimental` URLs continue to resolve
