### PR TITLE
docs: add "What's Hot" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@
 
 > *Part of the [NVIDIA NeMo](https://www.nvidia.com/en-us/ai-data-science/products/nemo/) software suite for managing the AI agent lifecycle.*
 
+## What's Hot
+
+Don't miss the latest capabilities developers are picking up:
+
+| Feature | What it unlocks | Read this |
+|---------|-----------------|-----------|
+| **Curator on Slurm** | Run multi-node Ray pipelines on HPC clusters — text, image, video, and audio workloads at scale | [Slurm Deployment Guide](https://docs.nvidia.com/nemo/curator/latest/admin/deployment/slurm/multi-node-ray.html) |
+| **Audio Curation** | Curate speech datasets for ASR and multimodal training — transcription, WER filtering, and quality assessment | [Audio Guide](https://docs.nvidia.com/nemo/curator/latest/curate-audio/index.html) |
+| **Inference Server** | Spin up an OpenAI-compatible LLM endpoint inside your pipeline for SDG, classification, and synthetic data workflows | [Inference Server](https://docs.nvidia.com/nemo/curator/latest/curate-text/synthetic/inference-server.html) |
+
+> Want something featured here? Open an issue or ping `@nemo-curator-leads`.
+
 ## Updates
 
 - **2026-04** — NeMo Curator 26.04: Cosmos-Xenna 0.2.0 upgrade, simplified `Resources` API, Ray runtime upgrade. See the [release notes](https://docs.nvidia.com/nemo/curator/latest/about/release-notes).

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Don't miss the latest capabilities developers are picking up:
 
 | Feature | What it unlocks | Read this |
 |---------|-----------------|-----------|
-| **Curator on Slurm** | Run multi-node Ray pipelines on HPC clusters — text, image, video, and audio workloads at scale | [Slurm Deployment Guide](https://docs.nvidia.com/nemo/curator/latest/admin/deployment/slurm/multi-node-ray.html) |
-| **Audio Curation** | Curate speech datasets for ASR and multimodal training — transcription, WER filtering, and quality assessment | [Audio Guide](https://docs.nvidia.com/nemo/curator/latest/curate-audio/index.html) |
-| **Inference Server** | Spin up an OpenAI-compatible LLM endpoint inside your pipeline for SDG, classification, and synthetic data workflows | [Inference Server](https://docs.nvidia.com/nemo/curator/latest/curate-text/synthetic/inference-server.html) |
+| **Curator on Slurm** | Run multi-node Ray pipelines on HPC clusters — text, image, video, and audio workloads at scale | [Slurm Deployment Guide](https://docs.nvidia.com/nemo/curator/latest/admin/deployment/slurm-multi-node-ray) |
+| **Audio Curation** | Build ALM and speech datasets with composite quality filtering, audio tagging, and speaker diarization | [Audio Guide](https://docs.nvidia.com/nemo/curator/latest/curate-audio) |
+| **Inference Server** | Spin up an OpenAI-compatible LLM endpoint inside your pipeline for SDG, classification, and synthetic data workflows | [Inference Server](https://docs.nvidia.com/nemo/curator/latest/curate-text/synthetic/inference-server) |
 
 > Want something featured here? Open an issue or ping `@nemo-curator-leads`.
 


### PR DESCRIPTION
## Summary
- Adds a "What's Hot" section to the top of the README highlighting Slurm deployment, Audio curation, and the Inference Server
- Sits above the existing "Updates" release log so feature highlights and release history serve distinct purposes
- Addresses [#1552](https://github.com/NVIDIA-NeMo/Curator/issues/1552) (better surfacing of new features on the landing page)

## Context
Requested by Arham in #docs Slack thread — developers landing on the README should immediately see the latest capabilities worth trying. The three highlighted features were called out by Arham; cc @nemo-curator-leads if anything else should be added before merge (candidates: Cosmos-Embed1 video embeddings, Nemotron-CC recipe, simplified `Resources` API).

## Test plan
- [ ] Preview README rendering on GitHub
- [ ] Verify all three doc links resolve
- [ ] Confirm leads are aligned on the three highlighted features

🤖 Generated with [Claude Code](https://claude.com/claude-code)