### PR TITLE
fix: fail fast for empty Ray Data fanout

### DIFF
--- a/nemo_curator/backends/experimental/ray_data/executor.py
+++ b/nemo_curator/backends/experimental/ray_data/executor.py
@@ -19,7 +19,7 @@ from loguru import logger
 from ray.data import DataContext, Dataset
 
 from nemo_curator.backends.base import BaseExecutor
-from nemo_curator.backends.experimental.utils import execute_setup_on_node
+from nemo_curator.backends.experimental.utils import RayStageSpecKeys, execute_setup_on_node
 from nemo_curator.backends.utils import register_loguru_serializer
 from nemo_curator.tasks import EmptyTask, Task
 
@@ -60,8 +60,9 @@ class RayDataExecutor(BaseExecutor):
         # This prevents verbose logging from Ray Data about serialization of the dataclass
         DataContext.get_current().enable_fallback_to_arrow_object_ext_type = True
         # Initialize with initial tasks if provided, otherwise start with EmptyTask
-        tasks: list[Task] = initial_tasks if initial_tasks else [EmptyTask]
+        tasks: list[Task] = initial_tasks or [EmptyTask]
         output_tasks: list[Task] = []
+        stages_to_run = stages
         try:
             # Initialize ray and explicitly set NOSET to empty
             # This ensures if Xenna was used before which was setting NOSET, we end up overriding it.
@@ -69,17 +70,23 @@ class RayDataExecutor(BaseExecutor):
                 ignore_reinit_error=True, runtime_env={"env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": ""}}
             )
 
+            if self._starts_with_empty_task(tasks) and self._is_fanout_stage(stages[0]):
+                tasks = self._get_initial_fanout_tasks(stages[0])
+                stages_to_run = stages[1:]
+
             # Convert tasks to dataset
             current_dataset = self._tasks_to_dataset(tasks)
 
             # Execute setup on node for all stages
-            execute_setup_on_node(stages, ignore_head_node=self.ignore_head_node)
-            logger.info(f"Setup on node complete for all stages. Starting Ray Data pipeline with {len(stages)} stages")
+            execute_setup_on_node(stages_to_run, ignore_head_node=self.ignore_head_node)
+            logger.info(
+                f"Setup on node complete for all stages. Starting Ray Data pipeline with {len(stages_to_run)} stages"
+            )
 
             # Process through each stage
-            for i, stage in enumerate(stages):
+            for i, stage in enumerate(stages_to_run):
                 # TODO: add pipeline level config for verbosity
-                logger.info(f"Processing stage {i + 1}/{len(stages)}: {stage}")
+                logger.info(f"Processing stage {i + 1}/{len(stages_to_run)}: {stage}")
                 logger.info(f"  CPU cores: {stage.resources.cpus}, GPU ratio: {stage.resources.gpus}")
 
                 # Create adapter for this stage
@@ -99,6 +106,26 @@ class RayDataExecutor(BaseExecutor):
             # This ensures we unset all the env vars set above during initialize and kill the pending actors.
             ray.shutdown()
         return output_tasks
+
+    def _get_initial_fanout_tasks(self, stage: "ProcessingStage") -> list[Task]:
+        """Run the first fanout stage eagerly so empty input fails before Ray Data execution."""
+        execute_setup_on_node([stage], ignore_head_node=self.ignore_head_node)
+        tasks = stage.process(EmptyTask)
+        if not tasks:
+            msg = (
+                f"No tasks produced by {stage.__class__.__name__}. "
+                "Check that the input path exists and contains files matching the reader extensions."
+            )
+            raise ValueError(msg)
+        return tasks
+
+    def _starts_with_empty_task(self, tasks: list[Task]) -> bool:
+        """Return True when execution starts from the default EmptyTask sentinel."""
+        return len(tasks) == 1 and tasks[0] is EmptyTask
+
+    def _is_fanout_stage(self, stage: "ProcessingStage") -> bool:
+        """Return True for stages that expand one input task into many output tasks."""
+        return bool(stage.ray_stage_spec().get(RayStageSpecKeys.IS_FANOUT_STAGE, False))
 
     def _tasks_to_dataset(self, tasks: list[Task]) -> Dataset:
         """Convert list of tasks to Ray Data dataset.

--- a/tests/backends/experimental/ray_data/test_max_calls_pid.py
+++ b/tests/backends/experimental/ray_data/test_max_calls_pid.py
@@ -16,6 +16,7 @@ import math
 import os
 import re
 import tempfile
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -26,6 +27,7 @@ from nemo_curator.backends.experimental.ray_data.executor import RayDataExecutor
 from nemo_curator.backends.experimental.utils import RayStageSpecKeys
 from nemo_curator.core.client import RayClient
 from nemo_curator.stages.base import ProcessingStage, Resources
+from nemo_curator.stages.file_partitioning import FilePartitioningStage
 from nemo_curator.tasks import DocumentBatch, EmptyTask
 from tests.backends.utils import capture_logs
 
@@ -267,3 +269,14 @@ def test_max_calls_not_fused_with_task_stage(max_calls_per_worker: int | None):
             f"Expected fused operator with 2 MapBatches, got: {map_batches_stages[0]}. "
             f"Full execution plan: {matches[-1]}"
         )
+
+
+@pytest.mark.usefixtures("single_cpu_ray_client")
+def test_file_partitioning_fails_fast_when_no_files_match(tmp_path: Path):
+    """RayDataExecutor should fail before building a Ray Data pipeline with no file tasks."""
+    (tmp_path / "data.parquet").write_text("not jsonl")
+    stage = FilePartitioningStage(str(tmp_path), file_extensions=[".jsonl"])
+    executor = RayDataExecutor()
+
+    with pytest.raises(ValueError, match="No tasks produced by FilePartitioningStage"):
+        executor.execute([stage])


### PR DESCRIPTION
## Description
Closes #1387.

This makes `RayDataExecutor` eagerly run an initial fanout stage that starts from the default `EmptyTask`. If that stage produces no tasks (for example, a text reader points at a missing path or a directory with non-matching file extensions), the executor raises a `ValueError` before constructing the Ray Data pipeline instead of hanging with no work scheduled.

## Usage
```python
from nemo_curator.backends.experimental.ray_data import RayDataExecutor
from nemo_curator.pipeline import Pipeline
from nemo_curator.stages.text.io.reader import JsonlReader

pipeline = Pipeline(name="test")
pipeline.add_stage(JsonlReader("/path/to/parquet/dir"))
pipeline.run(executor=RayDataExecutor())  # raises ValueError when no .jsonl files match
```

## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Testing
- `uv run ruff check nemo_curator/backends/experimental/ray_data/executor.py tests/backends/experimental/ray_data/test_max_calls_pid.py`
- `uv run python -m py_compile nemo_curator/backends/experimental/ray_data/executor.py tests/backends/experimental/ray_data/test_max_calls_pid.py`
- `git diff --check`

Note: I attempted the targeted pytest locally, but this machine is macOS and NeMo-Curator raises its Linux-only platform guard during test collection.
