### PR TITLE
fix(ModelStage): del self.model before gc.collect() in teardown()

### DIFF
--- a/nemo_curator/stages/text/models/model.py
+++ b/nemo_curator/stages/text/models/model.py
@@ -205,5 +205,7 @@ class ModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         )
 
     def teardown(self) -> None:
+        if hasattr(self, "model"):
+            del self.model
         gc.collect()
         torch.cuda.empty_cache()


### PR DESCRIPTION
## Summary

Fixes GPU memory not being released after xenna-based benchmarks complete, causing subsequent benchmarks to fail with out-of-memory errors.

`ModelStage.teardown()` was calling `gc.collect()` without first dropping the reference to `self.model`. Since the model was still referenced, the garbage collector had nothing to reclaim, leaving the model weights in GPU memory after the benchmark subprocess exited.

The fix explicitly deletes `self.model` before `gc.collect()` so the reference count drops to zero and the memory is actually freed before `torch.cuda.empty_cache()` runs. A `hasattr` guard is included for safety in case teardown is called before setup completes.

## Status

Draft — needs to be verified against benchmark logs and a test run on the affected machine before merging.

## Test plan

- [ ] Run xenna-based benchmarks sequentially and confirm GPU memory is fully released between runs
- [ ] Confirm the benchmark that previously failed with OOM now succeeds
- [ ] Review logs from the affected machine to confirm this is the right fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)