### PR TITLE
fix: infer fanout stages from process return type

### DIFF
--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -19,7 +19,7 @@ import copy
 import time
 from abc import ABC, ABCMeta, abstractmethod
 from inspect import isabstract
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, final
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, final, get_args, get_origin, get_type_hints
 
 from loguru import logger
 
@@ -294,6 +294,22 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
             "supports_batch_processing": self.supports_batch_processing(),
         }
 
+    def _process_returns_list(self) -> bool:
+        """Return whether the process return annotation can produce a list."""
+        try:
+            return_hint = get_type_hints(type(self).process).get("return")
+        except (NameError, TypeError):
+            return_hint = type(self).process.__annotations__.get("return")
+
+        if return_hint is None:
+            return False
+
+        origin = get_origin(return_hint)
+        if origin is list:
+            return True
+
+        return any(get_origin(arg) is list for arg in get_args(return_hint))
+
     def ray_stage_spec(self) -> dict[str, Any]:
         """Get Ray configuration for this stage.
         Note : This is only used for Ray Data which is an experimental backend.
@@ -302,6 +318,8 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
         Returns (dict[str, Any]):
             Dictionary containing Ray-specific configuration
         """
+        if self._process_returns_list():
+            return {"is_fanout_stage": True}
         return {}
 
     # --- Custom per-stage metrics helpers ---

--- a/tests/stages/common/test_base.py
+++ b/tests/stages/common/test_base.py
@@ -51,6 +51,35 @@ class ConcreteProcessingStage(ProcessingStage[MockTask, MockTask]):
         return [], []
 
 
+class FanoutProcessingStage(ProcessingStage[MockTask, MockTask]):
+    """Processing stage that emits multiple tasks."""
+
+    name = "FanoutProcessingStage"
+
+    def process(self, task: MockTask) -> list[MockTask]:
+        return [task]
+
+
+class OptionalFanoutProcessingStage(ProcessingStage[MockTask, MockTask]):
+    """Processing stage that can emit one or multiple tasks."""
+
+    name = "OptionalFanoutProcessingStage"
+
+    def process(self, task: MockTask) -> MockTask | list[MockTask]:
+        return task
+
+
+class TestProcessingStageRayStageSpec:
+    """Test the default Ray stage spec for ProcessingStage."""
+
+    def test_single_output_process_is_not_fanout(self):
+        assert ConcreteProcessingStage().ray_stage_spec() == {}
+
+    @pytest.mark.parametrize("stage_cls", [FanoutProcessingStage, OptionalFanoutProcessingStage])
+    def test_list_output_process_is_fanout(self, stage_cls: type[ProcessingStage]) -> None:
+        assert stage_cls().ray_stage_spec() == {"is_fanout_stage": True}
+
+
 class TestProcessingStageWith:
     """Test the with_ method for ProcessingStage."""
 


### PR DESCRIPTION
## Description
Closes #1613.

Adds default `ProcessingStage.ray_stage_spec()` logic that marks stages as fanout stages when their `process()` return annotation can produce a `list[...]`. This covers both always-fanout returns and union returns such as `Task | list[Task]`.

## Usage
N/A

## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Testing
- `uv run --group linting ruff check nemo_curator/stages/base.py tests/stages/common/test_base.py`
- `uv run pytest tests/stages/common/test_base.py` (blocked locally: NeMo-Curator currently supports Linux only, but this runner is macOS/Darwin)
