### PR TITLE
[benchmarking] Adds `--use-host-curator-benchmarking` and `--skip-curator-image-build*` options

### DIFF
--- a/benchmarking/tools/build_docker.sh
+++ b/benchmarking/tools/build_docker.sh
@@ -17,12 +17,32 @@
 # Exit immediately on error, unset vars are errors, pipeline errors are errors
 set -euo pipefail
 
-# Tag the images with ':latest' tag if --tag-as-latest flag is present.
-# This is not the default to prevent name collisions from multiple users.
+# Parse command-line arguments
 TAG_AS_LATEST=false
-if [[ "${*}" == *"--tag-as-latest"* ]]; then
-  TAG_AS_LATEST=true
-fi
+SKIP_CURATOR_BUILD=false
+SKIP_CURATOR_BUILD_AND_PULL=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag-as-latest)
+      TAG_AS_LATEST=true
+      shift
+      ;;
+    --skip-curator-image-build)
+      SKIP_CURATOR_BUILD=true
+      shift
+      ;;
+    --skip-curator-image-build-and-pull)
+      SKIP_CURATOR_BUILD_AND_PULL=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--tag-as-latest] [--skip-curator-image-build] [--skip-curator-image-build-and-pull]"
+      exit 1
+      ;;
+  esac
+done
 
 UTC_TIMESTAMP=$(date --utc "+%Y%m%d%H%M%SUTC")
 CURATOR_IMAGE=${CURATOR_IMAGE:-"nemo_curator:${UTC_TIMESTAMP}"}
@@ -32,16 +52,24 @@ CURATOR_BENCHMARKING_IMAGE=${CURATOR_BENCHMARKING_IMAGE:-"nemo_curator_benchmark
 THIS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CURATOR_DIR="$(cd ${THIS_SCRIPT_DIR}/../.. && pwd)"
 
-# Build the standard NeMo Curator image
-docker build \
-  -f ${CURATOR_DIR}/docker/Dockerfile \
-  --target nemo_curator \
-  --tag=${CURATOR_IMAGE} \
-  ${CURATOR_DIR}
+# Either pull, build, or skip the standard NeMo Curator image
+if ${SKIP_CURATOR_BUILD_AND_PULL}; then
+  echo "Skipping build and pull, using existing NeMo Curator image: ${CURATOR_IMAGE}"
+elif ${SKIP_CURATOR_BUILD}; then
+  echo "Skipping build, pulling NeMo Curator image: ${CURATOR_IMAGE}"
+  docker pull "${CURATOR_IMAGE}"
+else
+  echo "Building NeMo Curator image: ${CURATOR_IMAGE}"
+  docker build \
+    -f ${CURATOR_DIR}/docker/Dockerfile \
+    --target nemo_curator \
+    --tag=${CURATOR_IMAGE} \
+    ${CURATOR_DIR}
 
-if ${TAG_AS_LATEST}; then
-  # Tag image as <name>:latest, where <name> is the part of CURATOR_IMAGE before the colon
-  docker tag "${CURATOR_IMAGE}" "${CURATOR_IMAGE%%:*}:latest"
+  if ${TAG_AS_LATEST}; then
+    # Tag image as <name>:latest, where <name> is the part of CURATOR_IMAGE before the colon
+    docker tag "${CURATOR_IMAGE}" "${CURATOR_IMAGE%%:*}:latest"
+  fi
 fi
 
 # Build the benchmarking image which extends the standard NeMo Curator image

--- a/benchmarking/tools/build_docker.sh
+++ b/benchmarking/tools/build_docker.sh
@@ -53,6 +53,12 @@ THIS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CURATOR_DIR="$(cd ${THIS_SCRIPT_DIR}/../.. && pwd)"
 
 # Either pull, build, or skip the standard NeMo Curator image
+if ${SKIP_CURATOR_BUILD} && ${SKIP_CURATOR_BUILD_AND_PULL}; then
+  echo "Error: --skip-curator-image-build and --skip-curator-image-build-and-pull cannot be combined."
+  exit 1
+fi
+
+# Either pull, build, or skip the standard NeMo Curator image
 if ${SKIP_CURATOR_BUILD_AND_PULL}; then
   echo "Skipping build and pull, using existing NeMo Curator image: ${CURATOR_IMAGE}"
 elif ${SKIP_CURATOR_BUILD}; then

--- a/benchmarking/tools/gen_runscript_vars.py
+++ b/benchmarking/tools/gen_runscript_vars.py
@@ -57,6 +57,8 @@ def print_help(script_name: str) -> None:
 
   Options:
       --use-host-curator       Mount $HOST_CURATOR_DIR into the container for benchmarking/debugging curator sources without rebuilding the image.
+      --use-host-curator-benchmarking
+                               Like --use-host-curator, but only for the benchmarking directory. This is useful for using the host benchmarking tools to benchmark Curator installed in the container.
       --shell                  Start an interactive bash shell instead of running benchmarks. ARGS, if specified, will be passed to 'bash -c'.
                                For example: '--shell uv pip list | grep cugraph' will run 'uv pip list | grep cugraph' to display the version of cugraph installed in the container.
       --config <path>          Path to a YAML config file. Can be specified multiple times to merge configs. This arg is required if not using --shell.
@@ -77,7 +79,7 @@ def combine_dir_paths(patha: str | Path, pathb: str | Path) -> Path:
     return Path(f"{patha}/{pathb}").absolute().expanduser().resolve()
 
 
-def get_runscript_eval_str(argv: list[str]) -> str:  # noqa: C901, PLR0915
+def get_runscript_eval_str(argv: list[str]) -> str:  # noqa: C901, PLR0912, PLR0915
     """
     Parse CLI args and output env variables for bash integration.
     argv is a list of strings to be treated like sys.argv, where argv[0] is the name of this script.
@@ -113,16 +115,26 @@ def get_runscript_eval_str(argv: list[str]) -> str:  # noqa: C901, PLR0915
         add_help=False,
     )
     parser.add_argument("--use-host-curator", action="store_true")
+    parser.add_argument("--use-host-curator-benchmarking", action="store_true")
     parser.add_argument("--shell", action="store_true")
     parser.add_argument("--config", action="append", type=Path, default=[])
 
     args, unknown_args = parser.parse_known_args(argv[1:])
 
-    # Set volume mount for host curator directory.
+    # Set volume mount for host curator or benchmarking directories.
+    if args.use_host_curator and args.use_host_curator_benchmarking:
+        msg = "Cannot use --use-host-curator and --use-host-curator-benchmarking together."
+        raise RuntimeError(msg)
+
     if args.use_host_curator:
         # Do not use combine_dir_paths here since CONTAINER_CURATOR_DIR is assumed to be a unique absolute
         # path (e.g., /opt/Curator from Dockerfile).
         volume_mounts.append(f"--volume {Path(HOST_CURATOR_DIR).absolute()}:{CONTAINER_CURATOR_DIR}")
+
+    if args.use_host_curator_benchmarking:
+        volume_mounts.append(
+            f"--volume {(Path(HOST_CURATOR_DIR) / 'benchmarking').absolute()}:{Path(CONTAINER_CURATOR_DIR) / 'benchmarking'}"
+        )
 
     # Set entrypoint to bash if --shell is passed.
     if args.shell:

--- a/benchmarking/tools/run.sh
+++ b/benchmarking/tools/run.sh
@@ -73,6 +73,7 @@ docker run \
   \
   ${VOLUME_MOUNTS} \
   \
+  --env=NVIDIA_DRIVER_CAPABILITIES=compute,utility,video \
   --env=IMAGE_DIGEST=${IMAGE_DIGEST} \
   --env=MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI} \
   --env=SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \


### PR DESCRIPTION
[benchmarking] Adds `--use-host-curator-benchmarking` and `--skip-curator-image-build*` options, adds `NVIDIA_DRIVER_CAPABILITIES` to docker run script.

## Summary

This PR adds features to the benchmarking tools to make it easier to benchmark specific image builds (such as RC builds).
These features were first used in [this PR](https://github.com/NVIDIA-NeMo/Curator/pull/1431) but were never merged.

- **`gen_runscript_vars.py`**: Add `--use-host-curator-benchmarking` option that mounts only the `benchmarking/` subdirectory into the container, rather than the full curator repo as `--use-host-curator` does. Useful for iterating on benchmarking tools while using the Curator version installed in the image. The two flags are mutually exclusive.
- **`build_docker.sh`**: Replace the simple `--tag-as-latest` string check with a proper argument parser loop. Add two new options:
  - `--skip-curator-image-build`: pull the curator image instead of building it locally
  - `--skip-curator-image-build-and-pull`: skip both build and pull, using an existing local image
- **`run.sh`**: Adds `NVIDIA_DRIVER_CAPABILITIES` to docker run call.

## Test plan

- [x] Verify `--use-host-curator-benchmarking` mounts only `benchmarking/` and not the full repo
- [x] Verify `--use-host-curator` and `--use-host-curator-benchmarking` together produce a clear error
- [x] Verify `--skip-curator-image-build` pulls the image rather than building
- [x] Verify `--skip-curator-image-build-and-pull` skips both steps and uses the existing local image
- [x] Verify `--tag-as-latest` still works correctly with the new argument parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)
