### PR TITLE
fix: drop libopenh264 and libx264, keep h264_nvenc only

### DIFF
--- a/docker/common/install_ffmpeg.sh
+++ b/docker/common/install_ffmpeg.sh
@@ -48,7 +48,6 @@ apt-get install -y \
     libvorbis-dev \
     libvpx-dev \
     libwebp-dev \
-    libx264-dev \
     nasm \
     pkg-config \
     vainfo \
@@ -69,7 +68,6 @@ tar xjvf /tmp/ffmpeg-snapshot.tar.bz2 -C /tmp/
 cd /tmp/ffmpeg-${FFMPEG_VERSION}
 PATH="/usr/local/cuda/bin:$PATH" ./configure \
     --prefix=/usr/local \
-    --enable-gpl \
     --enable-nonfree \
     --enable-cuda-nvcc \
     --enable-libnpp \
@@ -78,7 +76,6 @@ PATH="/usr/local/cuda/bin:$PATH" ./configure \
     --enable-libvorbis \
     --enable-libvpx \
     --enable-libwebp \
-    --enable-libx264 \
     --enable-vaapi \
     --extra-cflags=-I/usr/local/cuda/include \
     --extra-ldflags=-L/usr/local/cuda/lib64 \

--- a/docker/common/install_ffmpeg.sh
+++ b/docker/common/install_ffmpeg.sh
@@ -48,6 +48,7 @@ apt-get install -y \
     libvorbis-dev \
     libvpx-dev \
     libwebp-dev \
+    libx264-dev \
     nasm \
     pkg-config \
     vainfo \
@@ -68,6 +69,7 @@ tar xjvf /tmp/ffmpeg-snapshot.tar.bz2 -C /tmp/
 cd /tmp/ffmpeg-${FFMPEG_VERSION}
 PATH="/usr/local/cuda/bin:$PATH" ./configure \
     --prefix=/usr/local \
+    --enable-gpl \
     --enable-nonfree \
     --enable-cuda-nvcc \
     --enable-libnpp \
@@ -76,6 +78,7 @@ PATH="/usr/local/cuda/bin:$PATH" ./configure \
     --enable-libvorbis \
     --enable-libvpx \
     --enable-libwebp \
+    --enable-libx264 \
     --enable-vaapi \
     --extra-cflags=-I/usr/local/cuda/include \
     --extra-ldflags=-L/usr/local/cuda/lib64 \

--- a/docker/common/install_ffmpeg.sh
+++ b/docker/common/install_ffmpeg.sh
@@ -43,7 +43,6 @@ apt-get install -y \
     libfreetype6-dev \
     libgnutls28-dev \
     libnuma-dev \
-    libopenh264-dev \
     libtool \
     libva-dev \
     libvorbis-dev \
@@ -72,7 +71,6 @@ PATH="/usr/local/cuda/bin:$PATH" ./configure \
     --enable-nonfree \
     --enable-cuda-nvcc \
     --enable-libnpp \
-    --enable-libopenh264 \
     --enable-libaom \
     --enable-libdav1d \
     --enable-libvorbis \

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -138,13 +138,13 @@ docker run --gpus all -it --rm nemo-curator:latest
 
 ### Install FFmpeg and Encoders (Required for Video)
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libopenh264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libx264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
 
 ::::{tab-set}
 
 :::{tab-item} Debian/Ubuntu (Script)
 
-Use the maintained script in the repository to build and install `FFmpeg` with `libopenh264` and NVIDIA NVENC support. The script enables `--enable-libopenh264`, `--enable-cuda-nvcc`, and `--enable-libnpp`.
+Use the maintained script in the repository to build and install `FFmpeg` with NVIDIA NVENC support. The script enables `--enable-cuda-nvcc` and `--enable-libnpp`.
 
 - Script source: [docker/common/install_ffmpeg.sh](https://github.com/NVIDIA-NeMo/Curator/blob/main/docker/common/install_ffmpeg.sh)
 
@@ -162,7 +162,7 @@ Confirm that `FFmpeg` is on your `PATH` and that at least one H.264 encoder is a
 
 ```bash
 ffmpeg -hide_banner -version | head -n 5
-ffmpeg -encoders | grep -E "h264_nvenc|libopenh264|libx264" | cat
+ffmpeg -encoders | grep -E "h264_nvenc|libx264" | cat
 ```
 
 If encoders are missing, reinstall `FFmpeg` with the required options or use the Debian/Ubuntu script above.

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -138,7 +138,7 @@ docker run --gpus all -it --rm nemo-curator:latest
 
 ### Install FFmpeg and Encoders (Required for Video)
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libx264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (using `--transcode-encoder h264_nvenc`), install `FFmpeg` with NVENC support.
 
 ::::{tab-set}
 
@@ -162,7 +162,7 @@ Confirm that `FFmpeg` is on your `PATH` and that at least one H.264 encoder is a
 
 ```bash
 ffmpeg -hide_banner -version | head -n 5
-ffmpeg -encoders | grep -E "h264_nvenc|libx264" | cat
+ffmpeg -encoders | grep h264_nvenc | cat
 ```
 
 If encoders are missing, reinstall `FFmpeg` with the required options or use the Debian/Ubuntu script above.

--- a/docs/curate-video/index.md
+++ b/docs/curate-video/index.md
@@ -121,7 +121,6 @@ Encode clips to H.264 using CPU or GPU encoders and tune performance.
 +++
 {bdg-primary}`clips`
 {bdg-secondary}`h264_nvenc`
-{bdg-secondary}`libopenh264`
 {bdg-secondary}`libx264`
 :::
 

--- a/docs/curate-video/index.md
+++ b/docs/curate-video/index.md
@@ -121,7 +121,6 @@ Encode clips to H.264 using CPU or GPU encoders and tune performance.
 +++
 {bdg-primary}`clips`
 {bdg-secondary}`h264_nvenc`
-{bdg-secondary}`libx264`
 :::
 
 :::{grid-item-card} {octicon}`filter;1.5em;sd-mr-1` Filter Clips and Frames

--- a/docs/curate-video/process-data/index.md
+++ b/docs/curate-video/process-data/index.md
@@ -42,7 +42,6 @@ Encode clips to H.264 using CPU or GPU encoders and tune performance.
 +++
 {bdg-primary}`clips`
 {bdg-secondary}`h264_nvenc`
-{bdg-secondary}`libx264`
 :::
 
 :::{grid-item-card} {octicon}`filter;1.5em;sd-mr-1` Filter Clips and Frames

--- a/docs/curate-video/process-data/index.md
+++ b/docs/curate-video/process-data/index.md
@@ -42,7 +42,7 @@ Encode clips to H.264 using CPU or GPU encoders and tune performance.
 +++
 {bdg-primary}`clips`
 {bdg-secondary}`h264_nvenc`
-{bdg-secondary}`libopenh264`
+{bdg-secondary}`libx264`
 :::
 
 :::{grid-item-card} {octicon}`filter;1.5em;sd-mr-1` Filter Clips and Frames

--- a/docs/curate-video/process-data/transcoding.md
+++ b/docs/curate-video/process-data/transcoding.md
@@ -41,7 +41,7 @@ from nemo_curator.stages.video.clipping.clip_extraction_stages import FixedStrid
 
 pipe = Pipeline(name="transcode_example")
 pipe.add_stage(FixedStrideExtractorStage(clip_len_s=10.0, clip_stride_s=10.0))
-pipe.add_stage(ClipTranscodingStage(encoder="libx264", encode_batch_size=16, encoder_threads=1, verbose=True))
+pipe.add_stage(ClipTranscodingStage(encoder="h264_nvenc", encode_batch_size=16, encoder_threads=1, verbose=True))
 pipe.run()
 ```
 
@@ -67,9 +67,6 @@ python -m ray_curator.examples.video.video_split_clip_example \
 * - Encoder
   - Hardware
   - Description
-* - `libx264`
-  - CPU
-  - Widely available, high quality, CPU-based.
 * - `h264_nvenc`
   - NVIDIA GPU (NVENC)
   - Uses NVENC for high-throughput H.264 encoding on NVIDIA GPU hardware.
@@ -99,7 +96,7 @@ Use `ClipTranscodingStage` to control encoder choice, batching, and acceleration
 from nemo_curator.stages.video.clipping.clip_extraction_stages import ClipTranscodingStage
 
 transcode = ClipTranscodingStage(
-    encoder="h264_nvenc",        # or "libx264"
+    encoder="h264_nvenc",
     use_hwaccel=True,             # enable NVENC when using h264_nvenc
     encoder_threads=1,            # CPU thread count for CPU encoders
     encode_batch_size=16,         # number of clips per encode batch
@@ -118,7 +115,7 @@ transcode = ClipTranscodingStage(
 * - Parameter
   - Description
 * - `encoder`
-  - Selects the encoding backend. Recommended defaults: `libx264` (CPU) or `h264_nvenc` (GPU).
+  - Selects the encoding backend. Currently only `h264_nvenc` (GPU) is supported.
 * - `use_hwaccel`
   - Enable when using GPU encoders like `h264_nvenc`.
 * - `encoder_threads`

--- a/docs/curate-video/process-data/transcoding.md
+++ b/docs/curate-video/process-data/transcoding.md
@@ -41,7 +41,7 @@ from nemo_curator.stages.video.clipping.clip_extraction_stages import FixedStrid
 
 pipe = Pipeline(name="transcode_example")
 pipe.add_stage(FixedStrideExtractorStage(clip_len_s=10.0, clip_stride_s=10.0))
-pipe.add_stage(ClipTranscodingStage(encoder="libopenh264", encode_batch_size=16, encoder_threads=1, verbose=True))
+pipe.add_stage(ClipTranscodingStage(encoder="libx264", encode_batch_size=16, encoder_threads=1, verbose=True))
 pipe.run()
 ```
 
@@ -70,9 +70,6 @@ python -m ray_curator.examples.video.video_split_clip_example \
 * - `libx264`
   - CPU
   - Widely available, high quality, CPU-based.
-* - `libopenh264`
-  - CPU
-  - Good quality and throughput balance. Often faster than `libx264` at similar presets.
 * - `h264_nvenc`
   - NVIDIA GPU (NVENC)
   - Uses NVENC for high-throughput H.264 encoding on NVIDIA GPU hardware.
@@ -102,7 +99,7 @@ Use `ClipTranscodingStage` to control encoder choice, batching, and acceleration
 from nemo_curator.stages.video.clipping.clip_extraction_stages import ClipTranscodingStage
 
 transcode = ClipTranscodingStage(
-    encoder="h264_nvenc",        # or "libopenh264", "libx264"
+    encoder="h264_nvenc",        # or "libx264"
     use_hwaccel=True,             # enable NVENC when using h264_nvenc
     encoder_threads=1,            # CPU thread count for CPU encoders
     encode_batch_size=16,         # number of clips per encode batch
@@ -121,7 +118,7 @@ transcode = ClipTranscodingStage(
 * - Parameter
   - Description
 * - `encoder`
-  - Selects the encoding backend. Recommended defaults: `libopenh264` (CPU) or `h264_nvenc` (GPU).
+  - Selects the encoding backend. Recommended defaults: `libx264` (CPU) or `h264_nvenc` (GPU).
 * - `use_hwaccel`
   - Enable when using GPU encoders like `h264_nvenc`.
 * - `encoder_threads`

--- a/docs/curate-video/tutorials/beginner.md
+++ b/docs/curate-video/tutorials/beginner.md
@@ -46,7 +46,7 @@ flowchart LR
 - **Data units**: Input videos → clip windows → frames → embeddings + files.
 - **Common choices**:
   - **Splitting**: fixed stride vs. scene-change (TransNetV2)
-  - **Encoding**: `libopenh264`, `h264_nvenc`, or `libx264`
+  - **Encoding**: `h264_nvenc` or `libx264`
   - **Embeddings**: Cosmos-Embed1
 - **Outputs**: Clips (mp4), previews (optional), and parquet embeddings for downstream tasks (such as semantic duplicate removal).
 
@@ -158,7 +158,7 @@ Convert clip buffers to H.264 using the selected encoder and settings. Refer to 
 pipeline.add_stage(
     ClipTranscodingStage(
         num_cpus_per_worker=6.0,
-        encoder="libopenh264",
+        encoder="libx264",
         encoder_threads=1,
         encode_batch_size=16,
         use_hwaccel=False,

--- a/docs/curate-video/tutorials/beginner.md
+++ b/docs/curate-video/tutorials/beginner.md
@@ -46,7 +46,7 @@ flowchart LR
 - **Data units**: Input videos → clip windows → frames → embeddings + files.
 - **Common choices**:
   - **Splitting**: fixed stride vs. scene-change (TransNetV2)
-  - **Encoding**: `h264_nvenc` or `libx264`
+  - **Encoding**: `h264_nvenc`
   - **Embeddings**: Cosmos-Embed1
 - **Outputs**: Clips (mp4), previews (optional), and parquet embeddings for downstream tasks (such as semantic duplicate removal).
 
@@ -158,7 +158,7 @@ Convert clip buffers to H.264 using the selected encoder and settings. Refer to 
 pipeline.add_stage(
     ClipTranscodingStage(
         num_cpus_per_worker=6.0,
-        encoder="libx264",
+        encoder="h264_nvenc",
         encoder_threads=1,
         encode_batch_size=16,
         use_hwaccel=False,

--- a/docs/curate-video/tutorials/split-dedup.md
+++ b/docs/curate-video/tutorials/split-dedup.md
@@ -38,7 +38,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
   --splitting-algorithm fixed_stride \
   --fixed-stride-split-duration 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libx264 \
+  --transcode-encoder h264_nvenc \
   --verbose
 ```
 

--- a/docs/curate-video/tutorials/split-dedup.md
+++ b/docs/curate-video/tutorials/split-dedup.md
@@ -38,7 +38,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
   --splitting-algorithm fixed_stride \
   --fixed-stride-split-duration 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libopenh264 \
+  --transcode-encoder libx264 \
   --verbose
 ```
 

--- a/docs/get-started/video.md
+++ b/docs/get-started/video.md
@@ -60,7 +60,7 @@ To use NeMo Curator's video curation capabilities, ensure your system meets thes
 #### Software Dependencies
 * **FFmpeg 8.0+** with H.264 encoding support
   - GPU encoder: `h264_nvenc` (recommended for performance)
-  - CPU encoders: `libopenh264` or `libx264` (fallback options)
+  - CPU encoder: `libx264` (fallback option)
 
 :::{tip}
 If `uv` is not installed, refer to the [Installation Guide](../admin/installation.md) for setup instructions, or install it quickly with:
@@ -122,13 +122,13 @@ For details on container environments and configurations, see [Container Environ
 
 ## Install FFmpeg and Encoders
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libopenh264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libx264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
 
 ::::{tab-set}
 
 :::{tab-item} Debian/Ubuntu (Script)
 
-Use the maintained script in the repository to build and install `FFmpeg` with `libopenh264` and NVIDIA NVENC support. The script enables `--enable-libopenh264`, `--enable-cuda-nvcc`, and `--enable-libnpp`.
+Use the maintained script in the repository to build and install `FFmpeg` with NVIDIA NVENC support. The script enables `--enable-cuda-nvcc` and `--enable-libnpp`.
 
 - Script source: [docker/common/install_ffmpeg.sh](https://github.com/NVIDIA-NeMo/Curator/blob/main/docker/common/install_ffmpeg.sh)
 
@@ -146,7 +146,7 @@ Confirm that `FFmpeg` is on your `PATH` and that at least one H.264 encoder is a
 
 ```bash
 ffmpeg -hide_banner -version | head -n 5
-ffmpeg -encoders | grep -E "h264_nvenc|libopenh264|libx264" | cat
+ffmpeg -encoders | grep -E "h264_nvenc|libx264" | cat
 ```
 
 If encoders are missing, reinstall `FFmpeg` with the required options or use the Debian/Ubuntu script above.
@@ -231,7 +231,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
   --splitting-algorithm fixed_stride \
   --fixed-stride-split-duration 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libopenh264 \
+  --transcode-encoder libx264 \
   --verbose
 ```
 
@@ -239,7 +239,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 1. Reads all video files from `$DATA_DIR`
 2. Splits each video into 10-second clips using fixed stride
 3. Generates embeddings using Cosmos-Embed1-224p model
-4. Encodes clips using libopenh264 codec
+4. Encodes clips using libx264 codec
 5. Writes output clips and metadata to `$OUT_DIR`
 
 ```{tip}
@@ -250,7 +250,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
     --splitting-algorithm fixed_stride
     --fixed-stride-split-duration 10.0
     --embedding-algorithm cosmos-embed1-224p
-    --transcode-encoder libopenh264' > my_config.txt
+    --transcode-encoder libx264' > my_config.txt
     
     python tutorials/video/getting-started/video_split_clip_example.py @my_config.txt
 ```
@@ -266,7 +266,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 | **Embedding** |
 | `--embedding-algorithm` | `cosmos-embed1-224p`, `cosmos-embed1-336p`, `cosmos-embed1-448p` | Embedding model to use |
 | **Encoding** |
-| `--transcode-encoder` | `h264_nvenc`, `libopenh264`, `libx264` | Video encoder for output clips |
+| `--transcode-encoder` | `h264_nvenc`, `libx264` | Video encoder for output clips |
 | `--transcode-use-hwaccel` | Flag | Enable hardware acceleration for encoding |
 | **Optional Features** |
 | `--generate-captions` | Flag | Generate text captions for each clip |

--- a/docs/get-started/video.md
+++ b/docs/get-started/video.md
@@ -60,7 +60,6 @@ To use NeMo Curator's video curation capabilities, ensure your system meets thes
 #### Software Dependencies
 * **FFmpeg 8.0+** with H.264 encoding support
   - GPU encoder: `h264_nvenc` (recommended for performance)
-  - CPU encoder: `libx264` (fallback option)
 
 :::{tip}
 If `uv` is not installed, refer to the [Installation Guide](../admin/installation.md) for setup instructions, or install it quickly with:
@@ -122,7 +121,7 @@ For details on container environments and configurations, see [Container Environ
 
 ## Install FFmpeg and Encoders
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libx264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (using `--transcode-encoder h264_nvenc`), install `FFmpeg` with NVENC support.
 
 ::::{tab-set}
 
@@ -146,7 +145,7 @@ Confirm that `FFmpeg` is on your `PATH` and that at least one H.264 encoder is a
 
 ```bash
 ffmpeg -hide_banner -version | head -n 5
-ffmpeg -encoders | grep -E "h264_nvenc|libx264" | cat
+ffmpeg -encoders | grep h264_nvenc | cat
 ```
 
 If encoders are missing, reinstall `FFmpeg` with the required options or use the Debian/Ubuntu script above.
@@ -231,7 +230,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
   --splitting-algorithm fixed_stride \
   --fixed-stride-split-duration 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libx264 \
+  --transcode-encoder h264_nvenc \
   --verbose
 ```
 
@@ -239,7 +238,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 1. Reads all video files from `$DATA_DIR`
 2. Splits each video into 10-second clips using fixed stride
 3. Generates embeddings using Cosmos-Embed1-224p model
-4. Encodes clips using libx264 codec
+4. Encodes clips using h264_nvenc codec
 5. Writes output clips and metadata to `$OUT_DIR`
 
 ```{tip}
@@ -250,7 +249,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
     --splitting-algorithm fixed_stride
     --fixed-stride-split-duration 10.0
     --embedding-algorithm cosmos-embed1-224p
-    --transcode-encoder libx264' > my_config.txt
+    --transcode-encoder h264_nvenc' > my_config.txt
     
     python tutorials/video/getting-started/video_split_clip_example.py @my_config.txt
 ```
@@ -266,7 +265,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 | **Embedding** |
 | `--embedding-algorithm` | `cosmos-embed1-224p`, `cosmos-embed1-336p`, `cosmos-embed1-448p` | Embedding model to use |
 | **Encoding** |
-| `--transcode-encoder` | `h264_nvenc`, `libx264` | Video encoder for output clips |
+| `--transcode-encoder` | `h264_nvenc` | Video encoder for output clips |
 | `--transcode-use-hwaccel` | Flag | Enable hardware acceleration for encoding |
 | **Optional Features** |
 | `--generate-captions` | Flag | Generate text captions for each clip |

--- a/nemo_curator/stages/video/clipping/clip_extraction_stages.py
+++ b/nemo_curator/stages/video/clipping/clip_extraction_stages.py
@@ -35,7 +35,7 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
     """Stage that transcodes video clips into a standardized format.
 
     This stage handles the conversion of video clips using FFmpeg, supporting both
-    software (libx264, libopenh264) and hardware (NVENC) encoding with configurable parameters.
+    software (libx264) and hardware (NVENC) encoding with configurable parameters.
 
     Args:
         num_cpus_per_worker: Number of CPUs per worker.
@@ -69,8 +69,8 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
         Args:
             worker_metadata (WorkerMetadata, optional): Information about the worker (provided by some backends)
         """
-        if self.encoder not in {"libopenh264", "libx264", "h264_nvenc"}:
-            error_msg = f"Expected encoder of `libopenh264`, `libx264`, or `h264_nvenc`. Got {self.encoder}"
+        if self.encoder not in {"libx264", "h264_nvenc"}:
+            error_msg = f"Expected encoder of `libx264` or `h264_nvenc`. Got {self.encoder}"
             raise ValueError(error_msg)
 
     def __post_init__(self) -> None:

--- a/nemo_curator/stages/video/clipping/clip_extraction_stages.py
+++ b/nemo_curator/stages/video/clipping/clip_extraction_stages.py
@@ -34,8 +34,8 @@ from nemo_curator.utils.operation_utils import make_pipeline_temporary_dir
 class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
     """Stage that transcodes video clips into a standardized format.
 
-    This stage handles the conversion of video clips using FFmpeg, supporting both
-    software (libx264) and hardware (NVENC) encoding with configurable parameters.
+    This stage handles the conversion of video clips using FFmpeg with hardware
+    (NVENC) encoding and configurable parameters.
 
     Args:
         num_cpus_per_worker: Number of CPUs per worker.
@@ -51,7 +51,7 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
     """
 
     num_cpus_per_worker: float = 6.0
-    encoder: str = "libx264"
+    encoder: str = "h264_nvenc"
     encoder_threads: int = 1
     encode_batch_size: int = 16
     nb_streams_per_gpu: int = 3
@@ -69,8 +69,8 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
         Args:
             worker_metadata (WorkerMetadata, optional): Information about the worker (provided by some backends)
         """
-        if self.encoder not in {"libx264", "h264_nvenc"}:
-            error_msg = f"Expected encoder of `libx264` or `h264_nvenc`. Got {self.encoder}"
+        if self.encoder != "h264_nvenc":
+            error_msg = f"Expected encoder of `h264_nvenc`. Got {self.encoder}"
             raise ValueError(error_msg)
 
     def __post_init__(self) -> None:

--- a/tests/stages/video/clipping/test_clip_transcoding_stage.py
+++ b/tests/stages/video/clipping/test_clip_transcoding_stage.py
@@ -22,7 +22,6 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from nemo_curator.backends.base import WorkerMetadata
-from nemo_curator.stages.resources import Resources
 from nemo_curator.stages.video.clipping.clip_extraction_stages import ClipTranscodingStage
 from nemo_curator.tasks.video import Clip, Video, VideoMetadata, VideoTask
 
@@ -46,7 +45,7 @@ class TestClipTranscodingStage:
         """Set up test fixtures."""
         self.stage = ClipTranscodingStage(
             num_cpus_per_worker=4.0,
-            encoder="libx264",
+            encoder="h264_nvenc",
             encoder_threads=2,
             encode_batch_size=8,
             use_hwaccel=False,
@@ -111,14 +110,6 @@ class TestClipTranscodingStage:
 
         assert RayStageSpecKeys.IS_FANOUT_STAGE in spec
         assert spec[RayStageSpecKeys.IS_FANOUT_STAGE] is True
-
-    def test_resources_cpu_encoder(self) -> None:
-        """Test resource requirements for CPU encoders."""
-        stage = ClipTranscodingStage(encoder="libx264", use_hwaccel=False, num_cpus_per_worker=6.0)
-
-        resources = stage.resources
-        assert isinstance(resources, Resources)
-        assert resources.cpus == 6.0
 
     def test_process_no_clips(self) -> None:
         """Test processing when video has no clips."""
@@ -317,7 +308,7 @@ class TestClipTranscodingStage:
         assert "-map" in command
         assert "0:v:0" in command
         assert "-c:v" in command
-        assert "libx264" in command
+        assert "h264_nvenc" in command
 
     def test_add_video_encoding_options_no_bitrate(self) -> None:
         """Test adding video encoding options without bit rate."""

--- a/tutorials/video/getting-started/README.md
+++ b/tutorials/video/getting-started/README.md
@@ -50,10 +50,10 @@ python video_split_clip_example.py \
   --transnetv2-min-length-s 2.0 \
   --transnetv2-max-length-s 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libx264 \
+  --transcode-encoder h264_nvenc \
   --verbose
 ```
-This example demonstrates a more advanced workflow than the minimal example by using scene-aware splitting with the TransNetV2 algorithm (which detects scene boundaries instead of fixed intervals), applies the Cosmos-Embed1 embedding model to each clip, transcodes the output using the `libx264` encoder, and enables verbose logging for more detailed output.
+This example demonstrates a more advanced workflow than the minimal example by using scene-aware splitting with the TransNetV2 algorithm (which detects scene boundaries instead of fixed intervals), applies the Cosmos-Embed1 embedding model to each clip, transcodes the output using the `h264_nvenc` encoder, and enables verbose logging for more detailed output.
 
 **Full pipeline with captions and filtering**:
 ```bash

--- a/tutorials/video/getting-started/README.md
+++ b/tutorials/video/getting-started/README.md
@@ -50,10 +50,10 @@ python video_split_clip_example.py \
   --transnetv2-min-length-s 2.0 \
   --transnetv2-max-length-s 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libopenh264 \
+  --transcode-encoder libx264 \
   --verbose
 ```
-This example demonstrates a more advanced workflow than the minimal example by using scene-aware splitting with the TransNetV2 algorithm (which detects scene boundaries instead of fixed intervals), applies the Cosmos-Embed1 embedding model to each clip, transcodes the output using the `libopenh264` encoder, and enables verbose logging for more detailed output.
+This example demonstrates a more advanced workflow than the minimal example by using scene-aware splitting with the TransNetV2 algorithm (which detects scene boundaries instead of fixed intervals), applies the Cosmos-Embed1 embedding model to each clip, transcodes the output using the `libx264` encoder, and enables verbose logging for more detailed output.
 
 **Full pipeline with captions and filtering**:
 ```bash

--- a/tutorials/video/getting-started/video_split_clip_example.py
+++ b/tutorials/video/getting-started/video_split_clip_example.py
@@ -379,8 +379,8 @@ def create_video_splitting_argparser() -> argparse.ArgumentParser:  # noqa: PLR0
     parser.add_argument(
         "--transcode-encoder",
         type=str,
-        default="libopenh264",
-        choices=["libopenh264", "h264_nvenc", "libx264"],
+        default="libx264",
+        choices=["h264_nvenc", "libx264"],
         help="Codec for transcoding clips; None to skip transcoding.",
     )
     parser.add_argument(

--- a/tutorials/video/getting-started/video_split_clip_example.py
+++ b/tutorials/video/getting-started/video_split_clip_example.py
@@ -379,8 +379,8 @@ def create_video_splitting_argparser() -> argparse.ArgumentParser:  # noqa: PLR0
     parser.add_argument(
         "--transcode-encoder",
         type=str,
-        default="libx264",
-        choices=["h264_nvenc", "libx264"],
+        default="h264_nvenc",
+        choices=["h264_nvenc"],
         help="Codec for transcoding clips; None to skip transcoding.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Description

  - Drops libopenh264 from the FFmpeg build (apt + --enable-libopenh264 flag) and narrows ClipTranscodingStage to h264_nvenc only.
  - Tutorial default, tests, and docs updated; CPU-encoder path is no longer surfaced as a supported option.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
