### PR TITLE
fix: update motion vector export flag handling in PyAV

### DIFF
--- a/nemo_curator/stages/video/filtering/motion_vector_backend.py
+++ b/nemo_curator/stages/video/filtering/motion_vector_backend.py
@@ -28,6 +28,21 @@ from torch import Tensor
 _MIN_SIDE_RESOLUTION = 256
 
 
+def _resolve_export_mvs_flag() -> int:
+    """Return the EXPORT_MVS bitflag, accepting either the PyAV >=15 lowercase
+    name (``export_mvs``) or the PyAV <=13 uppercase name (``EXPORT_MVS``).
+
+    The enum member was renamed between PyAV 13 and 15. Tests for both branches
+    pin this contract so a future PyAV bump that renames it again surfaces as
+    a failed unit test rather than silently zero motion vectors at runtime.
+    """
+    flags2 = av.codec.context.Flags2
+    flag = getattr(flags2, "export_mvs", None)
+    if flag is None:
+        flag = flags2.EXPORT_MVS  # type: ignore[attr-defined]
+    return flag
+
+
 class VideoResolutionTooSmallError(Exception):
     """Exception raised when video resolution is below the minimum required size.
 
@@ -161,7 +176,7 @@ def motion_vectors_to_flowfield(mvs: Tensor, size: list[int], flow: Tensor | Non
     return flow
 
 
-def decode_for_motion(  # noqa: C901, PLR0912
+def decode_for_motion(  # noqa: C901
     video: io.BytesIO,
     thread_count: int = 4,
     target_fps: float = 2.0,
@@ -184,13 +199,8 @@ def decode_for_motion(  # noqa: C901, PLR0912
     with cast("av.container.InputContainer", av.open(video, metadata_errors="ignore")) as input_container:
         stream = input_container.streams.video[0]
         ctx = stream.codec_context
-        # Set this flag to return motion vectors. PyAV renamed the enum member
-        # from EXPORT_MVS (PyAV <=13) to export_mvs (PyAV >=15); accept either.
-        _flags2 = av.codec.context.Flags2
-        export_mvs_flag = getattr(_flags2, "export_mvs", None)
-        if export_mvs_flag is None:
-            export_mvs_flag = _flags2.EXPORT_MVS  # type: ignore[attr-defined]
-        ctx.flags2 |= export_mvs_flag
+        # Request motion-vector side data from the decoder.
+        ctx.flags2 |= _resolve_export_mvs_flag()
         ctx.thread_type = av.codec.context.ThreadType.AUTO
         ctx.thread_count = thread_count
         mv_data = []

--- a/nemo_curator/stages/video/filtering/motion_vector_backend.py
+++ b/nemo_curator/stages/video/filtering/motion_vector_backend.py
@@ -186,9 +186,8 @@ def decode_for_motion(  # noqa: C901
         ctx = stream.codec_context
         # Set this flag to return motion vectors. PyAV renamed the enum member
         # from EXPORT_MVS (PyAV <=13) to export_mvs (PyAV >=15); accept either.
-        export_mvs_flag = getattr(
-            av.codec.context.Flags2, "export_mvs", None
-        ) or getattr(av.codec.context.Flags2, "EXPORT_MVS")
+        _flags2 = av.codec.context.Flags2
+        export_mvs_flag = getattr(_flags2, "export_mvs", None) or _flags2.EXPORT_MVS  # type: ignore[attr-defined]
         ctx.flags2 |= export_mvs_flag
         ctx.thread_type = av.codec.context.ThreadType.AUTO
         ctx.thread_count = thread_count

--- a/nemo_curator/stages/video/filtering/motion_vector_backend.py
+++ b/nemo_curator/stages/video/filtering/motion_vector_backend.py
@@ -184,8 +184,12 @@ def decode_for_motion(  # noqa: C901
     with cast("av.container.InputContainer", av.open(video, metadata_errors="ignore")) as input_container:
         stream = input_container.streams.video[0]
         ctx = stream.codec_context
-        # Set this flag to return motion vectors
-        ctx.flags2 |= av.codec.context.Flags2.EXPORT_MVS
+        # Set this flag to return motion vectors. PyAV renamed the enum member
+        # from EXPORT_MVS (PyAV <=13) to export_mvs (PyAV >=15); accept either.
+        export_mvs_flag = getattr(
+            av.codec.context.Flags2, "export_mvs", None
+        ) or getattr(av.codec.context.Flags2, "EXPORT_MVS")
+        ctx.flags2 |= export_mvs_flag
         ctx.thread_type = av.codec.context.ThreadType.AUTO
         ctx.thread_count = thread_count
         mv_data = []

--- a/nemo_curator/stages/video/filtering/motion_vector_backend.py
+++ b/nemo_curator/stages/video/filtering/motion_vector_backend.py
@@ -161,7 +161,7 @@ def motion_vectors_to_flowfield(mvs: Tensor, size: list[int], flow: Tensor | Non
     return flow
 
 
-def decode_for_motion(  # noqa: C901
+def decode_for_motion(  # noqa: C901, PLR0912
     video: io.BytesIO,
     thread_count: int = 4,
     target_fps: float = 2.0,
@@ -187,7 +187,9 @@ def decode_for_motion(  # noqa: C901
         # Set this flag to return motion vectors. PyAV renamed the enum member
         # from EXPORT_MVS (PyAV <=13) to export_mvs (PyAV >=15); accept either.
         _flags2 = av.codec.context.Flags2
-        export_mvs_flag = getattr(_flags2, "export_mvs", None) or _flags2.EXPORT_MVS  # type: ignore[attr-defined]
+        export_mvs_flag = getattr(_flags2, "export_mvs", None)
+        if export_mvs_flag is None:
+            export_mvs_flag = _flags2.EXPORT_MVS  # type: ignore[attr-defined]
         ctx.flags2 |= export_mvs_flag
         ctx.thread_type = av.codec.context.ThreadType.AUTO
         ctx.thread_count = thread_count

--- a/tests/stages/video/filtering/test_motion_vector_backend.py
+++ b/tests/stages/video/filtering/test_motion_vector_backend.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 import io
+import types
 from unittest.mock import Mock, patch
 
+import av
 import numpy as np
 import pytest
 import torch
 
+from nemo_curator.stages.video.filtering import motion_vector_backend
 from nemo_curator.stages.video.filtering.motion_vector_backend import (
     DecodedData,
     MotionInfo,
@@ -363,6 +366,27 @@ class TestDecodeForMotion:
 
             assert isinstance(result, DecodedData)
             assert result.frame_size == torch.Size([480, 640, 3])
+
+
+class TestResolveExportMvsFlag:
+    """Pin PyAV API-drift compat for the EXPORT_MVS bitflag.
+
+    PyAV <=13 exposed it as ``Flags2.EXPORT_MVS``; PyAV >=15 renamed it to the
+    lowercase ``Flags2.export_mvs``. A future rename would silently produce
+    zero motion vectors at runtime; these tests catch it as a unit-test failure.
+    """
+
+    def test_prefers_lowercase_export_mvs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # PyAV >=15 path: only the lowercase name exists.
+        fake_flags2 = types.SimpleNamespace(export_mvs=42)
+        monkeypatch.setattr(av.codec.context, "Flags2", fake_flags2)
+        assert motion_vector_backend._resolve_export_mvs_flag() == 42
+
+    def test_falls_back_to_uppercase_export_mvs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # PyAV <=13 path: only the uppercase name exists.
+        fake_flags2 = types.SimpleNamespace(EXPORT_MVS=84)
+        monkeypatch.setattr(av.codec.context, "Flags2", fake_flags2)
+        assert motion_vector_backend._resolve_export_mvs_flag() == 84
 
 
 class TestCheckIfSmallMotion:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
