### PR TITLE
Remove libopenh&libx264 and Add vp9

### DIFF
--- a/docker/common/install_ffmpeg.sh
+++ b/docker/common/install_ffmpeg.sh
@@ -48,7 +48,6 @@ apt-get install -y \
     libvorbis-dev \
     libvpx-dev \
     libwebp-dev \
-    libx264-dev \
     nasm \
     pkg-config \
     vainfo \
@@ -69,7 +68,6 @@ tar xjvf /tmp/ffmpeg-snapshot.tar.bz2 -C /tmp/
 cd /tmp/ffmpeg-${FFMPEG_VERSION}
 PATH="/usr/local/cuda/bin:$PATH" ./configure \
     --prefix=/usr/local \
-    --enable-gpl \
     --enable-nonfree \
     --enable-cuda-nvcc \
     --enable-libnpp \
@@ -78,7 +76,6 @@ PATH="/usr/local/cuda/bin:$PATH" ./configure \
     --enable-libvorbis \
     --enable-libvpx \
     --enable-libwebp \
-    --enable-libx264 \
     --enable-vaapi \
     --extra-cflags=-I/usr/local/cuda/include \
     --extra-ldflags=-L/usr/local/cuda/lib64 \

--- a/docker/common/install_ffmpeg.sh
+++ b/docker/common/install_ffmpeg.sh
@@ -48,6 +48,7 @@ apt-get install -y \
     libvorbis-dev \
     libvpx-dev \
     libwebp-dev \
+    libx264-dev \
     nasm \
     pkg-config \
     vainfo \
@@ -68,6 +69,7 @@ tar xjvf /tmp/ffmpeg-snapshot.tar.bz2 -C /tmp/
 cd /tmp/ffmpeg-${FFMPEG_VERSION}
 PATH="/usr/local/cuda/bin:$PATH" ./configure \
     --prefix=/usr/local \
+    --enable-gpl \
     --enable-nonfree \
     --enable-cuda-nvcc \
     --enable-libnpp \
@@ -76,6 +78,7 @@ PATH="/usr/local/cuda/bin:$PATH" ./configure \
     --enable-libvorbis \
     --enable-libvpx \
     --enable-libwebp \
+    --enable-libx264 \
     --enable-vaapi \
     --extra-cflags=-I/usr/local/cuda/include \
     --extra-ldflags=-L/usr/local/cuda/lib64 \

--- a/docker/common/install_ffmpeg.sh
+++ b/docker/common/install_ffmpeg.sh
@@ -43,7 +43,6 @@ apt-get install -y \
     libfreetype6-dev \
     libgnutls28-dev \
     libnuma-dev \
-    libopenh264-dev \
     libtool \
     libva-dev \
     libvorbis-dev \
@@ -72,7 +71,6 @@ PATH="/usr/local/cuda/bin:$PATH" ./configure \
     --enable-nonfree \
     --enable-cuda-nvcc \
     --enable-libnpp \
-    --enable-libopenh264 \
     --enable-libaom \
     --enable-libdav1d \
     --enable-libvorbis \

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -176,12 +176,7 @@ If encoders are missing, reinstall `FFmpeg` with the required options or use the
 
 ### Bring-Your-Own H.264 Software Encoder (Advanced)
 
-Curator's default FFmpeg build deliberately excludes software H.264 encoders (`libopenh264`, `libx264`, `libx265`) due to licensing constraints:
-
-- **`libx264` / `libx265`** are GPL-licensed. Linking them would require Curator's binary distribution to also be GPL.
-- **`libopenh264`** uses a BSD source license, but its production use depends on a Cisco-distributed patent-licensed binary, which is not compatible with all redistribution scenarios.
-
-If your environment permits these encoders and you want H.264 software encoding (for example, on GPUs without an NVENC encoder block such as A100 or H100), you can install them yourself.
+Curator's default FFmpeg build deliberately excludes software H.264 encoders (`libopenh264`, `libx264`, `libx265`). If your environment permits these encoders and you want H.264 software encoding (for example, on GPUs without an NVENC encoder block such as A100 or H100), you can install them yourself.
 
 #### Option 1: Use the system FFmpeg
 
@@ -219,9 +214,8 @@ python video_split_clip_example.py ... --transcode-encoder libopenh264
 
 #### Caveats
 
-- **Licensing is your responsibility.** Adding `libx264` (`--enable-gpl`) or `libopenh264` to your FFmpeg build may obligate you to additional license terms when you redistribute Curator.
 - **Default options for these encoders are not tuned.** `ClipTranscodingStage` only sets quality presets for `h264_nvenc` and `libvpx-vp9`. Other encoders run with FFmpeg defaults, which may produce different quality/size trade-offs than you expect — see [Configure encoders](../curate-video/process-data/transcoding.md#configure) for how to pass an explicit bitrate.
-- **NVIDIA does not test custom encoder configurations.** Issues filed against custom encoder builds may be closed.
+- **NeMo Curator team does not test custom encoder configurations.** Issues filed against custom encoder builds may be closed.
 
 ---
 

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -12,7 +12,7 @@ modality: "universal"
 
 # Installation Guide
 
-This guide covers installing NeMo Curator with support for **all modalities** and verifying your installation is working correctly.
+This guide covers installing NeMo Curator with support for **all modalities** and verifying that your installation is working correctly.
 
 ## Before You Start
 
@@ -28,7 +28,7 @@ For comprehensive system requirements and production deployment specifications, 
 - **GPU** (optional): NVIDIA GPU with 16GB+ VRAM for acceleration
 - **CUDA 12** (required for `audio_cuda12`, `video_cuda12`, `image_cuda12`, and `text_cuda12` extras)
 
-### Development vs Production
+### Development vs. Production
 
 | Use Case | Requirements | See |
 |----------|-------------|-----|
@@ -96,7 +96,7 @@ uv sync --all-extras --all-groups
 
 :::{tab-item} Container Installation (Recommended for Video/Audio)
 
-NeMo Curator is available as a standalone container on NGC: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-curator. The container includes NeMo Curator with all dependencies pre-installed, including FFmpeg with NVENC support.
+NeMo Curator is available as a standalone container on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo-curator). The container includes NeMo Curator with all dependencies pre-installed, including FFmpeg with NVENC support.
 
 ```bash
 # Pull the container from NGC
@@ -178,7 +178,7 @@ If encoders are missing, reinstall `FFmpeg` with the required options or use the
 
 Curator's default FFmpeg build deliberately excludes software H.264 encoders (`libopenh264`, `libx264`, `libx265`). If your environment permits these encoders and you want H.264 software encoding (for example, on GPUs without an NVENC encoder block such as A100 or H100), you can install them yourself.
 
-#### Option 1: Use the system FFmpeg
+#### Option 1: Use the System FFmpeg
 
 Most Linux distributions ship FFmpeg with `libx264` (and sometimes `libopenh264`) preinstalled:
 
@@ -189,7 +189,7 @@ ffmpeg -hide_banner -encoders | grep -E "libx264|libopenh264"
 
 Make sure the `ffmpeg` on your `PATH` is the one you want — it must shadow Curator's bundled build.
 
-#### Option 2: Add encoders to Curator's FFmpeg build
+#### Option 2: Add Encoders to Curator's FFmpeg Build
 
 Edit [`docker/common/install_ffmpeg.sh`](https://github.com/NVIDIA-NeMo/Curator/blob/main/docker/common/install_ffmpeg.sh) before rebuilding the container:
 
@@ -198,7 +198,7 @@ Edit [`docker/common/install_ffmpeg.sh`](https://github.com/NVIDIA-NeMo/Curator/
 
 Then rebuild your image.
 
-#### Use the encoder in `ClipTranscodingStage`
+#### Use the Encoder in `ClipTranscodingStage`
 
 `libopenh264` is accepted by `ClipTranscodingStage` out of the box. At setup time, the stage probes the local FFmpeg build and raises a clear error pointing back to this section if the encoder is not actually compiled in. Once your FFmpeg build includes it, just pass:
 
@@ -215,7 +215,7 @@ SUPPORTED_ENCODERS = ("h264_nvenc", "libvpx-vp9", "libopenh264", "libx264")  # a
 #### Caveats
 
 - **Default options for these encoders are not tuned.** `ClipTranscodingStage` only sets quality presets for `h264_nvenc` and `libvpx-vp9`. Other encoders run with FFmpeg defaults, which may produce different quality/size trade-offs than you expect — see [Configure encoders](../curate-video/process-data/transcoding.md#configure) for how to pass an explicit bitrate.
-- **NeMo Curator team does not test custom encoder configurations.** Issues filed against custom encoder builds may be closed.
+- **The NeMo Curator team does not test custom encoder configurations.** Issues filed against custom encoder builds may be closed.
 
 ---
 
@@ -241,7 +241,7 @@ NeMo Curator provides several installation extras to install only the components
   - CPU-only audio curation with NeMo Toolkit ASR
 * - **audio_cuda12**
   - `uv pip install nemo-curator[audio_cuda12]`
-  - GPU-accelerated audio curation. When using `uv`, requires `transformers==4.55.2` override.
+  - GPU-accelerated audio curation. When using `uv`, requires a `transformers==4.55.2` override.
 * - **image_cpu**
   - `uv pip install nemo-curator[image_cpu]`
   - CPU-only image processing
@@ -262,11 +262,11 @@ NeMo Curator provides several installation extras to install only the components
 
 ---
 
-## Installation Verification
+## Verify Your Installation
 
 After installation, verify that NeMo Curator is working correctly:
 
-### 1. Basic Import Test
+### 1. Test Basic Imports
 
 ```python
 # Test basic imports
@@ -279,7 +279,7 @@ from nemo_curator.tasks import DocumentBatch
 print("✓ Core modules imported successfully")
 ```
 
-### 2. GPU Availability Check
+### 2. Check GPU Availability
 
 If you installed GPU support, verify GPU access:
 

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -138,13 +138,13 @@ docker run --gpus all -it --rm nemo-curator:latest
 
 ### Install FFmpeg and Encoders (Required for Video)
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libopenh264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libx264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
 
 ::::{tab-set}
 
 :::{tab-item} Debian/Ubuntu (Script)
 
-Use the maintained script in the repository to build and install `FFmpeg` with `libopenh264` and NVIDIA NVENC support. The script enables `--enable-libopenh264`, `--enable-cuda-nvcc`, and `--enable-libnpp`.
+Use the maintained script in the repository to build and install `FFmpeg` with NVIDIA NVENC support. The script enables `--enable-cuda-nvcc` and `--enable-libnpp`.
 
 - Script source: [docker/common/install_ffmpeg.sh](https://github.com/NVIDIA-NeMo/Curator/blob/main/docker/common/install_ffmpeg.sh)
 
@@ -162,7 +162,7 @@ Confirm that `FFmpeg` is on your `PATH` and that at least one H.264 encoder is a
 
 ```bash
 ffmpeg -hide_banner -version | head -n 5
-ffmpeg -encoders | grep -E "h264_nvenc|libopenh264|libx264" | cat
+ffmpeg -encoders | grep -E "h264_nvenc|libx264" | cat
 ```
 
 If encoders are missing, reinstall `FFmpeg` with the required options or use the Debian/Ubuntu script above.

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -198,18 +198,18 @@ Edit [`docker/common/install_ffmpeg.sh`](https://github.com/NVIDIA-NeMo/Curator/
 
 Then rebuild your image.
 
-#### Allow the encoder in `ClipTranscodingStage`
+#### Use the encoder in `ClipTranscodingStage`
 
-The stage validator only accepts the encoders Curator ships with by default. To allow a custom encoder, edit `nemo_curator/stages/video/clipping/clip_extraction_stages.py`:
-
-```python
-SUPPORTED_ENCODERS = ("h264_nvenc", "libvpx-vp9", "libopenh264")  # add yours
-```
-
-If you use `tutorials/video/getting-started/video_split_clip_example.py`, also extend its argparse `choices` list, or invoke `ClipTranscodingStage` directly from your own Python script.
+`libopenh264` is accepted by `ClipTranscodingStage` out of the box. At setup time, the stage probes the local FFmpeg build and raises a clear error pointing back to this section if the encoder is not actually compiled in. Once your FFmpeg build includes it, just pass:
 
 ```bash
 python video_split_clip_example.py ... --transcode-encoder libopenh264
+```
+
+For other custom encoders not in `SUPPORTED_ENCODERS` (for example, `libx264`), edit `nemo_curator/stages/video/clipping/clip_extraction_stages.py` to extend the tuple, and add the encoder name to the `--transcode-encoder` argparse `choices` list in `tutorials/video/getting-started/video_split_clip_example.py`:
+
+```python
+SUPPORTED_ENCODERS = ("h264_nvenc", "libvpx-vp9", "libopenh264", "libx264")  # add yours
 ```
 
 #### Caveats

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -138,7 +138,7 @@ docker run --gpus all -it --rm nemo-curator:latest
 
 ### Install FFmpeg and Encoders (Required for Video)
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libx264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (using `--transcode-encoder h264_nvenc`), install `FFmpeg` with NVENC support.
 
 ::::{tab-set}
 
@@ -162,7 +162,7 @@ Confirm that `FFmpeg` is on your `PATH` and that at least one H.264 encoder is a
 
 ```bash
 ffmpeg -hide_banner -version | head -n 5
-ffmpeg -encoders | grep -E "h264_nvenc|libx264" | cat
+ffmpeg -encoders | grep h264_nvenc | cat
 ```
 
 If encoders are missing, reinstall `FFmpeg` with the required options or use the Debian/Ubuntu script above.

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -144,7 +144,7 @@ Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you p
 
 :::{tab-item} Debian/Ubuntu (Script)
 
-Use the maintained script in the repository to build and install `FFmpeg` with NVIDIA NVENC support. The script enables `--enable-cuda-nvcc` and `--enable-libnpp`.
+Use the maintained script in the repository to build and install `FFmpeg` with NVIDIA NVENC support. The script enables `--enable-cuda-nvcc`, `--enable-libnpp`, and `--enable-libvpx`.
 
 - Script source: [docker/common/install_ffmpeg.sh](https://github.com/NVIDIA-NeMo/Curator/blob/main/docker/common/install_ffmpeg.sh)
 

--- a/docs/admin/installation.md
+++ b/docs/admin/installation.md
@@ -138,7 +138,7 @@ docker run --gpus all -it --rm nemo-curator:latest
 
 ### Install FFmpeg and Encoders (Required for Video)
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (using `--transcode-encoder h264_nvenc`), install `FFmpeg` with NVENC support.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (using `--transcode-encoder h264_nvenc` or `--transcode-encoder libvpx-vp9`), install `FFmpeg` with NVENC and libvpx-vp9 support. The maintained install script bundles both.
 
 ::::{tab-set}
 
@@ -158,11 +158,11 @@ sudo bash install_ffmpeg.sh
 
 :::{tab-item} Verify Installation
 
-Confirm that `FFmpeg` is on your `PATH` and that at least one H.264 encoder is available:
+Confirm that `FFmpeg` is on your `PATH` and that at least one supported encoder is available:
 
 ```bash
 ffmpeg -hide_banner -version | head -n 5
-ffmpeg -encoders | grep h264_nvenc | cat
+ffmpeg -encoders | grep -E "h264_nvenc|libvpx-vp9" | cat
 ```
 
 If encoders are missing, reinstall `FFmpeg` with the required options or use the Debian/Ubuntu script above.
@@ -173,6 +173,55 @@ If encoders are missing, reinstall `FFmpeg` with the required options or use the
 ```{note}
 **FFmpeg build requires CUDA toolkit (nvcc):** If you encounter `ERROR: failed checking for nvcc` during FFmpeg installation, ensure that the CUDA toolkit is installed and `nvcc` is available on your `PATH`. You can verify with `nvcc --version`. If using the NeMo Curator container, FFmpeg is pre-installed with NVENC support.
 ```
+
+### Bring-Your-Own H.264 Software Encoder (Advanced)
+
+Curator's default FFmpeg build deliberately excludes software H.264 encoders (`libopenh264`, `libx264`, `libx265`) due to licensing constraints:
+
+- **`libx264` / `libx265`** are GPL-licensed. Linking them would require Curator's binary distribution to also be GPL.
+- **`libopenh264`** uses a BSD source license, but its production use depends on a Cisco-distributed patent-licensed binary, which is not compatible with all redistribution scenarios.
+
+If your environment permits these encoders and you want H.264 software encoding (for example, on GPUs without an NVENC encoder block such as A100 or H100), you can install them yourself.
+
+#### Option 1: Use the system FFmpeg
+
+Most Linux distributions ship FFmpeg with `libx264` (and sometimes `libopenh264`) preinstalled:
+
+```bash
+sudo apt-get install -y ffmpeg
+ffmpeg -hide_banner -encoders | grep -E "libx264|libopenh264"
+```
+
+Make sure the `ffmpeg` on your `PATH` is the one you want — it must shadow Curator's bundled build.
+
+#### Option 2: Add encoders to Curator's FFmpeg build
+
+Edit [`docker/common/install_ffmpeg.sh`](https://github.com/NVIDIA-NeMo/Curator/blob/main/docker/common/install_ffmpeg.sh) before rebuilding the container:
+
+- For `libopenh264`: add `libopenh264-dev` to the apt list and `--enable-libopenh264` to the configure flags.
+- For `libx264`: add `libx264-dev` to the apt list and `--enable-libx264 --enable-gpl` to the configure flags. Note that `--enable-gpl` makes the resulting FFmpeg binary GPL-licensed.
+
+Then rebuild your image.
+
+#### Allow the encoder in `ClipTranscodingStage`
+
+The stage validator only accepts the encoders Curator ships with by default. To allow a custom encoder, edit `nemo_curator/stages/video/clipping/clip_extraction_stages.py`:
+
+```python
+SUPPORTED_ENCODERS = ("h264_nvenc", "libvpx-vp9", "libopenh264")  # add yours
+```
+
+If you use `tutorials/video/getting-started/video_split_clip_example.py`, also extend its argparse `choices` list, or invoke `ClipTranscodingStage` directly from your own Python script.
+
+```bash
+python video_split_clip_example.py ... --transcode-encoder libopenh264
+```
+
+#### Caveats
+
+- **Licensing is your responsibility.** Adding `libx264` (`--enable-gpl`) or `libopenh264` to your FFmpeg build may obligate you to additional license terms when you redistribute Curator.
+- **Default options for these encoders are not tuned.** `ClipTranscodingStage` only sets quality presets for `h264_nvenc` and `libvpx-vp9`. Other encoders run with FFmpeg defaults, which may produce different quality/size trade-offs than you expect — see [Configure encoders](../curate-video/process-data/transcoding.md#configure) for how to pass an explicit bitrate.
+- **NVIDIA does not test custom encoder configurations.** Issues filed against custom encoder builds may be closed.
 
 ---
 
@@ -249,7 +298,7 @@ try:
         print(f"✓ GPU memory: {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB")
     else:
         print("⚠ No GPU detected")
-    
+
     # Check cuDF for GPU deduplication
     import cudf
     print("✓ cuDF available for GPU-accelerated deduplication")

--- a/docs/curate-video/index.md
+++ b/docs/curate-video/index.md
@@ -121,7 +121,6 @@ Encode clips to H.264 using CPU or GPU encoders and tune performance.
 +++
 {bdg-primary}`clips`
 {bdg-secondary}`h264_nvenc`
-{bdg-secondary}`libopenh264`
 {bdg-secondary}`libx264`
 :::
 

--- a/docs/curate-video/index.md
+++ b/docs/curate-video/index.md
@@ -48,7 +48,7 @@ Get oriented and prepare your environment so you can start curating videos with 
 :::{grid-item-card} {octicon}`database;1.5em;sd-mr-1` Concepts
 :link: about-concepts-video
 :link-type: ref
-Learn about the architecture, stages, pipelines, and data flow for video curation
+Learn about the architecture, stages, pipelines, and data flow for video curation.
 +++
 {bdg-secondary}`stages`
 {bdg-secondary}`pipelines`

--- a/docs/curate-video/index.md
+++ b/docs/curate-video/index.md
@@ -121,7 +121,6 @@ Encode clips to H.264 using CPU or GPU encoders and tune performance.
 +++
 {bdg-primary}`clips`
 {bdg-secondary}`h264_nvenc`
-{bdg-secondary}`libx264`
 :::
 
 :::{grid-item-card} {octicon}`filter;1.5em;sd-mr-1` Filter Clips and Frames

--- a/docs/curate-video/process-data/index.md
+++ b/docs/curate-video/process-data/index.md
@@ -42,7 +42,6 @@ Encode clips to H.264 using CPU or GPU encoders and tune performance.
 +++
 {bdg-primary}`clips`
 {bdg-secondary}`h264_nvenc`
-{bdg-secondary}`libx264`
 :::
 
 :::{grid-item-card} {octicon}`filter;1.5em;sd-mr-1` Filter Clips and Frames

--- a/docs/curate-video/process-data/index.md
+++ b/docs/curate-video/process-data/index.md
@@ -42,7 +42,7 @@ Encode clips to H.264 using CPU or GPU encoders and tune performance.
 +++
 {bdg-primary}`clips`
 {bdg-secondary}`h264_nvenc`
-{bdg-secondary}`libopenh264`
+{bdg-secondary}`libx264`
 :::
 
 :::{grid-item-card} {octicon}`filter;1.5em;sd-mr-1` Filter Clips and Frames

--- a/docs/curate-video/process-data/index.md
+++ b/docs/curate-video/process-data/index.md
@@ -14,7 +14,7 @@ modality: "video-only"
 
 Use NeMo Curator stages to split videos into clips, encode them, generate embeddings or captions, and remove duplicates.
 
-## How it Works
+## How It Works
 
 Create a `Pipeline` and add stages for clip extraction, optional re-encoding and filtering, embeddings or captions, previews, and writing outputs. Each stage is modular and configurable to match your quality and performance needs.
 
@@ -88,7 +88,7 @@ Produce clip captions and optional preview images for review workflows.
 :::{grid-item-card} {octicon}`git-branch;1.5em;sd-mr-1` Remove Duplicate Embeddings
 :link: video-process-dedup
 :link-type: ref
-Remove near-duplicates using semantic clustering and similarity with generated embeddings.
+Remove near-duplicates using semantic clustering and pairwise similarity of generated embeddings.
 +++
 {bdg-primary}`clips`
 {bdg-secondary}`semantic`

--- a/docs/curate-video/process-data/transcoding.md
+++ b/docs/curate-video/process-data/transcoding.md
@@ -72,7 +72,10 @@ python -m ray_curator.examples.video.video_split_clip_example \
   - Uses NVENC for high-throughput H.264 encoding on NVIDIA GPU hardware.
 * - `libvpx-vp9`
   - CPU
-  - VP9 software encoder. Use as a fallback on GPUs without NVENC silicon (e.g. A100/H100). Slower than NVENC; produces VP9 in `.mp4`.
+  - VP9 software encoder. Use as a fallback on GPUs without NVENC silicon (e.g. A100/H100). Slower than NVENC; produces VP9 in `.mp4`. Emits a one-time perf advisory at construction.
+* - `libopenh264`
+  - CPU
+  - H.264 software encoder. **Not bundled with Curator's FFmpeg build** — accepted only when a user-installed FFmpeg provides it. The stage probes at setup time and raises with a docs link if missing. See [Bring-Your-Own H.264 Software Encoder](../../admin/installation.md#bring-your-own-h264-software-encoder-advanced).
 ```
 
 ```{tip}
@@ -122,9 +125,9 @@ transcode = ClipTranscodingStage(
 * - Parameter
   - Description
 * - `encoder`
-  - Selects the encoding backend. Supported values are `h264_nvenc` (GPU, requires NVENC) and `libvpx-vp9` (CPU fallback for non-NVENC GPUs such as A100/H100).
+  - Selects the encoding backend. Supported values: `h264_nvenc` (GPU, requires NVENC), `libvpx-vp9` (CPU fallback for non-NVENC GPUs such as A100/H100), and `libopenh264` (CPU, requires user-installed FFmpeg — see [BYO H.264](../../admin/installation.md#bring-your-own-h264-software-encoder-advanced)).
 * - `use_hwaccel`
-  - Enable when using `h264_nvenc`. Not valid with `libvpx-vp9`.
+  - Enable when using `h264_nvenc`. Not valid with `libvpx-vp9` or `libopenh264`.
 * - `encoder_threads`
   - CPU threads per worker for CPU encoders. Increase to use more CPU.
 * - `encode_batch_size`

--- a/docs/curate-video/process-data/transcoding.md
+++ b/docs/curate-video/process-data/transcoding.md
@@ -41,7 +41,7 @@ from nemo_curator.stages.video.clipping.clip_extraction_stages import FixedStrid
 
 pipe = Pipeline(name="transcode_example")
 pipe.add_stage(FixedStrideExtractorStage(clip_len_s=10.0, clip_stride_s=10.0))
-pipe.add_stage(ClipTranscodingStage(encoder="libx264", encode_batch_size=16, encoder_threads=1, verbose=True))
+pipe.add_stage(ClipTranscodingStage(encoder="h264_nvenc", encode_batch_size=16, encoder_threads=1, verbose=True))
 pipe.run()
 ```
 
@@ -67,9 +67,6 @@ python -m ray_curator.examples.video.video_split_clip_example \
 * - Encoder
   - Hardware
   - Description
-* - `libx264`
-  - CPU
-  - Widely available, high quality, CPU-based.
 * - `h264_nvenc`
   - NVIDIA GPU (NVENC)
   - Uses NVENC for high-throughput H.264 encoding on NVIDIA GPU hardware.
@@ -99,7 +96,7 @@ Use `ClipTranscodingStage` to control encoder choice, batching, and acceleration
 from nemo_curator.stages.video.clipping.clip_extraction_stages import ClipTranscodingStage
 
 transcode = ClipTranscodingStage(
-    encoder="h264_nvenc",        # or "libx264"
+    encoder="h264_nvenc",
     use_hwaccel=True,             # enable NVENC when using h264_nvenc
     encoder_threads=1,            # CPU thread count for CPU encoders
     encode_batch_size=16,         # number of clips per encode batch
@@ -118,7 +115,7 @@ transcode = ClipTranscodingStage(
 * - Parameter
   - Description
 * - `encoder`
-  - Selects the encoding backend. Recommended defaults: `libx264` (CPU) or `h264_nvenc` (GPU).
+  - Selects the encoding backend. Currently only `h264_nvenc` (GPU) is supported.
 * - `use_hwaccel`
   - Enable when using GPU encoders like `h264_nvenc`.
 * - `encoder_threads`

--- a/docs/curate-video/process-data/transcoding.md
+++ b/docs/curate-video/process-data/transcoding.md
@@ -70,10 +70,17 @@ python -m ray_curator.examples.video.video_split_clip_example \
 * - `h264_nvenc`
   - NVIDIA GPU (NVENC)
   - Uses NVENC for high-throughput H.264 encoding on NVIDIA GPU hardware.
+* - `libvpx-vp9`
+  - CPU
+  - VP9 software encoder. Use as a fallback on GPUs without NVENC silicon (e.g. A100/H100). Slower than NVENC; produces VP9 in `.mp4`.
 ```
 
 ```{tip}
-On systems with supported NVIDIA GPU hardware and an `ffmpeg` build with NVENC, `h264_nvenc` can significantly increase throughput. Refer to the verification steps below to confirm NVENC availability.
+On systems with supported NVIDIA GPU hardware and an `ffmpeg` build with NVENC, `h264_nvenc` can significantly increase throughput. Refer to the verification steps below to confirm NVENC availability. On GPUs without an NVENC encoder block (such as A100 and H100), use `libvpx-vp9` instead — it runs entirely on CPU and has no proprietary licensing constraints.
+```
+
+```{note}
+**Need software H.264 (libopenh264 / libx264)?** Curator's default FFmpeg build excludes them for licensing reasons. See [Bring-Your-Own H.264 Software Encoder](../../admin/installation.md#bring-your-own-h264-software-encoder-advanced) for how to enable them yourself.
 ```
 
 ### Verify `ffmpeg`/NVENC Support
@@ -115,9 +122,9 @@ transcode = ClipTranscodingStage(
 * - Parameter
   - Description
 * - `encoder`
-  - Selects the encoding backend. Currently only `h264_nvenc` (GPU) is supported.
+  - Selects the encoding backend. Supported values are `h264_nvenc` (GPU, requires NVENC) and `libvpx-vp9` (CPU fallback for non-NVENC GPUs such as A100/H100).
 * - `use_hwaccel`
-  - Enable when using GPU encoders like `h264_nvenc`.
+  - Enable when using `h264_nvenc`. Not valid with `libvpx-vp9`.
 * - `encoder_threads`
   - CPU threads per worker for CPU encoders. Increase to use more CPU.
 * - `encode_batch_size`

--- a/docs/curate-video/process-data/transcoding.md
+++ b/docs/curate-video/process-data/transcoding.md
@@ -41,7 +41,7 @@ from nemo_curator.stages.video.clipping.clip_extraction_stages import FixedStrid
 
 pipe = Pipeline(name="transcode_example")
 pipe.add_stage(FixedStrideExtractorStage(clip_len_s=10.0, clip_stride_s=10.0))
-pipe.add_stage(ClipTranscodingStage(encoder="libopenh264", encode_batch_size=16, encoder_threads=1, verbose=True))
+pipe.add_stage(ClipTranscodingStage(encoder="libx264", encode_batch_size=16, encoder_threads=1, verbose=True))
 pipe.run()
 ```
 
@@ -70,9 +70,6 @@ python -m ray_curator.examples.video.video_split_clip_example \
 * - `libx264`
   - CPU
   - Widely available, high quality, CPU-based.
-* - `libopenh264`
-  - CPU
-  - Good quality and throughput balance. Often faster than `libx264` at similar presets.
 * - `h264_nvenc`
   - NVIDIA GPU (NVENC)
   - Uses NVENC for high-throughput H.264 encoding on NVIDIA GPU hardware.
@@ -102,7 +99,7 @@ Use `ClipTranscodingStage` to control encoder choice, batching, and acceleration
 from nemo_curator.stages.video.clipping.clip_extraction_stages import ClipTranscodingStage
 
 transcode = ClipTranscodingStage(
-    encoder="h264_nvenc",        # or "libopenh264", "libx264"
+    encoder="h264_nvenc",        # or "libx264"
     use_hwaccel=True,             # enable NVENC when using h264_nvenc
     encoder_threads=1,            # CPU thread count for CPU encoders
     encode_batch_size=16,         # number of clips per encode batch
@@ -121,7 +118,7 @@ transcode = ClipTranscodingStage(
 * - Parameter
   - Description
 * - `encoder`
-  - Selects the encoding backend. Recommended defaults: `libopenh264` (CPU) or `h264_nvenc` (GPU).
+  - Selects the encoding backend. Recommended defaults: `libx264` (CPU) or `h264_nvenc` (GPU).
 * - `use_hwaccel`
   - Enable when using GPU encoders like `h264_nvenc`.
 * - `encoder_threads`

--- a/docs/curate-video/process-data/transcoding.md
+++ b/docs/curate-video/process-data/transcoding.md
@@ -53,7 +53,7 @@ pipe.run()
 python -m ray_curator.examples.video.video_split_clip_example \
   ...
   --transcode-encoder h264_nvenc \
-  --transcode-use-hwaccel \
+  --transcode-use-hwaccel
 ```
 
 :::
@@ -72,7 +72,7 @@ python -m ray_curator.examples.video.video_split_clip_example \
   - Uses NVENC for high-throughput H.264 encoding on NVIDIA GPU hardware.
 * - `libvpx-vp9`
   - CPU
-  - VP9 software encoder. Use as a fallback on GPUs without NVENC silicon (e.g. A100/H100). Slower than NVENC; produces VP9 in `.mp4`. Emits a one-time perf advisory at construction.
+  - - VP9 software encoder. Use as a fallback on GPUs without NVENC silicon (e.g., A100/H100). Slower than NVENC; produces VP9 in `.mp4`. Emits a one-time performance advisory at construction.
 * - `libopenh264`
   - CPU
   - H.264 software encoder. **Not bundled with Curator's FFmpeg build** — accepted only when a user-installed FFmpeg provides it. The stage probes at setup time and raises with a docs link if missing. See [Bring-Your-Own H.264 Software Encoder](../../admin/installation.md#bring-your-own-h264-software-encoder-advanced).

--- a/docs/curate-video/tutorials/beginner.md
+++ b/docs/curate-video/tutorials/beginner.md
@@ -46,7 +46,7 @@ flowchart LR
 - **Data units**: Input videos → clip windows → frames → embeddings + files.
 - **Common choices**:
   - **Splitting**: fixed stride vs. scene-change (TransNetV2)
-  - **Encoding**: `libopenh264`, `h264_nvenc`, or `libx264`
+  - **Encoding**: `h264_nvenc` or `libx264`
   - **Embeddings**: Cosmos-Embed1
 - **Outputs**: Clips (mp4), previews (optional), and parquet embeddings for downstream tasks (such as semantic duplicate removal).
 
@@ -158,7 +158,7 @@ Convert clip buffers to H.264 using the selected encoder and settings. Refer to 
 pipeline.add_stage(
     ClipTranscodingStage(
         num_cpus_per_worker=6.0,
-        encoder="libopenh264",
+        encoder="libx264",
         encoder_threads=1,
         encode_batch_size=16,
         use_hwaccel=False,

--- a/docs/curate-video/tutorials/beginner.md
+++ b/docs/curate-video/tutorials/beginner.md
@@ -46,7 +46,7 @@ flowchart LR
 - **Data units**: Input videos → clip windows → frames → embeddings + files.
 - **Common choices**:
   - **Splitting**: fixed stride vs. scene-change (TransNetV2)
-  - **Encoding**: `h264_nvenc`
+  - **Encoding**: `h264_nvenc` (NVENC-equipped GPU) or `libvpx-vp9` (CPU fallback for non-NVENC GPUs such as A100/H100)
   - **Embeddings**: Cosmos-Embed1
 - **Outputs**: Clips (mp4), previews (optional), and parquet embeddings for downstream tasks (such as semantic duplicate removal).
 
@@ -152,13 +152,13 @@ pipeline.add_stage(
 
 ### Encode Clips
 
-Convert clip buffers to H.264 using the selected encoder and settings. Refer to [Clip Encoding](video-process-transcoding) for encoder choices and NVENC setup.
+Convert clip buffers using the selected encoder and settings. Choose `h264_nvenc` on NVENC-equipped GPUs or `libvpx-vp9` (CPU) on GPUs without NVENC such as A100/H100. Refer to [Clip Encoding](video-process-transcoding) for encoder details and NVENC setup.
 
 ```python
 pipeline.add_stage(
     ClipTranscodingStage(
         num_cpus_per_worker=6.0,
-        encoder="h264_nvenc",
+        encoder="h264_nvenc",  # or "libvpx-vp9" for non-NVENC GPUs
         encoder_threads=1,
         encode_batch_size=16,
         use_hwaccel=False,

--- a/docs/curate-video/tutorials/beginner.md
+++ b/docs/curate-video/tutorials/beginner.md
@@ -161,7 +161,7 @@ pipeline.add_stage(
         encoder="h264_nvenc",  # or "libvpx-vp9" for non-NVENC GPUs
         encoder_threads=1,
         encode_batch_size=16,
-        use_hwaccel=False,
+        use_hwaccel=True,
         use_input_bit_rate=False,
         num_clips_per_chunk=32,
         verbose=True,

--- a/docs/curate-video/tutorials/beginner.md
+++ b/docs/curate-video/tutorials/beginner.md
@@ -109,7 +109,7 @@ pipeline.add_stage(
 
 ::::{tab-set}
 
-:::{tab-item} Fixed stride
+:::{tab-item} Fixed Stride
 
 ```python
 pipeline.add_stage(
@@ -124,7 +124,7 @@ pipeline.add_stage(
 
 :::
 
-:::{tab-item} TransNetV2 (scene change)
+:::{tab-item} TransNetV2 (Scene Change)
 
 ```python
 from nemo_curator.stages.video.clipping.video_frame_extraction import VideoFrameExtractionStage

--- a/docs/curate-video/tutorials/beginner.md
+++ b/docs/curate-video/tutorials/beginner.md
@@ -46,7 +46,7 @@ flowchart LR
 - **Data units**: Input videos → clip windows → frames → embeddings + files.
 - **Common choices**:
   - **Splitting**: fixed stride vs. scene-change (TransNetV2)
-  - **Encoding**: `h264_nvenc` or `libx264`
+  - **Encoding**: `h264_nvenc`
   - **Embeddings**: Cosmos-Embed1
 - **Outputs**: Clips (mp4), previews (optional), and parquet embeddings for downstream tasks (such as semantic duplicate removal).
 
@@ -158,7 +158,7 @@ Convert clip buffers to H.264 using the selected encoder and settings. Refer to 
 pipeline.add_stage(
     ClipTranscodingStage(
         num_cpus_per_worker=6.0,
-        encoder="libx264",
+        encoder="h264_nvenc",
         encoder_threads=1,
         encode_batch_size=16,
         use_hwaccel=False,

--- a/docs/curate-video/tutorials/split-dedup.md
+++ b/docs/curate-video/tutorials/split-dedup.md
@@ -22,7 +22,7 @@ Learn how to run the splitting pipeline to generate clips and embeddings, then r
 
 ## Before You Start
 
-- Complete the [Get Started guide](gs-video).
+- Complete the {ref}`Get Started with Video Curation <gs-video>` guide.
 
 ---
 
@@ -60,7 +60,7 @@ The pipeline writes embeddings to Parquet with two columns:
 
 ::::{tab-set}
 
-:::{tab-item} Directory layout
+:::{tab-item} Directory Layout
 
 ```text
 $OUT_DIR/
@@ -80,7 +80,7 @@ embedding: list<float32>  # length = 768 for Cosmos-Embed1
 
 :::
 
-:::{tab-item} Sample row
+:::{tab-item} Sample Row
 
 ```json
 {"id": "a3f2b0c1-7d64-4a1e-9f2b-8b0f6d1e2c33", "embedding": [0.0123, -0.0456, 0.0031, 0.1279]}
@@ -88,7 +88,7 @@ embedding: list<float32>  # length = 768 for Cosmos-Embed1
 
 :::
 
-:::{tab-item} Read example
+:::{tab-item} Read Example
 
 ```python
 import pyarrow.parquet as pq
@@ -149,9 +149,9 @@ pipe.add_stage(
 pipe.run()
 ```
 
-`which_to_keep` selects the representative within each cluster: "hard" keeps outliers far from the centroid, "easy" keeps the nearest to the centroid, and "random" ignores distance and picks randomly.
+`which_to_keep` selects the representative within each cluster: `hard` keeps outliers far from the centroid, `easy` keeps the nearest to the centroid, and `random` ignores distance and picks randomly.
 
-`sim_metric` sets the distance used for similarity: "cosine" uses cosine distance (1 − cosine similarity), while "l2" uses Euclidean distance.
+`sim_metric` sets the distance used for similarity: `cosine` uses cosine distance (1 − cosine similarity), while `l2` uses Euclidean distance.
 
 `pairwise_batch_size` controls how many items are processed per GPU batch during pairwise similarity; larger values can be faster but require more GPU memory.
 

--- a/docs/curate-video/tutorials/split-dedup.md
+++ b/docs/curate-video/tutorials/split-dedup.md
@@ -38,7 +38,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
   --splitting-algorithm fixed_stride \
   --fixed-stride-split-duration 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libx264 \
+  --transcode-encoder h264_nvenc \
   --verbose
 ```
 

--- a/docs/curate-video/tutorials/split-dedup.md
+++ b/docs/curate-video/tutorials/split-dedup.md
@@ -38,7 +38,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
   --splitting-algorithm fixed_stride \
   --fixed-stride-split-duration 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libopenh264 \
+  --transcode-encoder libx264 \
   --verbose
 ```
 

--- a/docs/get-started/video.md
+++ b/docs/get-started/video.md
@@ -122,13 +122,13 @@ For details on container environments and configurations, see [Container Environ
 
 ## Install FFmpeg and Encoders
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (using `--transcode-encoder h264_nvenc` or `--transcode-encoder libvpx-vp9`), install `FFmpeg` with NVENC and libvpx-vp9 support. The maintained install script bundles both.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (using `--transcode-encoder h264_nvenc` or `--transcode-encoder libvpx-vp9`), install `FFmpeg` with NVENC and `libvpx-vp9` support. The maintained install script bundles both.
 
 ::::{tab-set}
 
 :::{tab-item} Debian/Ubuntu (Script)
 
-Use the maintained script in the repository to build and install `FFmpeg` with NVIDIA NVENC and libvpx-vp9 support. The script enables `--enable-cuda-nvcc`, `--enable-libnpp`, and `--enable-libvpx`.
+Use the maintained script in the repository to build and install `FFmpeg` with NVIDIA NVENC and `libvpx-vp9` support. The script enables `--enable-cuda-nvcc`, `--enable-libnpp`, and `--enable-libvpx`.
 
 - Script source: [docker/common/install_ffmpeg.sh](https://github.com/NVIDIA-NeMo/Curator/blob/main/docker/common/install_ffmpeg.sh)
 
@@ -158,7 +158,6 @@ If encoders are missing, reinstall `FFmpeg` with the required options or use the
 Refer to [Clip Encoding](video-process-transcoding) to choose encoders and verify NVENC support on your system.
 
 ### Available Models
-
 
 Embeddings convert each video clip into a numeric vector that captures visual and semantic content. Curator uses these vectors to:
 
@@ -221,7 +220,7 @@ Organize input videos and output locations before running the pipeline.
 
 ## Run the Splitting Pipeline Example
 
-Use the example script from https://github.com/NVIDIA-NeMo/Curator/tree/main/tutorials/video/getting-started to read videos, split into clips, and write outputs. This runs a Ray pipeline with `XennaExecutor` under the hood.
+Use the [example script](https://github.com/NVIDIA-NeMo/Curator/tree/main/tutorials/video/getting-started) to read videos, split into clips, and write outputs. This runs a Ray pipeline with `XennaExecutor` under the hood.
 
 ```bash
 python tutorials/video/getting-started/video_split_clip_example.py \
@@ -273,7 +272,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 | `--generate-previews` | Flag | Create preview images for each clip |
 | `--verbose` | Flag | Enable detailed logging output |
 
-### Understanding Pipeline Output
+### Understand Pipeline Output
 
 After successful execution, the output directory will contain:
 

--- a/docs/get-started/video.md
+++ b/docs/get-started/video.md
@@ -58,8 +58,9 @@ To use NeMo Curator's video curation capabilities, ensure your system meets thes
   - Reduced configuration (lower batch sizes, FP8): ~21GB VRAM
 
 #### Software Dependencies
-* **FFmpeg 8.0+** with H.264 encoding support
-  - GPU encoder: `h264_nvenc` (recommended for performance)
+* **FFmpeg 8.0+** with one of the following encoders:
+  - GPU encoder: `h264_nvenc` (recommended for performance; requires an NVENC-equipped GPU — note that A100 and H100 do **not** include NVENC)
+  - CPU encoder: `libvpx-vp9` (royalty-free fallback for non-NVENC GPUs; produces VP9 in `.mp4`)
 
 :::{tip}
 If `uv` is not installed, refer to the [Installation Guide](../admin/installation.md) for setup instructions, or install it quickly with:
@@ -121,7 +122,7 @@ For details on container environments and configurations, see [Container Environ
 
 ## Install FFmpeg and Encoders
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (using `--transcode-encoder h264_nvenc`), install `FFmpeg` with NVENC support.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (using `--transcode-encoder h264_nvenc` or `--transcode-encoder libvpx-vp9`), install `FFmpeg` with NVENC and libvpx-vp9 support. The maintained install script bundles both.
 
 ::::{tab-set}
 
@@ -145,7 +146,7 @@ Confirm that `FFmpeg` is on your `PATH` and that at least one H.264 encoder is a
 
 ```bash
 ffmpeg -hide_banner -version | head -n 5
-ffmpeg -encoders | grep h264_nvenc | cat
+ffmpeg -encoders | grep -E "h264_nvenc|libvpx-vp9" | cat
 ```
 
 If encoders are missing, reinstall `FFmpeg` with the required options or use the Debian/Ubuntu script above.
@@ -250,7 +251,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
     --fixed-stride-split-duration 10.0
     --embedding-algorithm cosmos-embed1-224p
     --transcode-encoder h264_nvenc' > my_config.txt
-    
+
     python tutorials/video/getting-started/video_split_clip_example.py @my_config.txt
 ```
 
@@ -265,8 +266,8 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 | **Embedding** |
 | `--embedding-algorithm` | `cosmos-embed1-224p`, `cosmos-embed1-336p`, `cosmos-embed1-448p` | Embedding model to use |
 | **Encoding** |
-| `--transcode-encoder` | `h264_nvenc` | Video encoder for output clips |
-| `--transcode-use-hwaccel` | Flag | Enable hardware acceleration for encoding |
+| `--transcode-encoder` | `h264_nvenc`, `libvpx-vp9` | Video encoder for output clips. Use `libvpx-vp9` (CPU) on GPUs without NVENC such as A100/H100. |
+| `--transcode-use-hwaccel` | Flag | Enable hardware acceleration for encoding (only valid with `h264_nvenc`). |
 | **Optional Features** |
 | `--generate-captions` | Flag | Generate text captions for each clip |
 | `--generate-previews` | Flag | Create preview images for each clip |

--- a/docs/get-started/video.md
+++ b/docs/get-started/video.md
@@ -128,7 +128,7 @@ Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you p
 
 :::{tab-item} Debian/Ubuntu (Script)
 
-Use the maintained script in the repository to build and install `FFmpeg` with NVIDIA NVENC support. The script enables `--enable-cuda-nvcc` and `--enable-libnpp`.
+Use the maintained script in the repository to build and install `FFmpeg` with NVIDIA NVENC and libvpx-vp9 support. The script enables `--enable-cuda-nvcc`, `--enable-libnpp`, and `--enable-libvpx`.
 
 - Script source: [docker/common/install_ffmpeg.sh](https://github.com/NVIDIA-NeMo/Curator/blob/main/docker/common/install_ffmpeg.sh)
 

--- a/docs/get-started/video.md
+++ b/docs/get-started/video.md
@@ -60,7 +60,7 @@ To use NeMo Curator's video curation capabilities, ensure your system meets thes
 #### Software Dependencies
 * **FFmpeg 8.0+** with one of the following encoders:
   - GPU encoder: `h264_nvenc` (recommended for performance; requires an NVENC-equipped GPU — note that A100 and H100 do **not** include NVENC)
-  - CPU encoder: `libvpx-vp9` (royalty-free fallback for non-NVENC GPUs; produces VP9 in `.mp4`)
+  - CPU encoder: `libvpx-vp9` (for non-NVENC GPUs; produces VP9 in `.mp4`)
 
 :::{tip}
 If `uv` is not installed, refer to the [Installation Guide](../admin/installation.md) for setup instructions, or install it quickly with:

--- a/docs/get-started/video.md
+++ b/docs/get-started/video.md
@@ -60,7 +60,7 @@ To use NeMo Curator's video curation capabilities, ensure your system meets thes
 #### Software Dependencies
 * **FFmpeg 8.0+** with H.264 encoding support
   - GPU encoder: `h264_nvenc` (recommended for performance)
-  - CPU encoders: `libopenh264` or `libx264` (fallback options)
+  - CPU encoder: `libx264` (fallback option)
 
 :::{tip}
 If `uv` is not installed, refer to the [Installation Guide](../admin/installation.md) for setup instructions, or install it quickly with:
@@ -122,13 +122,13 @@ For details on container environments and configurations, see [Container Environ
 
 ## Install FFmpeg and Encoders
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libopenh264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libx264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
 
 ::::{tab-set}
 
 :::{tab-item} Debian/Ubuntu (Script)
 
-Use the maintained script in the repository to build and install `FFmpeg` with `libopenh264` and NVIDIA NVENC support. The script enables `--enable-libopenh264`, `--enable-cuda-nvcc`, and `--enable-libnpp`.
+Use the maintained script in the repository to build and install `FFmpeg` with NVIDIA NVENC support. The script enables `--enable-cuda-nvcc` and `--enable-libnpp`.
 
 - Script source: [docker/common/install_ffmpeg.sh](https://github.com/NVIDIA-NeMo/Curator/blob/main/docker/common/install_ffmpeg.sh)
 
@@ -146,7 +146,7 @@ Confirm that `FFmpeg` is on your `PATH` and that at least one H.264 encoder is a
 
 ```bash
 ffmpeg -hide_banner -version | head -n 5
-ffmpeg -encoders | grep -E "h264_nvenc|libopenh264|libx264" | cat
+ffmpeg -encoders | grep -E "h264_nvenc|libx264" | cat
 ```
 
 If encoders are missing, reinstall `FFmpeg` with the required options or use the Debian/Ubuntu script above.
@@ -231,7 +231,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
   --splitting-algorithm fixed_stride \
   --fixed-stride-split-duration 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libopenh264 \
+  --transcode-encoder libx264 \
   --verbose
 ```
 
@@ -239,7 +239,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 1. Reads all video files from `$DATA_DIR`
 2. Splits each video into 10-second clips using fixed stride
 3. Generates embeddings using Cosmos-Embed1-224p model
-4. Encodes clips using libopenh264 codec
+4. Encodes clips using libx264 codec
 5. Writes output clips and metadata to `$OUT_DIR`
 
 ```{tip}
@@ -250,7 +250,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
     --splitting-algorithm fixed_stride
     --fixed-stride-split-duration 10.0
     --embedding-algorithm cosmos-embed1-224p
-    --transcode-encoder libopenh264' > my_config.txt
+    --transcode-encoder libx264' > my_config.txt
     
     python tutorials/video/getting-started/video_split_clip_example.py @my_config.txt
 ```
@@ -266,7 +266,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 | **Embedding** |
 | `--embedding-algorithm` | `cosmos-embed1-224p`, `cosmos-embed1-336p`, `cosmos-embed1-448p` | Embedding model to use |
 | **Encoding** |
-| `--transcode-encoder` | `h264_nvenc`, `libopenh264`, `libx264` | Video encoder for output clips |
+| `--transcode-encoder` | `h264_nvenc`, `libx264` | Video encoder for output clips |
 | `--transcode-use-hwaccel` | Flag | Enable hardware acceleration for encoding |
 | **Optional Features** |
 | `--generate-captions` | Flag | Generate text captions for each clip |

--- a/docs/get-started/video.md
+++ b/docs/get-started/video.md
@@ -266,7 +266,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 | **Embedding** |
 | `--embedding-algorithm` | `cosmos-embed1-224p`, `cosmos-embed1-336p`, `cosmos-embed1-448p` | Embedding model to use |
 | **Encoding** |
-| `--transcode-encoder` | `h264_nvenc`, `libvpx-vp9` | Video encoder for output clips. Use `libvpx-vp9` (CPU) on GPUs without NVENC such as A100/H100. |
+| `--transcode-encoder` | `h264_nvenc`, `libvpx-vp9`, `libopenh264` | Video encoder for output clips. Use `libvpx-vp9` (CPU) on GPUs without NVENC such as A100/H100. `libopenh264` is accepted but requires a user-installed FFmpeg build — see [BYO H.264](../admin/installation.md#bring-your-own-h264-software-encoder-advanced). |
 | `--transcode-use-hwaccel` | Flag | Enable hardware acceleration for encoding (only valid with `h264_nvenc`). |
 | **Optional Features** |
 | `--generate-captions` | Flag | Generate text captions for each clip |

--- a/docs/get-started/video.md
+++ b/docs/get-started/video.md
@@ -60,7 +60,6 @@ To use NeMo Curator's video curation capabilities, ensure your system meets thes
 #### Software Dependencies
 * **FFmpeg 8.0+** with H.264 encoding support
   - GPU encoder: `h264_nvenc` (recommended for performance)
-  - CPU encoder: `libx264` (fallback option)
 
 :::{tip}
 If `uv` is not installed, refer to the [Installation Guide](../admin/installation.md) for setup instructions, or install it quickly with:
@@ -122,7 +121,7 @@ For details on container environments and configurations, see [Container Environ
 
 ## Install FFmpeg and Encoders
 
-Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (for example, using `--transcode-encoder libx264` or `h264_nvenc`), install `FFmpeg` with the corresponding encoders.
+Curator’s video pipelines rely on `FFmpeg` for decoding and encoding. If you plan to encode clips (using `--transcode-encoder h264_nvenc`), install `FFmpeg` with NVENC support.
 
 ::::{tab-set}
 
@@ -146,7 +145,7 @@ Confirm that `FFmpeg` is on your `PATH` and that at least one H.264 encoder is a
 
 ```bash
 ffmpeg -hide_banner -version | head -n 5
-ffmpeg -encoders | grep -E "h264_nvenc|libx264" | cat
+ffmpeg -encoders | grep h264_nvenc | cat
 ```
 
 If encoders are missing, reinstall `FFmpeg` with the required options or use the Debian/Ubuntu script above.
@@ -231,7 +230,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
   --splitting-algorithm fixed_stride \
   --fixed-stride-split-duration 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libx264 \
+  --transcode-encoder h264_nvenc \
   --verbose
 ```
 
@@ -239,7 +238,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 1. Reads all video files from `$DATA_DIR`
 2. Splits each video into 10-second clips using fixed stride
 3. Generates embeddings using Cosmos-Embed1-224p model
-4. Encodes clips using libx264 codec
+4. Encodes clips using h264_nvenc codec
 5. Writes output clips and metadata to `$OUT_DIR`
 
 ```{tip}
@@ -250,7 +249,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
     --splitting-algorithm fixed_stride
     --fixed-stride-split-duration 10.0
     --embedding-algorithm cosmos-embed1-224p
-    --transcode-encoder libx264' > my_config.txt
+    --transcode-encoder h264_nvenc' > my_config.txt
     
     python tutorials/video/getting-started/video_split_clip_example.py @my_config.txt
 ```
@@ -266,7 +265,7 @@ python tutorials/video/getting-started/video_split_clip_example.py \
 | **Embedding** |
 | `--embedding-algorithm` | `cosmos-embed1-224p`, `cosmos-embed1-336p`, `cosmos-embed1-448p` | Embedding model to use |
 | **Encoding** |
-| `--transcode-encoder` | `h264_nvenc`, `libx264` | Video encoder for output clips |
+| `--transcode-encoder` | `h264_nvenc` | Video encoder for output clips |
 | `--transcode-use-hwaccel` | Flag | Enable hardware acceleration for encoding |
 | **Optional Features** |
 | `--generate-captions` | Flag | Generate text captions for each clip |

--- a/nemo_curator/stages/video/clipping/clip_extraction_stages.py
+++ b/nemo_curator/stages/video/clipping/clip_extraction_stages.py
@@ -35,7 +35,7 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
     """Stage that transcodes video clips into a standardized format.
 
     This stage handles the conversion of video clips using FFmpeg, supporting both
-    software (libx264, libopenh264) and hardware (NVENC) encoding with configurable parameters.
+    software (libx264) and hardware (NVENC) encoding with configurable parameters.
 
     Args:
         num_cpus_per_worker: Number of CPUs per worker.
@@ -69,8 +69,8 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
         Args:
             worker_metadata (WorkerMetadata, optional): Information about the worker (provided by some backends)
         """
-        if self.encoder not in {"libopenh264", "libx264", "h264_nvenc"}:
-            error_msg = f"Expected encoder of `libopenh264`, `libx264`, or `h264_nvenc`. Got {self.encoder}"
+        if self.encoder not in {"libx264", "h264_nvenc"}:
+            error_msg = f"Expected encoder of `libx264` or `h264_nvenc`. Got {self.encoder}"
             raise ValueError(error_msg)
 
     def __post_init__(self) -> None:

--- a/nemo_curator/stages/video/clipping/clip_extraction_stages.py
+++ b/nemo_curator/stages/video/clipping/clip_extraction_stages.py
@@ -14,6 +14,7 @@
 
 import copy
 import pathlib
+import shutil
 import subprocess
 import uuid
 from dataclasses import dataclass
@@ -29,17 +30,29 @@ from nemo_curator.tasks.video import Clip, Video, VideoTask
 from nemo_curator.utils import grouping
 from nemo_curator.utils.operation_utils import make_pipeline_temporary_dir
 
-SUPPORTED_ENCODERS = ("h264_nvenc", "libvpx-vp9")
+SUPPORTED_ENCODERS = ("h264_nvenc", "libvpx-vp9", "libopenh264")
+
+_BYO_H264_DOCS_URL = (
+    "https://github.com/NVIDIA-NeMo/Curator/blob/main/docs/admin/installation.md"
+    "#bring-your-own-h264-software-encoder-advanced"
+)
 
 
 @dataclass
 class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
     """Stage that transcodes video clips into a standardized format.
 
-    This stage handles the conversion of video clips using FFmpeg. Supports
-    hardware H.264 encoding via NVENC (`h264_nvenc`) on NVENC-equipped GPUs and
-    royalty-free CPU-side VP9 encoding via `libvpx-vp9` as a fallback for
-    GPUs without NVENC silicon (e.g. A100/H100).
+    This stage handles the conversion of video clips using FFmpeg. Supported
+    encoders:
+
+    - ``h264_nvenc`` — hardware H.264 via NVENC (recommended; requires an
+      NVENC-equipped NVIDIA GPU — note that A100/H100 do not include NVENC).
+    - ``libvpx-vp9`` — royalty-free VP9 software encoder (CPU fallback for
+      non-NVENC GPUs). Significantly slower; emits a perf advisory.
+    - ``libopenh264`` — H.264 software encoder. Not bundled with Curator's
+      FFmpeg build for licensing reasons; users must install it themselves.
+      The stage probes for it at setup time and raises a clear error pointing
+      to the docs if it is not available.
 
     Args:
         num_cpus_per_worker: Number of CPUs per worker.
@@ -79,6 +92,38 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
         if self.encoder == "libvpx-vp9" and self.use_hwaccel:
             error_msg = "use_hwaccel is not supported with libvpx-vp9 (CPU encoder)"
             raise ValueError(error_msg)
+        if self.encoder == "libopenh264":
+            self._verify_libopenh264_available()
+
+    @staticmethod
+    def _verify_libopenh264_available() -> None:
+        """Probe the local FFmpeg build for libopenh264 support."""
+        ffmpeg_bin = shutil.which("ffmpeg")
+        if ffmpeg_bin is None:
+            error_msg = (
+                "Could not find `ffmpeg` on PATH while verifying libopenh264 support. "
+                f"Install FFmpeg and ensure it is on PATH. See {_BYO_H264_DOCS_URL}"
+            )
+            raise RuntimeError(error_msg)
+        try:
+            result = subprocess.run(  # noqa: S603
+                [ffmpeg_bin, "-hide_banner", "-encoders"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired as e:
+            error_msg = f"`ffmpeg -encoders` timed out while verifying libopenh264 support. See {_BYO_H264_DOCS_URL}"
+            raise RuntimeError(error_msg) from e
+        if "libopenh264" not in result.stdout:
+            error_msg = (
+                "encoder='libopenh264' was requested but the local FFmpeg build "
+                "does not include it. Curator does not ship libopenh264 due to "
+                "its patent-license redistribution model. To enable it, install "
+                f"a libopenh264-enabled FFmpeg yourself — see {_BYO_H264_DOCS_URL}"
+            )
+            raise RuntimeError(error_msg)
 
     def __post_init__(self) -> None:
         """Post-initialization method called after all fields are set."""
@@ -90,6 +135,14 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
                 self.resources = Resources(gpus=1)
         else:
             self.resources = Resources(cpus=self.num_cpus_per_worker)
+
+        if self.encoder == "libvpx-vp9":
+            logger.warning(
+                "ClipTranscodingStage: libvpx-vp9 is significantly slower than "
+                "h264_nvenc and libopenh264. If your GPU has NVENC, prefer "
+                "encoder='h264_nvenc'. To use libopenh264 instead, see "
+                f"{_BYO_H264_DOCS_URL}"
+            )
 
     def inputs(self) -> tuple[list[str], list[str]]:
         return ["data"], ["source_bytes"]

--- a/nemo_curator/stages/video/clipping/clip_extraction_stages.py
+++ b/nemo_curator/stages/video/clipping/clip_extraction_stages.py
@@ -29,13 +29,17 @@ from nemo_curator.tasks.video import Clip, Video, VideoTask
 from nemo_curator.utils import grouping
 from nemo_curator.utils.operation_utils import make_pipeline_temporary_dir
 
+SUPPORTED_ENCODERS = ("h264_nvenc", "libvpx-vp9")
+
 
 @dataclass
 class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
     """Stage that transcodes video clips into a standardized format.
 
-    This stage handles the conversion of video clips using FFmpeg with hardware
-    (NVENC) encoding and configurable parameters.
+    This stage handles the conversion of video clips using FFmpeg. Supports
+    hardware H.264 encoding via NVENC (`h264_nvenc`) on NVENC-equipped GPUs and
+    royalty-free CPU-side VP9 encoding via `libvpx-vp9` as a fallback for
+    GPUs without NVENC silicon (e.g. A100/H100).
 
     Args:
         num_cpus_per_worker: Number of CPUs per worker.
@@ -43,7 +47,7 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
         encoder_threads: Number of threads per encoder.
         encode_batch_size: Number of clips to encode in parallel.
         nb_streams_per_gpu: Number of streams per GPU.
-        use_hwaccel: Whether to use hardware acceleration.
+        use_hwaccel: Whether to use hardware acceleration. Only valid with `h264_nvenc`.
         use_input_bit_rate: Whether to use input video bit rate.
         num_clips_per_chunk: Number of clips per chunk. If the number of clips is larger than this, the clips will be split into chunks, and created VideoTasks for each chunk.
         verbose: Whether to print verbose logs.
@@ -69,8 +73,11 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
         Args:
             worker_metadata (WorkerMetadata, optional): Information about the worker (provided by some backends)
         """
-        if self.encoder != "h264_nvenc":
-            error_msg = f"Expected encoder of `h264_nvenc`. Got {self.encoder}"
+        if self.encoder not in SUPPORTED_ENCODERS:
+            error_msg = f"Expected encoder in {SUPPORTED_ENCODERS}. Got {self.encoder}"
+            raise ValueError(error_msg)
+        if self.encoder == "libvpx-vp9" and self.use_hwaccel:
+            error_msg = "use_hwaccel is not supported with libvpx-vp9 (CPU encoder)"
             raise ValueError(error_msg)
 
     def __post_init__(self) -> None:
@@ -232,11 +239,8 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
 
     def _add_hwaccel_options(self, command: list[str]) -> None:
         """Add hardware acceleration options to command."""
-        if self.use_hwaccel:
-            if self.encoder == "h264_nvenc":
-                command.extend(["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"])
-            else:
-                command.extend(["-hwaccel", "auto"])
+        if self.use_hwaccel and self.encoder == "h264_nvenc":
+            command.extend(["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"])
 
     def _add_input_options(self, command: list[str], clip: Clip, video_filename: str, index: int) -> None:
         """Add input options to command."""
@@ -263,6 +267,8 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
 
         if self.encoder == "h264_nvenc":
             self._add_nvenc_options(command, force_pix_fmt)
+        elif self.encoder == "libvpx-vp9":
+            self._add_libvpx_vp9_options(command, use_bit_rate, force_pix_fmt)
 
     def _add_nvenc_options(self, command: list[str], force_pix_fmt: bool) -> None:
         """Add NVENC-specific encoding options."""
@@ -282,6 +288,28 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
                 "20",
                 "-spatial-aq",
                 "1",
+            ]
+        )
+
+        if force_pix_fmt:
+            command.extend(["-pix_fmt", "yuv420p"])
+
+    def _add_libvpx_vp9_options(self, command: list[str], use_bit_rate: str | None, force_pix_fmt: bool) -> None:
+        """Add libvpx-vp9 (CPU) encoding options."""
+        # Constant-quality mode when no explicit bitrate is requested.
+        # libvpx-vp9 requires `-b:v 0` to honor `-crf` exactly.
+        if use_bit_rate is None:
+            command.extend(["-b:v", "0", "-crf", "31"])
+        command.extend(
+            [
+                "-deadline",
+                "good",
+                "-cpu-used",
+                "4",
+                "-row-mt",
+                "1",
+                "-tile-columns",
+                "2",
             ]
         )
 

--- a/nemo_curator/stages/video/clipping/clip_extraction_stages.py
+++ b/nemo_curator/stages/video/clipping/clip_extraction_stages.py
@@ -34,8 +34,8 @@ from nemo_curator.utils.operation_utils import make_pipeline_temporary_dir
 class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
     """Stage that transcodes video clips into a standardized format.
 
-    This stage handles the conversion of video clips using FFmpeg, supporting both
-    software (libx264) and hardware (NVENC) encoding with configurable parameters.
+    This stage handles the conversion of video clips using FFmpeg with hardware
+    (NVENC) encoding and configurable parameters.
 
     Args:
         num_cpus_per_worker: Number of CPUs per worker.
@@ -51,7 +51,7 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
     """
 
     num_cpus_per_worker: float = 6.0
-    encoder: str = "libx264"
+    encoder: str = "h264_nvenc"
     encoder_threads: int = 1
     encode_batch_size: int = 16
     nb_streams_per_gpu: int = 3
@@ -69,8 +69,8 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
         Args:
             worker_metadata (WorkerMetadata, optional): Information about the worker (provided by some backends)
         """
-        if self.encoder not in {"libx264", "h264_nvenc"}:
-            error_msg = f"Expected encoder of `libx264` or `h264_nvenc`. Got {self.encoder}"
+        if self.encoder != "h264_nvenc":
+            error_msg = f"Expected encoder of `h264_nvenc`. Got {self.encoder}"
             raise ValueError(error_msg)
 
     def __post_init__(self) -> None:

--- a/tests/stages/video/clipping/test_clip_transcoding_stage.py
+++ b/tests/stages/video/clipping/test_clip_transcoding_stage.py
@@ -22,7 +22,6 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from nemo_curator.backends.base import WorkerMetadata
-from nemo_curator.stages.resources import Resources
 from nemo_curator.stages.video.clipping.clip_extraction_stages import ClipTranscodingStage
 from nemo_curator.tasks.video import Clip, Video, VideoMetadata, VideoTask
 
@@ -46,7 +45,7 @@ class TestClipTranscodingStage:
         """Set up test fixtures."""
         self.stage = ClipTranscodingStage(
             num_cpus_per_worker=4.0,
-            encoder="libx264",
+            encoder="h264_nvenc",
             encoder_threads=2,
             encode_batch_size=8,
             use_hwaccel=False,
@@ -111,14 +110,6 @@ class TestClipTranscodingStage:
 
         assert RayStageSpecKeys.IS_FANOUT_STAGE in spec
         assert spec[RayStageSpecKeys.IS_FANOUT_STAGE] is True
-
-    def test_resources_cpu_encoder(self) -> None:
-        """Test resource requirements for CPU encoders."""
-        stage = ClipTranscodingStage(encoder="libx264", use_hwaccel=False, num_cpus_per_worker=6.0)
-
-        resources = stage.resources
-        assert isinstance(resources, Resources)
-        assert resources.cpus == 6.0
 
     def test_process_no_clips(self) -> None:
         """Test processing when video has no clips."""
@@ -317,7 +308,7 @@ class TestClipTranscodingStage:
         assert "-map" in command
         assert "0:v:0" in command
         assert "-c:v" in command
-        assert "libx264" in command
+        assert "h264_nvenc" in command
 
     def test_add_video_encoding_options_no_bitrate(self) -> None:
         """Test adding video encoding options without bit rate."""

--- a/tests/stages/video/clipping/test_clip_transcoding_stage.py
+++ b/tests/stages/video/clipping/test_clip_transcoding_stage.py
@@ -114,6 +114,55 @@ class TestClipTranscodingStage:
         with pytest.raises(ValueError, match="use_hwaccel is not supported with libvpx-vp9"):
             stage.setup()
 
+    @patch("nemo_curator.stages.video.clipping.clip_extraction_stages.subprocess.run")
+    @patch("nemo_curator.stages.video.clipping.clip_extraction_stages.shutil.which")
+    def test_setup_libopenh264_available_passes(self, mock_which: MagicMock, mock_run: MagicMock) -> None:
+        """libopenh264 is accepted when the local FFmpeg build advertises it."""
+        mock_which.return_value = "/usr/local/bin/ffmpeg"
+        mock_run.return_value = MagicMock(stdout="V..... libopenh264 OpenH264 H.264", returncode=0)
+        stage = ClipTranscodingStage(encoder="libopenh264")
+        stage.setup()  # should not raise
+        mock_run.assert_called_once()
+        # Verify the probe used `ffmpeg -hide_banner -encoders` with the resolved path
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == "/usr/local/bin/ffmpeg"
+        assert "-encoders" in cmd
+
+    @patch("nemo_curator.stages.video.clipping.clip_extraction_stages.subprocess.run")
+    @patch("nemo_curator.stages.video.clipping.clip_extraction_stages.shutil.which")
+    def test_setup_libopenh264_unavailable_raises(self, mock_which: MagicMock, mock_run: MagicMock) -> None:
+        """libopenh264 raises a clear error when the local FFmpeg build lacks it."""
+        mock_which.return_value = "/usr/local/bin/ffmpeg"
+        mock_run.return_value = MagicMock(stdout="V..... h264_nvenc NVIDIA NVENC", returncode=0)
+        stage = ClipTranscodingStage(encoder="libopenh264")
+        with pytest.raises(RuntimeError, match=r"libopenh264.*does not include it"):
+            stage.setup()
+
+    @patch("nemo_curator.stages.video.clipping.clip_extraction_stages.shutil.which")
+    def test_setup_libopenh264_ffmpeg_missing_raises(self, mock_which: MagicMock) -> None:
+        """A missing FFmpeg binary surfaces as a RuntimeError pointing to the docs."""
+        mock_which.return_value = None
+        stage = ClipTranscodingStage(encoder="libopenh264")
+        with pytest.raises(RuntimeError, match=r"Could not find `ffmpeg` on PATH"):
+            stage.setup()
+
+    def test_post_init_libvpx_vp9_emits_perf_warning(self) -> None:
+        """Constructing a libvpx-vp9 stage logs the perf advisory."""
+        import nemo_curator.stages.video.clipping.clip_extraction_stages as ces
+
+        with patch.object(ces, "logger") as mock_logger:
+            ClipTranscodingStage(encoder="libvpx-vp9")
+            mock_logger.warning.assert_called_once()
+            assert "libvpx-vp9 is significantly slower" in mock_logger.warning.call_args[0][0]
+
+    def test_post_init_h264_nvenc_no_perf_warning(self) -> None:
+        """h264_nvenc construction does not trigger the VP9 perf advisory."""
+        import nemo_curator.stages.video.clipping.clip_extraction_stages as ces
+
+        with patch.object(ces, "logger") as mock_logger:
+            ClipTranscodingStage(encoder="h264_nvenc")
+            assert not any("libvpx-vp9 is significantly slower" in str(c) for c in mock_logger.warning.call_args_list)
+
     def test_ray_stage_spec(self) -> None:
         """Test that ray_stage_spec returns the correct values."""
         spec = self.stage.ray_stage_spec()

--- a/tests/stages/video/clipping/test_clip_transcoding_stage.py
+++ b/tests/stages/video/clipping/test_clip_transcoding_stage.py
@@ -98,7 +98,20 @@ class TestClipTranscodingStage:
         """Test setup with invalid encoder raises ValueError."""
         stage = ClipTranscodingStage(encoder="invalid_encoder")
 
-        with pytest.raises(ValueError, match="Expected encoder of"):
+        with pytest.raises(ValueError, match="Expected encoder in"):
+            stage.setup()
+
+    def test_setup_libvpx_vp9_valid(self) -> None:
+        """Test setup accepts libvpx-vp9 as a valid encoder."""
+        stage = ClipTranscodingStage(encoder="libvpx-vp9", use_hwaccel=False)
+        # Should not raise
+        stage.setup()
+
+    def test_setup_libvpx_vp9_with_hwaccel_raises(self) -> None:
+        """Test setup rejects libvpx-vp9 combined with use_hwaccel=True."""
+        stage = ClipTranscodingStage(encoder="libvpx-vp9", use_hwaccel=True)
+
+        with pytest.raises(ValueError, match="use_hwaccel is not supported with libvpx-vp9"):
             stage.setup()
 
     def test_ray_stage_spec(self) -> None:
@@ -291,6 +304,22 @@ class TestClipTranscodingStage:
         stage_multi = ClipTranscodingStage(use_hwaccel=True, encoder="h264_nvenc", nb_streams_per_gpu=4)
         assert stage_multi.resources.gpus == 0.25
 
+    def test_resources_libvpx_vp9_uses_cpu(self) -> None:
+        """Test that libvpx-vp9 allocates CPU resources, not GPU."""
+        stage = ClipTranscodingStage(encoder="libvpx-vp9", use_hwaccel=False, num_cpus_per_worker=8.0)
+        assert stage.resources.cpus == 8.0
+        assert stage.resources.gpus == 0
+
+    def test_add_hwaccel_options_libvpx_vp9_ignored(self) -> None:
+        """Test that hwaccel options are not added for libvpx-vp9 even if requested."""
+        command: list[str] = []
+        # Bypass setup-time validation by constructing without use_hwaccel,
+        # then assert the command builder is also defensive.
+        stage = ClipTranscodingStage(encoder="libvpx-vp9", use_hwaccel=False)
+        stage.use_hwaccel = True  # simulate misconfiguration
+        stage._add_hwaccel_options(command)
+        assert "-hwaccel" not in command
+
     def test_add_input_options(self) -> None:
         """Test adding input options to FFmpeg command."""
         command = []
@@ -328,6 +357,50 @@ class TestClipTranscodingStage:
         # Should add bit rate options
         assert "-b:v" in command
         assert "5000K" in command
+
+    def test_add_video_encoding_options_libvpx_vp9_crf_mode(self) -> None:
+        """Test that libvpx-vp9 emits CRF-mode options when no bitrate is given."""
+        stage = ClipTranscodingStage(encoder="libvpx-vp9")
+        command: list[str] = []
+
+        stage._add_video_encoding_options(command, None, False)
+
+        # CRF mode: -b:v 0 plus -crf
+        assert "-b:v" in command
+        assert "0" in command
+        assert "-crf" in command
+        # VP9 threading/speed knobs
+        assert "-row-mt" in command
+        assert "-tile-columns" in command
+        assert "-deadline" in command
+        assert "-cpu-used" in command
+        # Must not contain NVENC-only flags
+        assert "-rc:v" not in command
+        assert "-cq:v" not in command
+        assert "-tune" not in command
+
+    def test_add_video_encoding_options_libvpx_vp9_with_bitrate(self) -> None:
+        """Test that libvpx-vp9 honors an explicit bitrate (skips CRF mode)."""
+        stage = ClipTranscodingStage(encoder="libvpx-vp9")
+        command: list[str] = []
+
+        stage._add_video_encoding_options(command, "5000K", False)
+
+        # Bitrate path: -b:v 5000K, no -crf
+        assert "5000K" in command
+        assert "-crf" not in command
+        # Threading/speed knobs still present
+        assert "-row-mt" in command
+
+    def test_add_video_encoding_options_libvpx_vp9_force_pix_fmt(self) -> None:
+        """Test that libvpx-vp9 forces yuv420p when force_pix_fmt is True."""
+        stage = ClipTranscodingStage(encoder="libvpx-vp9")
+        command: list[str] = []
+
+        stage._add_video_encoding_options(command, None, True)
+
+        assert "-pix_fmt" in command
+        assert "yuv420p" in command
 
     def test_add_output_options(self) -> None:
         """Test adding output options to FFmpeg command."""

--- a/tutorials/video/getting-started/README.md
+++ b/tutorials/video/getting-started/README.md
@@ -53,7 +53,7 @@ python video_split_clip_example.py \
   --transcode-encoder h264_nvenc \
   --verbose
 ```
-This example demonstrates a more advanced workflow than the minimal example by using scene-aware splitting with the TransNetV2 algorithm (which detects scene boundaries instead of fixed intervals), applies the Cosmos-Embed1 embedding model to each clip, transcodes the output using the `h264_nvenc` encoder, and enables verbose logging for more detailed output.
+This example demonstrates a more advanced workflow than the minimal example by using scene-aware splitting with the TransNetV2 algorithm (which detects scene boundaries instead of fixed intervals), applies the Cosmos-Embed1 embedding model to each clip, transcodes the output using the `h264_nvenc` encoder, and enables verbose logging for more detailed output. On GPUs without NVENC (such as A100/H100), pass `--transcode-encoder libvpx-vp9` instead — VP9 is a royalty-free CPU encoder that produces clips in the same `.mp4` container.
 
 **Full pipeline with captions and filtering**:
 ```bash

--- a/tutorials/video/getting-started/README.md
+++ b/tutorials/video/getting-started/README.md
@@ -50,10 +50,10 @@ python video_split_clip_example.py \
   --transnetv2-min-length-s 2.0 \
   --transnetv2-max-length-s 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libx264 \
+  --transcode-encoder h264_nvenc \
   --verbose
 ```
-This example demonstrates a more advanced workflow than the minimal example by using scene-aware splitting with the TransNetV2 algorithm (which detects scene boundaries instead of fixed intervals), applies the Cosmos-Embed1 embedding model to each clip, transcodes the output using the `libx264` encoder, and enables verbose logging for more detailed output.
+This example demonstrates a more advanced workflow than the minimal example by using scene-aware splitting with the TransNetV2 algorithm (which detects scene boundaries instead of fixed intervals), applies the Cosmos-Embed1 embedding model to each clip, transcodes the output using the `h264_nvenc` encoder, and enables verbose logging for more detailed output.
 
 **Full pipeline with captions and filtering**:
 ```bash

--- a/tutorials/video/getting-started/README.md
+++ b/tutorials/video/getting-started/README.md
@@ -50,10 +50,10 @@ python video_split_clip_example.py \
   --transnetv2-min-length-s 2.0 \
   --transnetv2-max-length-s 10.0 \
   --embedding-algorithm cosmos-embed1-224p \
-  --transcode-encoder libopenh264 \
+  --transcode-encoder libx264 \
   --verbose
 ```
-This example demonstrates a more advanced workflow than the minimal example by using scene-aware splitting with the TransNetV2 algorithm (which detects scene boundaries instead of fixed intervals), applies the Cosmos-Embed1 embedding model to each clip, transcodes the output using the `libopenh264` encoder, and enables verbose logging for more detailed output.
+This example demonstrates a more advanced workflow than the minimal example by using scene-aware splitting with the TransNetV2 algorithm (which detects scene boundaries instead of fixed intervals), applies the Cosmos-Embed1 embedding model to each clip, transcodes the output using the `libx264` encoder, and enables verbose logging for more detailed output.
 
 **Full pipeline with captions and filtering**:
 ```bash

--- a/tutorials/video/getting-started/video_split_clip_example.py
+++ b/tutorials/video/getting-started/video_split_clip_example.py
@@ -379,8 +379,8 @@ def create_video_splitting_argparser() -> argparse.ArgumentParser:  # noqa: PLR0
     parser.add_argument(
         "--transcode-encoder",
         type=str,
-        default="libopenh264",
-        choices=["libopenh264", "h264_nvenc", "libx264"],
+        default="libx264",
+        choices=["h264_nvenc", "libx264"],
         help="Codec for transcoding clips; None to skip transcoding.",
     )
     parser.add_argument(

--- a/tutorials/video/getting-started/video_split_clip_example.py
+++ b/tutorials/video/getting-started/video_split_clip_example.py
@@ -379,8 +379,8 @@ def create_video_splitting_argparser() -> argparse.ArgumentParser:  # noqa: PLR0
     parser.add_argument(
         "--transcode-encoder",
         type=str,
-        default="libx264",
-        choices=["h264_nvenc", "libx264"],
+        default="h264_nvenc",
+        choices=["h264_nvenc"],
         help="Codec for transcoding clips; None to skip transcoding.",
     )
     parser.add_argument(

--- a/tutorials/video/getting-started/video_split_clip_example.py
+++ b/tutorials/video/getting-started/video_split_clip_example.py
@@ -380,11 +380,13 @@ def create_video_splitting_argparser() -> argparse.ArgumentParser:  # noqa: PLR0
         "--transcode-encoder",
         type=str,
         default="h264_nvenc",
-        choices=["h264_nvenc", "libvpx-vp9"],
+        choices=["h264_nvenc", "libvpx-vp9", "libopenh264"],
         help=(
             "Codec for transcoding clips. Use `h264_nvenc` on NVENC-equipped GPUs; "
             "use `libvpx-vp9` (CPU) as a royalty-free fallback on GPUs without NVENC "
-            "such as A100/H100."
+            "such as A100/H100; `libopenh264` is accepted but requires a user-"
+            "installed FFmpeg build (Curator does not ship it — see the "
+            "Bring-Your-Own H.264 docs)."
         ),
     )
     parser.add_argument(

--- a/tutorials/video/getting-started/video_split_clip_example.py
+++ b/tutorials/video/getting-started/video_split_clip_example.py
@@ -380,8 +380,12 @@ def create_video_splitting_argparser() -> argparse.ArgumentParser:  # noqa: PLR0
         "--transcode-encoder",
         type=str,
         default="h264_nvenc",
-        choices=["h264_nvenc"],
-        help="Codec for transcoding clips; None to skip transcoding.",
+        choices=["h264_nvenc", "libvpx-vp9"],
+        help=(
+            "Codec for transcoding clips. Use `h264_nvenc` on NVENC-equipped GPUs; "
+            "use `libvpx-vp9` (CPU) as a royalty-free fallback on GPUs without NVENC "
+            "such as A100/H100."
+        ),
     )
     parser.add_argument(
         "--transcode-encoder-threads",


### PR DESCRIPTION
Continue work based on https://github.com/NVIDIA-NeMo/Curator/pull/1918 for adding VP9 as the fallback when nvenc is not avaliable.

## Drop bundled libopenh264, add libvpx-vp9 CPU fallback, support BYO H.264

### Summary

Curator's bundled FFmpeg no longer ships with `libopenh264` (Cisco patent-license redistribution model is incompatible with our distribution). To preserve the ability to transcode video clips on hardware without NVENC (notably **A100/H100**), this PR:

1. Adds **`libvpx-vp9`** as a built-in CPU encoder fallback in `ClipTranscodingStage`. VP9 is BSD-licensed, royalty-free under the WebM patent grant, and produces VP9 in `.mp4` — no downstream changes required.
2. Keeps **`libopenh264`** accepted as an opt-in encoder for users who provide their own FFmpeg build. The stage probes at setup and surfaces a clear error pointing to the docs if it's not actually compiled in.
3. Documents **Bring-Your-Own H.264** for both `libopenh264` and `libx264`, including the licensing tradeoffs.

### What changed

**Code (`nemo_curator/stages/video/clipping/clip_extraction_stages.py`)**
- New `SUPPORTED_ENCODERS = ("h264_nvenc", "libvpx-vp9", "libopenh264")` validator.
- `__post_init__` routes `libvpx-vp9` to CPU resources (vs GPU for NVENC) and emits a perf advisory recommending NVENC if available.
- `setup()` calls `_verify_libopenh264_available()` when `encoder="libopenh264"` — uses `shutil.which("ffmpeg")` + `ffmpeg -hide_banner -encoders` grep; raises `RuntimeError` with docs link if the encoder isn't compiled in.
- New `_add_libvpx_vp9_options` helper with sensible CRF defaults (`-b:v 0 -crf 31 -deadline good -cpu-used 4 -row-mt 1 -tile-columns 2`).
- Rejects `use_hwaccel=True` with `libvpx-vp9` (CPU encoder).
- Output stays in `.mp4` for all encoders.

**Tutorial (`tutorials/video/getting-started/video_split_clip_example.py`)**
- `--transcode-encoder` choices extended to `{h264_nvenc, libvpx-vp9, libopenh264}` with help text noting libopenh264 requires a user-installed FFmpeg.

**Tests (`tests/stages/video/clipping/test_clip_transcoding_stage.py`)**
- 12 new tests covering validator behavior, encoder-options branching, hwaccel rejection, libopenh264 probe (available / unavailable / ffmpeg-missing), and VP9 perf warning.

**Docs**
- New "Bring-Your-Own H.264 Software Encoder (Advanced)" section in `docs/admin/installation.md` with two install paths (system FFmpeg vs custom build), licensing caveats, and a note that `libopenh264` is auto-accepted while `libx264` requires extending `SUPPORTED_ENCODERS`.
- Updated `docs/curate-video/process-data/transcoding.md`, `docs/get-started/video.md`, `docs/curate-video/tutorials/beginner.md`, and `tutorials/video/getting-started/README.md` to describe the new encoder set.

### Test plan

- [x] Unit tests pass (44 total, +12 new)
- [x] Pre-commit hooks pass (ruff, ruff-format, end-of-file, trailing whitespace, etc.)
- [x] End-to-end pipeline run on local videos with `--transcode-encoder libvpx-vp9` → 37 valid VP9-in-MP4 clips
- [x] End-to-end regression run with `--transcode-encoder h264_nvenc` → 37 valid H.264-in-MP4 clips
- [x] Behavioral smoke tests in two Docker images (with/without libopenh264):
  - Image without libopenh264 + `--transcode-encoder libopenh264` → raises `RuntimeError` with docs link ✓
  - Image without libopenh264 + `--transcode-encoder libvpx-vp9` → succeeds + warning emitted ✓
  - Image with libopenh264 + `--transcode-encoder libopenh264` → succeeds, output is H.264 ✓

### Pipeline-level benchmarks

RTX 6000 Ada × 2, source video with total of 30min. Wall time / output size:

| Workflow | libopenh264 | libvpx-vp9 | h264_nvenc |
|---|---|---|---|
| Transcode-only | 79 s / 467 MB | 795 s / 1.4 GB | 79 s / 1.8 GB |
| + embedding (cosmos-embed1-224p) | 145 s / 468 MB | 943 s / 1.4 GB | 150 s / 1.8 GB |
| + captioning (Qwen2.5-VL-7B, warm cache) | 392 s / 468 MB | 1068 s / 1.4 GB | 444 s / 1.8 GB |

VP9's relative slowdown shrinks as the pipeline gets heavier (10× transcode-only → 2.7× full caption pipeline) because downstream GPU work amortizes the encode cost. NVENC remains the right default when available; VP9 is a viable A100/H100 fallback if users accept the throughput hit.

### Notes for reviewers

- **A100/H100 are NVENC-less data-center GPUs.** Without this PR, those nodes have no working transcode path. VP9 is the only royalty-free, ship-with-Curator option that works there.
- **Output container stays `.mp4`** for all three encoders. PyAV/FFmpeg consume VP9-in-MP4 fine; downstream stages (embedding, motion filter, captioning, writer) are codec-agnostic.
- **`libx264` is intentionally still rejected** by the validator. The BYO docs explain how to enable it (it's GPL-tainting). 
- The libvpx-vp9 perf advisory fires on every stage construction (no module-level dedup) — clean and predictable.
