### PR TITLE
Package translation prompt yamls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ include = [
     "nemo_curator.*",
 ]
 
+[tool.setuptools.package-data]
+"nemo_curator.stages.text.experimental.translation" = ["prompts/*.yaml"]
+
 [tool.setuptools.dynamic]
 version = { attr = "nemo_curator.package_info.__version__" }
 


### PR DESCRIPTION
## Description

  This PR updates Curator packaging so the experimental translation prompt templates are included in built wheels and source installs.

  The translation runtime loads prompt templates from:

  nemo_curator/stages/text/experimental/translation/prompts/

Without explicitly declaring these YAML files as package data, wheel-based installs can omit translate.yaml and faith_eval.yaml, causing FileNotFoundError at runtime when translation or FAITH scoring initializes. This change adds the prompt YAML files to setuptools package data so they are available after pip install, uv sync, or Git-based installs.

  ## Checklist

  - [x] I am familiar with the Contributing Guide (https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
  - [x] New or Existing tests cover these changes.
  - [x] The documentation is up to date with these changes.