### PR TITLE
Lazy init for openai client

### DIFF
--- a/nemo_curator/models/client/openai_client.py
+++ b/nemo_curator/models/client/openai_client.py
@@ -75,6 +75,9 @@ class OpenAIClient(LLMClient):
                 logger.warning(f"extra_kwargs will overwrite existing parameter(s): {overlapping}")
             create_kwargs.update(generation_config.extra_kwargs)
 
+        if not hasattr(self, "client"):
+            self.setup()
+
         response = self.client.chat.completions.create(**create_kwargs)
 
         return [choice.message.content for choice in response.choices]
@@ -148,6 +151,9 @@ class AsyncOpenAIClient(AsyncLLMClient):
             if overlapping:
                 logger.warning(f"extra_kwargs will overwrite existing parameter(s): {overlapping}")
             create_kwargs.update(generation_config.extra_kwargs)
+
+        if not hasattr(self, "client"):
+            self.setup()
 
         response = await self.client.chat.completions.create(**create_kwargs)
 

--- a/tests/models/client/test_openai_client.py
+++ b/tests/models/client/test_openai_client.py
@@ -175,6 +175,50 @@ class TestOpenAIClient:
             assert len(w) == 1
             assert "top_k is not used in an OpenAIClient" in str(w[0].message)
 
+    @patch("nemo_curator.models.client.openai_client.OpenAI")
+    def test_query_model_lazy_init_calls_setup_when_client_missing(self, mock_openai: Mock) -> None:
+        """Test that query_model calls setup() automatically when client is not initialized."""
+        mock_choice = Mock()
+        mock_choice.message.content = "Test response"
+        mock_response = Mock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = Mock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        client = OpenAIClient()
+        assert not hasattr(client, "client")
+
+        with patch.object(client, "setup", wraps=client.setup) as mock_setup:
+            client.query_model(messages=[{"role": "user", "content": "test"}], model="gpt-4")
+            mock_setup.assert_called_once()
+
+        assert hasattr(client, "client")
+        assert client.client == mock_client
+
+    @patch("nemo_curator.models.client.openai_client.OpenAI")
+    def test_query_model_lazy_init_skips_setup_when_client_exists(self, mock_openai: Mock) -> None:
+        """Test that query_model does not call setup() again when client is already initialized."""
+        mock_choice = Mock()
+        mock_choice.message.content = "Test response"
+        mock_response = Mock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = Mock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_openai.return_value = mock_client
+
+        client = OpenAIClient()
+        client.setup()
+        existing_client = client.client
+
+        with patch.object(client, "setup") as mock_setup:
+            client.query_model(messages=[{"role": "user", "content": "test"}], model="gpt-4")
+            mock_setup.assert_not_called()
+
+        assert client.client is existing_client
+
 
 class TestAsyncOpenAIClient:
     """Test cases for the AsyncOpenAIClient class."""
@@ -333,6 +377,52 @@ class TestAsyncOpenAIClient:
 
             assert len(w) == 1
             assert "top_k is not used in an AsyncOpenAIClient" in str(w[0].message)
+
+    @pytest.mark.asyncio
+    @patch("nemo_curator.models.client.openai_client.AsyncOpenAI")
+    async def test_query_model_impl_lazy_init_calls_setup_when_client_missing(self, mock_async_openai: Mock) -> None:
+        """Test that _query_model_impl calls setup() automatically when client is not initialized."""
+        mock_choice = Mock()
+        mock_choice.message.content = "Test response"
+        mock_response = Mock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_async_openai.return_value = mock_client
+
+        client = AsyncOpenAIClient()
+        assert not hasattr(client, "client")
+
+        with patch.object(client, "setup", wraps=client.setup) as mock_setup:
+            await client._query_model_impl(messages=[{"role": "user", "content": "test"}], model="gpt-4")
+            mock_setup.assert_called_once()
+
+        assert hasattr(client, "client")
+        assert client.client == mock_client
+
+    @pytest.mark.asyncio
+    @patch("nemo_curator.models.client.openai_client.AsyncOpenAI")
+    async def test_query_model_impl_lazy_init_skips_setup_when_client_exists(self, mock_async_openai: Mock) -> None:
+        """Test that _query_model_impl does not call setup() again when client is already initialized."""
+        mock_choice = Mock()
+        mock_choice.message.content = "Test response"
+        mock_response = Mock()
+        mock_response.choices = [mock_choice]
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        mock_async_openai.return_value = mock_client
+
+        client = AsyncOpenAIClient()
+        client.setup()
+        existing_client = client.client
+
+        with patch.object(client, "setup") as mock_setup:
+            await client._query_model_impl(messages=[{"role": "user", "content": "test"}], model="gpt-4")
+            mock_setup.assert_not_called()
+
+        assert client.client is existing_client
 
     @pytest.mark.asyncio
     @patch("nemo_curator.models.client.openai_client.AsyncOpenAI")


### PR DESCRIPTION
## Summary

- `OpenAIClient.query_model()` and `AsyncOpenAIClient._query_model_impl()` now lazy-initialize `self.client` via `setup()` if it hasn't been called yet
- Eliminates a confusing `AttributeError: object has no attribute 'client'` that gave no actionable hint to users who skipped the `setup()` lifecycle step
- Code that already calls `setup()` explicitly is unaffected; the Ray executor pattern (which calls `setup()` on each worker) continues to work unchanged


