### PR TITLE
Add unique and deterministic id generation

### DIFF
--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -17,7 +17,7 @@ from typing import Any
 from loguru import logger
 
 from nemo_curator.backends.base import BaseExecutor
-from nemo_curator.stages.base import CompositeStage, ProcessingStage, assign_root_lineage
+from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.tasks import Task
 
 
@@ -213,5 +213,7 @@ class Pipeline:
                 )
 
         if initial_tasks:
-            assign_root_lineage(initial_tasks)
+            # Assign deterministic root-level lineage to initial pipeline tasks
+            for i, task in enumerate(initial_tasks):
+                task._set_lineage([], i)
         return executor.execute(self.stages, initial_tasks)

--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -17,7 +17,7 @@ from typing import Any
 from loguru import logger
 
 from nemo_curator.backends.base import BaseExecutor
-from nemo_curator.stages.base import CompositeStage, ProcessingStage
+from nemo_curator.stages.base import CompositeStage, ProcessingStage, assign_root_lineage
 from nemo_curator.tasks import Task
 
 
@@ -212,4 +212,6 @@ class Pipeline:
                     "The executor will schedule GPU stages on GPUs not held by Serve."
                 )
 
+        if initial_tasks:
+            assign_root_lineage(initial_tasks)
         return executor.execute(self.stages, initial_tasks)

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -35,6 +35,37 @@ Y = TypeVar("Y", bound=Task)  # Output task type
 _STAGE_REGISTRY: dict[str, type[ProcessingStage]] = {}
 
 
+def assign_child_lineage(
+    parent_paths: list[str],
+    result: Task | list[Task] | None,
+) -> list[Task]:
+    """Normalize a stage's ``process()`` result and assign deterministic lineage.
+
+    Each surviving ``children[i]`` gets ``_lineage_path`` and ``_uuid`` derived
+    from ``(parent_paths, i)`` so that the same pipeline run twice on the same
+    inputs produces byte-identical task IDs. Call this from any custom
+    ``process_batch`` override to keep outputs consistent with the rest of the
+    pipeline.
+
+    Args:
+        parent_paths: One element per logical parent (typically
+            ``[task._lineage_path]`` for 1:N stages, or multiple paths for
+            join/aggregate stages).
+        result: Whatever ``process()`` (or your custom batch logic) returned for
+            this parent set — a single task, a list, or ``None``.
+
+    Returns:
+        The normalized list of children with lineage assigned. May be empty.
+    """
+    if result is None:
+        return []
+    children = result if isinstance(result, list) else [result]
+    children = [c for c in children if c is not None]
+    for i, child in enumerate(children):
+        child._set_lineage(parent_paths, i)
+    return children
+
+
 class StageMeta(ABCMeta):
     """Metaclass that automatically registers concrete Stage subclasses.
     A class is considered *concrete* if it directly inherits from
@@ -179,9 +210,21 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
             - Single task: For 1-to-1 transformations
             - List of tasks: For 1-to-many transformations
             - None: If the task should be filtered out
-        Note: The returned list should have the same length as the input list,
-        with each element corresponding to the result of processing the task
-        at the same index.
+
+        Lineage contract: every emitted child must have its ``_lineage_path``
+        and ``_uuid`` set so the pipeline produces deterministic IDs. The
+        default implementation below delegates to
+        :func:`assign_child_lineage` per input task. If you override this
+        method, you are responsible for calling ``assign_child_lineage`` on
+        each chunk of outputs that share parentage, e.g.::
+
+            outputs = []
+            for task in tasks:
+                raw = self.my_batched_process(task)
+                outputs.extend(assign_child_lineage([task._lineage_path], raw))
+            return outputs
+
+        Outputs that skip this step will carry empty ``_uuid``/``_lineage_path``.
         """
         # Default implementation: process tasks one by one
         # This is only used as a fallback if a stage doesn't override this method
@@ -192,10 +235,7 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
                 raise ValueError(msg)
 
             result = self.process(task)
-            if isinstance(result, list):
-                results.extend(result)
-            else:
-                results.append(result)
+            results.extend(assign_child_lineage([task._lineage_path], result))
         return results
 
     def setup_on_node(self, node_info: NodeInfo | None = None, worker_metadata: WorkerMetadata | None = None) -> None:

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -41,11 +41,16 @@ def assign_child_lineage(
 ) -> list[Task]:
     """Normalize a stage's ``process()`` result and assign deterministic lineage.
 
-    Each surviving ``children[i]`` gets ``_lineage_path`` and ``_uuid`` derived
+    Each surviving ``children[i]`` gets ``_lineage_path`` and ``_udid`` derived
     from ``(parent_paths, i)`` so that the same pipeline run twice on the same
     inputs produces byte-identical task IDs. Call this from any custom
     ``process_batch`` override to keep outputs consistent with the rest of the
     pipeline.
+
+    Children whose ``_udid`` is already set are passed through unchanged. This
+    happens when a stage mutates and returns the same task instance it received
+    (e.g. an embedder that writes results onto the input task): the framework
+    must not treat such a task as a new child of itself.
 
     Args:
         parent_paths: One element per logical parent (typically
@@ -212,7 +217,7 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
             - None: If the task should be filtered out
 
         Lineage contract: every emitted child must have its ``_lineage_path``
-        and ``_uuid`` set so the pipeline produces deterministic IDs. The
+        and ``_udid`` set so the pipeline produces deterministic IDs. The
         default implementation below delegates to
         :func:`assign_child_lineage` per input task. If you override this
         method, you are responsible for calling ``assign_child_lineage`` on
@@ -224,7 +229,12 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
                 outputs.extend(assign_child_lineage([task._lineage_path], raw))
             return outputs
 
-        Outputs that skip this step will carry empty ``_uuid``/``_lineage_path``.
+        In-place returns are supported: if ``process()`` mutates and returns the
+        same task it received, ``assign_child_lineage`` will preserve that
+        task's existing ``_lineage_path`` / ``_udid`` rather than treating it as
+        a new child of itself.
+
+        Outputs that skip this step will carry empty ``_udid``/``_lineage_path``.
         """
         # Default implementation: process tasks one by one
         # This is only used as a fallback if a stage doesn't override this method

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -71,22 +71,6 @@ def assign_child_lineage(
     return children
 
 
-def assign_root_lineage(tasks: list[Task]) -> list[Task]:
-    """Assign deterministic root-level lineage to initial pipeline tasks.
-
-    Each ``tasks[i]`` gets ``_lineage_path = str(i)`` and the corresponding
-    ``_udid``. Tasks whose ``_udid`` is already set are left untouched
-    (``_set_lineage`` early-returns), so calling this twice is a no-op.
-
-    Without this step every root carries ``_lineage_path = ""``, and the
-    empty-string filter in ``_set_lineage`` collapses first-stage children of
-    different roots onto the same lineage path, producing identical ``_udid``.
-    """
-    for i, task in enumerate(tasks):
-        task._set_lineage([], i)
-    return tasks
-
-
 class StageMeta(ABCMeta):
     """Metaclass that automatically registers concrete Stage subclasses.
     A class is considered *concrete* if it directly inherits from

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -71,6 +71,22 @@ def assign_child_lineage(
     return children
 
 
+def assign_root_lineage(tasks: list[Task]) -> list[Task]:
+    """Assign deterministic root-level lineage to initial pipeline tasks.
+
+    Each ``tasks[i]`` gets ``_lineage_path = str(i)`` and the corresponding
+    ``_udid``. Tasks whose ``_udid`` is already set are left untouched
+    (``_set_lineage`` early-returns), so calling this twice is a no-op.
+
+    Without this step every root carries ``_lineage_path = ""``, and the
+    empty-string filter in ``_set_lineage`` collapses first-stage children of
+    different roots onto the same lineage path, producing identical ``_udid``.
+    """
+    for i, task in enumerate(tasks):
+        task._set_lineage([], i)
+    return tasks
+
+
 class StageMeta(ABCMeta):
     """Metaclass that automatically registers concrete Stage subclasses.
     A class is considered *concrete* if it directly inherits from

--- a/nemo_curator/tasks/tasks.py
+++ b/nemo_curator/tasks/tasks.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -40,10 +41,22 @@ class Task(ABC, Generic[T]):
     _stage_perf: list[StagePerfStats] = field(default_factory=list)
     _metadata: dict[str, Any] = field(default_factory=dict)
     _uuid: str = field(init=False, default_factory=lambda: str(uuid.uuid4()))
+    # `_lineage_path` is the index-based path of this task through the pipeline
+    # DAG (e.g. "3_0_7" = 4th root task, then 1st child, then 8th grandchild).
+    # It is propagated to children and hashed into `_udid`, the deterministic
+    # task id.
+    _lineage_path: str = field(init=False, default="")
+    _udid: str = field(init=False, default="")
 
     def __post_init__(self) -> None:
         """Post-initialization hook."""
         self.validate()
+
+    def _set_lineage(self, parent_lineage_paths: list[str], child_index: int) -> None:
+        # DAG structure does. Clear cache directories when changing config.
+        parts = [*[p for p in parent_lineage_paths if p], str(child_index)]
+        self._lineage_path = "_".join(parts)
+        self._udid = hashlib.sha256(self._lineage_path.encode()).hexdigest()[:32]
 
     @property
     @abstractmethod

--- a/nemo_curator/tasks/tasks.py
+++ b/nemo_curator/tasks/tasks.py
@@ -52,11 +52,19 @@ class Task(ABC, Generic[T]):
         """Post-initialization hook."""
         self.validate()
 
-    def _set_lineage(self, parent_lineage_paths: list[str], child_index: int) -> None:
-        # DAG structure does. Clear cache directories when changing config.
+    def _set_lineage(self, parent_lineage_paths: list[str], child_index: int) -> bool:
+        """Assign deterministic lineage to this task.
+
+        Returns ``True`` if lineage was newly assigned, ``False`` if ``_udid``
+        was already set — which signals the task was returned in place by an
+        earlier stage and its existing lineage must be preserved.
+        """
+        if self._udid:
+            return False
         parts = [*[p for p in parent_lineage_paths if p], str(child_index)]
         self._lineage_path = "_".join(parts)
         self._udid = hashlib.sha256(self._lineage_path.encode()).hexdigest()[:32]
+        return True
 
     @property
     @abstractmethod

--- a/nemo_curator/tasks/tasks.py
+++ b/nemo_curator/tasks/tasks.py
@@ -56,7 +56,7 @@ class Task(ABC, Generic[T]):
         """Assign deterministic lineage to this task.
 
         Returns ``True`` if lineage was newly assigned, ``False`` if ``_udid``
-        was already set — which signals the task was returned in place by an
+        was already set - which signals the task was returned in place by an
         earlier stage and its existing lineage must be preserved.
         """
         if self._udid:

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -20,7 +20,7 @@ import pytest
 
 from nemo_curator.backends.base import BaseStageAdapter
 from nemo_curator.pipeline.pipeline import Pipeline
-from nemo_curator.stages.base import ProcessingStage, assign_child_lineage
+from nemo_curator.stages.base import ProcessingStage, assign_child_lineage, assign_root_lineage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import Task
 
@@ -116,6 +116,7 @@ def _drive(pipeline: Pipeline, initial_tasks: list[Task]) -> list[Task]:
     """Walk a built pipeline by hand, threading tasks through BaseStageAdapter
     for each stage. This is what every real executor does internally; using it
     here lets us exercise the determinism contract without needing Ray."""
+    assign_root_lineage(initial_tasks)
     current = initial_tasks
     for stage in pipeline.stages:
         current = BaseStageAdapter(stage).process_batch(current)
@@ -134,10 +135,10 @@ def test_pipeline_udid_deterministic_across_runs():
     paths_b, udids_b = run_once()
     assert paths_a == paths_b
     assert udids_a == udids_b
-    # First-generation outputs use index-only paths because the root task has
-    # an empty _lineage_path. After the second stage the paths should match
-    # the documented "{parent_idx}_{child_idx}" shape.
-    assert paths_a == [f"{i}_{j}" for i in range(2) for j in range(3)]
+    # Root index "0" is prepended by `assign_root_lineage`; subsequent fan-outs
+    # extend the path one segment at a time per the documented
+    # "{root_idx}_{child_idx}_{grandchild_idx}" shape.
+    assert paths_a == [f"0_{i}_{j}" for i in range(2) for j in range(3)]
     assert udids_a == [hashlib.sha256(p.encode()).hexdigest()[:32] for p in paths_a]
 
 
@@ -224,13 +225,13 @@ def test_pipeline_udid_fanout_passthrough_fanin_passthrough():
 
         Input ─▶ FanOut(3) ─▶ Passthrough ─▶ FanIn ─▶ Passthrough ─▶ Output
 
-    Starting from one root task (with `_lineage_path = ""`), the framework
-    should produce the following paths:
+    Starting from one root task assigned ``_lineage_path = "0"`` by
+    ``assign_root_lineage``, the framework should produce the following paths:
 
-        After FanOut:      ["0", "1", "2"]
-        After Passthrough: ["0_0", "1_0", "2_0"]
-        After FanIn:       ["0_0_1_0_2_0_0"]      (all 3 parents + idx 0)
-        After Passthrough: ["0_0_1_0_2_0_0_0"]
+        After FanOut:      ["0_0", "0_1", "0_2"]
+        After Passthrough: ["0_0_0", "0_1_0", "0_2_0"]
+        After FanIn:       ["0_0_0_0_1_0_0_2_0_0"]   (all 3 parents + idx 0)
+        After Passthrough: ["0_0_0_0_1_0_0_2_0_0_0"]
     """
     pipeline = Pipeline(
         name="fanout_fanin",
@@ -244,6 +245,7 @@ def test_pipeline_udid_fanout_passthrough_fanin_passthrough():
     pipeline.build()
 
     root = _SimpleTask(task_id="r", dataset_name="d", data=[1])
+    assign_root_lineage([root])
 
     # Drive stage-by-stage so we can inspect each intermediate set of tasks.
     after_fanout = BaseStageAdapter(pipeline.stages[0]).process_batch([root])
@@ -252,19 +254,19 @@ def test_pipeline_udid_fanout_passthrough_fanin_passthrough():
     after_passthrough_2 = BaseStageAdapter(pipeline.stages[3]).process_batch(after_fanin)
 
     # Expected paths at every level.
-    assert [t._lineage_path for t in after_fanout] == ["0", "1", "2"]
-    assert [t._lineage_path for t in after_passthrough_1] == ["0_0", "1_0", "2_0"]
-    assert [t._lineage_path for t in after_fanin] == ["0_0_1_0_2_0_0"]
-    assert [t._lineage_path for t in after_passthrough_2] == ["0_0_1_0_2_0_0_0"]
+    assert [t._lineage_path for t in after_fanout] == ["0_0", "0_1", "0_2"]
+    assert [t._lineage_path for t in after_passthrough_1] == ["0_0_0", "0_1_0", "0_2_0"]
+    assert [t._lineage_path for t in after_fanin] == ["0_0_0_0_1_0_0_2_0_0"]
+    assert [t._lineage_path for t in after_passthrough_2] == ["0_0_0_0_1_0_0_2_0_0_0"]
 
     # Expected _udid values are exactly sha256(lineage_path)[:32].
     def udid(path: str) -> str:
         return hashlib.sha256(path.encode()).hexdigest()[:32]
 
-    assert [t._udid for t in after_fanout] == [udid("0"), udid("1"), udid("2")]
-    assert [t._udid for t in after_passthrough_1] == [udid("0_0"), udid("1_0"), udid("2_0")]
-    assert [t._udid for t in after_fanin] == [udid("0_0_1_0_2_0_0")]
-    assert [t._udid for t in after_passthrough_2] == [udid("0_0_1_0_2_0_0_0")]
+    assert [t._udid for t in after_fanout] == [udid("0_0"), udid("0_1"), udid("0_2")]
+    assert [t._udid for t in after_passthrough_1] == [udid("0_0_0"), udid("0_1_0"), udid("0_2_0")]
+    assert [t._udid for t in after_fanin] == [udid("0_0_0_0_1_0_0_2_0_0")]
+    assert [t._udid for t in after_passthrough_2] == [udid("0_0_0_0_1_0_0_2_0_0_0")]
 
     # Uniqueness: every task emitted anywhere in the pipeline has a distinct
     # _udid (and a distinct _lineage_path).
@@ -322,20 +324,21 @@ def test_inplace_stage_preserves_lineage():
     pipeline.build()
 
     root = _SimpleTask(task_id="r", dataset_name="d", data=[1])
+    assign_root_lineage([root])
     after_fanout = BaseStageAdapter(pipeline.stages[0]).process_batch([root])
     after_ip1 = BaseStageAdapter(pipeline.stages[1]).process_batch(after_fanout)
     after_ip2 = BaseStageAdapter(pipeline.stages[2]).process_batch(after_ip1)
 
-    # Fan-out gave the children paths "0" and "1". The two in-place stages
+    # Fan-out gave the children paths "0_0" and "0_1". The two in-place stages
     # must NOT extend the lineage path — same instances come back unchanged.
-    assert [t._lineage_path for t in after_fanout] == ["0", "1"]
-    assert [t._lineage_path for t in after_ip1] == ["0", "1"]
-    assert [t._lineage_path for t in after_ip2] == ["0", "1"]
+    assert [t._lineage_path for t in after_fanout] == ["0_0", "0_1"]
+    assert [t._lineage_path for t in after_ip1] == ["0_0", "0_1"]
+    assert [t._lineage_path for t in after_ip2] == ["0_0", "0_1"]
 
     def udid(path: str) -> str:
         return hashlib.sha256(path.encode()).hexdigest()[:32]
 
-    expected_udids = [udid("0"), udid("1")]
+    expected_udids = [udid("0_0"), udid("0_1")]
     assert [t._udid for t in after_fanout] == expected_udids
     assert [t._udid for t in after_ip1] == expected_udids
     assert [t._udid for t in after_ip2] == expected_udids
@@ -343,3 +346,31 @@ def test_inplace_stage_preserves_lineage():
     # Identity check: the in-place stages return the same task instances.
     assert all(a is b for a, b in zip(after_fanout, after_ip1, strict=True))
     assert all(a is b for a, b in zip(after_ip1, after_ip2, strict=True))
+
+
+# ---------------------------------------------------------------------------
+# Multiple root tasks must produce distinct _udid through a 1:1 first stage
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_udid_no_collision_across_multiple_roots():
+    """Multiple root tasks through a 1:1 first stage must produce distinct _udid.
+
+    Without ``assign_root_lineage`` every root carries ``_lineage_path = ""``;
+    the empty-string filter in ``_set_lineage`` then collapses all first-stage
+    children onto the same path ("0"), so their ``_udid`` collides.
+    """
+    pipeline = Pipeline(name="multi_root", stages=[_Passthrough(name="pt")])
+    pipeline.build()
+
+    roots = [
+        _SimpleTask(task_id="r0", dataset_name="d", data=[1]),
+        _SimpleTask(task_id="r1", dataset_name="d", data=[2]),
+        _SimpleTask(task_id="r2", dataset_name="d", data=[3]),
+    ]
+    out = _drive(pipeline, roots)
+
+    paths = [t._lineage_path for t in out]
+    udids = [t._udid for t in out]
+    assert paths == ["0_0", "1_0", "2_0"]
+    assert len(set(udids)) == len(udids)

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
+from dataclasses import dataclass
 from unittest.mock import Mock, patch
 
 import pytest
 
+from nemo_curator.backends.base import BaseStageAdapter
 from nemo_curator.pipeline.pipeline import Pipeline
-from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.stages.base import ProcessingStage, assign_child_lineage
 from nemo_curator.stages.resources import Resources
+from nemo_curator.tasks import Task
 
 
 def test_pipeline_uses_xenna_executor_by_default():
@@ -69,3 +73,219 @@ def test_raises_when_ray_serve_active_with_xenna_and_gpu_stages() -> None:
 
         with pytest.raises(RuntimeError, match="Cannot run XennaExecutor"):
             pipeline.run(executor=mock_executor)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic _udid / _lineage_path end-to-end
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SimpleTask(Task[list[int]]):
+    @property
+    def num_items(self) -> int:
+        return len(self.data) if self.data is not None else 0
+
+    def validate(self) -> bool:
+        return True
+
+
+@dataclass
+class _Repeat(ProcessingStage[_SimpleTask, _SimpleTask]):
+    times: int = 3
+    name: str = "repeat"
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        return [], []
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], []
+
+    def process(self, task: _SimpleTask) -> list[_SimpleTask]:
+        return [
+            _SimpleTask(
+                task_id=f"{task.task_id}_{i}",
+                dataset_name=task.dataset_name,
+                data=task.data,
+            )
+            for i in range(self.times)
+        ]
+
+
+def _drive(pipeline: Pipeline, initial_tasks: list[Task]) -> list[Task]:
+    """Walk a built pipeline by hand, threading tasks through BaseStageAdapter
+    for each stage. This is what every real executor does internally; using it
+    here lets us exercise the determinism contract without needing Ray."""
+    current = initial_tasks
+    for stage in pipeline.stages:
+        current = BaseStageAdapter(stage).process_batch(current)
+    return current
+
+
+def test_pipeline_udid_deterministic_across_runs():
+    def run_once() -> tuple[list[str], list[str]]:
+        pipeline = Pipeline(name="det", stages=[_Repeat(times=2), _Repeat(times=3)])
+        pipeline.build()
+        root = _SimpleTask(task_id="r", dataset_name="d", data=[1, 2])
+        out = _drive(pipeline, [root])
+        return [t._lineage_path for t in out], [t._udid for t in out]
+
+    paths_a, udids_a = run_once()
+    paths_b, udids_b = run_once()
+    assert paths_a == paths_b
+    assert udids_a == udids_b
+    # First-generation outputs use index-only paths because the root task has
+    # an empty _lineage_path. After the second stage the paths should match
+    # the documented "{parent_idx}_{child_idx}" shape.
+    assert paths_a == [f"{i}_{j}" for i in range(2) for j in range(3)]
+    assert udids_a == [hashlib.sha256(p.encode()).hexdigest()[:32] for p in paths_a]
+
+
+# ---------------------------------------------------------------------------
+# Fan-out / passthrough / fan-in topology with explicit expected _udid values
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Passthrough(ProcessingStage[_SimpleTask, _SimpleTask]):
+    name: str = "passthrough"
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        return [], []
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], []
+
+    def process(self, task: _SimpleTask) -> _SimpleTask:
+        return _SimpleTask(
+            task_id=f"{task.task_id}_pt",
+            dataset_name=task.dataset_name,
+            data=task.data,
+        )
+
+
+@dataclass
+class _FanOut(ProcessingStage[_SimpleTask, _SimpleTask]):
+    times: int = 3
+    name: str = "fanout"
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        return [], []
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], []
+
+    def process(self, task: _SimpleTask) -> list[_SimpleTask]:
+        return [
+            _SimpleTask(
+                task_id=f"{task.task_id}_{i}",
+                dataset_name=task.dataset_name,
+                data=task.data,
+            )
+            for i in range(self.times)
+        ]
+
+
+@dataclass
+class _FanIn(ProcessingStage[_SimpleTask, _SimpleTask]):
+    """Overrides `process_batch` to combine the whole batch into a single
+    output. Demonstrates the multi-parent path of `assign_child_lineage`."""
+
+    name: str = "fanin"
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        return [], []
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], []
+
+    def process(self, task: _SimpleTask) -> _SimpleTask:
+        _ = task
+        msg = "FanIn only supports batched execution"
+        raise NotImplementedError(msg)
+
+    def process_batch(self, tasks: list[_SimpleTask]) -> list[_SimpleTask]:
+        combined: list[int] = []
+        for t in tasks:
+            combined.extend(t.data)
+        merged = _SimpleTask(
+            task_id="merged",
+            dataset_name=tasks[0].dataset_name,
+            data=combined,
+        )
+        return assign_child_lineage([t._lineage_path for t in tasks], merged)
+
+
+def test_pipeline_udid_fanout_passthrough_fanin_passthrough():
+    """End-to-end: a 4-stage pipeline that exercises 1:N, 1:1, N:1, 1:1 and
+    verifies the exact `_lineage_path` / `_udid` values at every step.
+
+    Pipeline topology:
+
+        Input ─▶ FanOut(3) ─▶ Passthrough ─▶ FanIn ─▶ Passthrough ─▶ Output
+
+    Starting from one root task (with `_lineage_path = ""`), the framework
+    should produce the following paths:
+
+        After FanOut:      ["0", "1", "2"]
+        After Passthrough: ["0_0", "1_0", "2_0"]
+        After FanIn:       ["0_0_1_0_2_0_0"]      (all 3 parents + idx 0)
+        After Passthrough: ["0_0_1_0_2_0_0_0"]
+    """
+    pipeline = Pipeline(
+        name="fanout_fanin",
+        stages=[
+            _FanOut(times=3),
+            _Passthrough(name="pt1"),
+            _FanIn(),
+            _Passthrough(name="pt2"),
+        ],
+    )
+    pipeline.build()
+
+    root = _SimpleTask(task_id="r", dataset_name="d", data=[1])
+
+    # Drive stage-by-stage so we can inspect each intermediate set of tasks.
+    after_fanout = BaseStageAdapter(pipeline.stages[0]).process_batch([root])
+    after_passthrough_1 = BaseStageAdapter(pipeline.stages[1]).process_batch(after_fanout)
+    after_fanin = BaseStageAdapter(pipeline.stages[2]).process_batch(after_passthrough_1)
+    after_passthrough_2 = BaseStageAdapter(pipeline.stages[3]).process_batch(after_fanin)
+
+    # Expected paths at every level.
+    assert [t._lineage_path for t in after_fanout] == ["0", "1", "2"]
+    assert [t._lineage_path for t in after_passthrough_1] == ["0_0", "1_0", "2_0"]
+    assert [t._lineage_path for t in after_fanin] == ["0_0_1_0_2_0_0"]
+    assert [t._lineage_path for t in after_passthrough_2] == ["0_0_1_0_2_0_0_0"]
+
+    # Expected _udid values are exactly sha256(lineage_path)[:32].
+    def udid(path: str) -> str:
+        return hashlib.sha256(path.encode()).hexdigest()[:32]
+
+    assert [t._udid for t in after_fanout] == [udid("0"), udid("1"), udid("2")]
+    assert [t._udid for t in after_passthrough_1] == [udid("0_0"), udid("1_0"), udid("2_0")]
+    assert [t._udid for t in after_fanin] == [udid("0_0_1_0_2_0_0")]
+    assert [t._udid for t in after_passthrough_2] == [udid("0_0_1_0_2_0_0_0")]
+
+    # Uniqueness: every task emitted anywhere in the pipeline has a distinct
+    # _udid (and a distinct _lineage_path).
+    all_tasks = [*after_fanout, *after_passthrough_1, *after_fanin, *after_passthrough_2]
+    all_udids = [t._udid for t in all_tasks]
+    all_paths = [t._lineage_path for t in all_tasks]
+    assert len(set(all_udids)) == len(all_udids)
+    assert len(set(all_paths)) == len(all_paths)
+
+    # Determinism: running the same pipeline shape over the same input again
+    # yields byte-identical _udid and _lineage_path everywhere.
+    pipeline2 = Pipeline(
+        name="fanout_fanin",
+        stages=[
+            _FanOut(times=3),
+            _Passthrough(name="pt1"),
+            _FanIn(),
+            _Passthrough(name="pt2"),
+        ],
+    )
+    pipeline2.build()
+    second_run = _drive(pipeline2, [_SimpleTask(task_id="r", dataset_name="d", data=[1])])
+    assert [t._lineage_path for t in second_run] == [t._lineage_path for t in after_passthrough_2]
+    assert [t._udid for t in second_run] == [t._udid for t in after_passthrough_2]

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -289,3 +289,57 @@ def test_pipeline_udid_fanout_passthrough_fanin_passthrough():
     second_run = _drive(pipeline2, [_SimpleTask(task_id="r", dataset_name="d", data=[1])])
     assert [t._lineage_path for t in second_run] == [t._lineage_path for t in after_passthrough_2]
     assert [t._udid for t in second_run] == [t._udid for t in after_passthrough_2]
+
+
+# ---------------------------------------------------------------------------
+# In-place stages (process() returns the same task) preserve lineage
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _InPlace(ProcessingStage[_SimpleTask, _SimpleTask]):
+    """Mutates the input task and returns the same instance — the pattern used
+    by ImageEmbeddingStage and ~28 other stages across audio/image/video."""
+
+    name: str = "inplace"
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        return [], []
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], []
+
+    def process(self, task: _SimpleTask) -> _SimpleTask:
+        task.data = [*(task.data or []), 0]
+        return task
+
+
+def test_inplace_stage_preserves_lineage():
+    pipeline = Pipeline(
+        name="inplace",
+        stages=[_Repeat(times=2), _InPlace(name="ip1"), _InPlace(name="ip2")],
+    )
+    pipeline.build()
+
+    root = _SimpleTask(task_id="r", dataset_name="d", data=[1])
+    after_fanout = BaseStageAdapter(pipeline.stages[0]).process_batch([root])
+    after_ip1 = BaseStageAdapter(pipeline.stages[1]).process_batch(after_fanout)
+    after_ip2 = BaseStageAdapter(pipeline.stages[2]).process_batch(after_ip1)
+
+    # Fan-out gave the children paths "0" and "1". The two in-place stages
+    # must NOT extend the lineage path — same instances come back unchanged.
+    assert [t._lineage_path for t in after_fanout] == ["0", "1"]
+    assert [t._lineage_path for t in after_ip1] == ["0", "1"]
+    assert [t._lineage_path for t in after_ip2] == ["0", "1"]
+
+    def udid(path: str) -> str:
+        return hashlib.sha256(path.encode()).hexdigest()[:32]
+
+    expected_udids = [udid("0"), udid("1")]
+    assert [t._udid for t in after_fanout] == expected_udids
+    assert [t._udid for t in after_ip1] == expected_udids
+    assert [t._udid for t in after_ip2] == expected_udids
+
+    # Identity check: the in-place stages return the same task instances.
+    assert all(a is b for a, b in zip(after_fanout, after_ip1, strict=True))
+    assert all(a is b for a, b in zip(after_ip1, after_ip2, strict=True))

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -110,6 +110,20 @@ def test_fanout_udid_from_empty_root():
     assert len({t._uuid for t in output}) == 3
 
 
+def test_set_lineage_is_idempotent():
+    # First assignment fills in path/udid and returns True.
+    task = SimpleTask(task_id="t", dataset_name="d", data=[])
+    assert task._set_lineage(["3"], 0) is True
+    assert task._lineage_path == "3_0"
+    assert task._udid == _sha256_32("3_0")
+
+    # Re-assigning with different parent/index is a no-op and returns False.
+    # This is how the framework detects that a stage returned a task in place.
+    assert task._set_lineage(["7"], 4) is False
+    assert task._lineage_path == "3_0"
+    assert task._udid == _sha256_32("3_0")
+
+
 def test_udid_deterministic_across_runs():
     # Same pipeline run twice over the same input must yield byte-identical
     # _udid / _lineage_path sequences. (`_uuid` will differ because it's a

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 from dataclasses import dataclass
 
+from nemo_curator.backends.base import BaseStageAdapter
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import Task
 
@@ -69,3 +71,61 @@ def test_fanout_tasks_have_unique_uuid():
     assert len(output) == 3
     uuids = [t._uuid for t in output]
     assert len(set(uuids)) == 3, f"Expected unique _uuid per task, got {uuids}"
+
+
+def _sha256_32(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()[:32]
+
+
+def test_lineage_path_and_udid_format():
+    # Empty parent → just the child index
+    task = SimpleTask(task_id="root", dataset_name="t", data=[])
+    task._set_lineage([], 4)
+    assert task._lineage_path == "4"
+    assert task._udid == _sha256_32("4")
+
+    # Single non-empty parent
+    child = SimpleTask(task_id="c", dataset_name="t", data=[])
+    child._set_lineage(["3"], 0)
+    assert child._lineage_path == "3_0"
+    assert child._udid == _sha256_32("3_0")
+
+    # Multi-parent join
+    grandchild = SimpleTask(task_id="g", dataset_name="t", data=[])
+    grandchild._set_lineage(["3_0", "4_1"], 2)
+    assert grandchild._lineage_path == "3_0_4_1_2"
+    assert grandchild._udid == _sha256_32("3_0_4_1_2")
+
+
+def test_fanout_udid_from_empty_root():
+    # Driving through the adapter triggers the default process_batch which
+    # calls assign_child_lineage. Parent _lineage_path is "" (no lineage
+    # assigned yet), so children get indices as their root paths.
+    task = _sample_task()
+    output = BaseStageAdapter(Repeat(times=3)).process_batch([task])
+
+    assert [t._lineage_path for t in output] == ["0", "1", "2"]
+    assert [t._udid for t in output] == [_sha256_32("0"), _sha256_32("1"), _sha256_32("2")]
+    # Original _uuid stays random and unique per task.
+    assert len({t._uuid for t in output}) == 3
+
+
+def test_udid_deterministic_across_runs():
+    # Same pipeline run twice over the same input must yield byte-identical
+    # _udid / _lineage_path sequences. (`_uuid` will differ because it's a
+    # fresh uuid4 each run; that's expected and not what _udid is for.)
+    def run_once() -> tuple[list[str], list[str]]:
+        task = _sample_task()
+        after_first = BaseStageAdapter(Repeat(times=2)).process_batch([task])
+        after_second = BaseStageAdapter(Repeat(times=3)).process_batch(after_first)
+        return (
+            [t._lineage_path for t in after_second],
+            [t._udid for t in after_second],
+        )
+
+    paths_a, udids_a = run_once()
+    paths_b, udids_b = run_once()
+    assert paths_a == paths_b
+    assert udids_a == udids_b
+    # Sanity: lineage paths follow the documented "{parent_idx}_{child_idx}" shape.
+    assert paths_a == [f"{i}_{j}" for i in range(2) for j in range(3)]


### PR DESCRIPTION
## Deterministic task identifiers via DAG-path lineage

### Why

`Task._uuid` is generated by `uuid.uuid4()` on construction, so running the same pipeline twice on the same inputs produces a completely different set of IDs. That makes any kind of caching, checkpointing, or "resume from intermediate output" impossible — and it already affects real code: dedup stages name Parquet files after `_uuid` ([minhash.py:309](nemo_curator/stages/deduplication/fuzzy/minhash.py#L309), [buckets_to_edges.py:83](nemo_curator/stages/deduplication/fuzzy/buckets_to_edges.py#L83), [kmeans.py:235](nemo_curator/stages/deduplication/semantic/kmeans.py#L235)), and `AddId` prefixes document IDs with it ([add_id.py:71](nemo_curator/stages/text/modules/add_id.py#L71)).

### What changed

Two new fields on `Task`, derived from the task's path through the pipeline DAG:

| Field | Meaning |
|---|---|
| `_uuid` | **Unchanged** — still `uuid.uuid4()`. There are existing calls and existing call sites keep working. |
| `_lineage_path` | Underscore-separated index path through the DAG. Propagated to children. E.g. `"3_0_7"` = 4th root, 1st child, 8th grandchild. |
| `_udid` | `sha256(_lineage_path)[:32]` — 32-char hex, deterministic across runs. Use this for cache keys / output filenames. |

Lineage assignment happens at one chokepoint — the default `ProcessingStage.process_batch` calls a new module-level helper, `nemo_curator.stages.base.assign_child_lineage(parent_paths, result)`, on the output of each `process()` call. Stages that override `process_batch` are responsible for calling the helper themselves (documented in the docstring); if they forget, outputs have empty `_lineage_path`/`_udid` — a loud, easy-to-catch failure rather than a silent mis-id.

### Examples

| `_lineage_path` | `_udid` |
|---|---|
| `"3"` (root task, 4th output of first stage) | `4e07408562bedb8b60ce05c1decfe3ad` |
| `"3_0"` (its single child) | `sha256("3_0")[:32]` |
| `"3_0_7"` (further descendant) | `sha256("3_0_7")[:32]` |
| `"0_0_1_0_2_0_0"` (fan-in of 3 parents + idx 0) | `sha256(...)[:32]` |

### Files

| File | Change |
|---|---|
| [`nemo_curator/tasks/tasks.py`](nemo_curator/tasks/tasks.py) | Add `_lineage_path` and `_udid` fields + `_set_lineage(parents, idx)` helper on `Task`. `_uuid` untouched. |
| [`nemo_curator/stages/base.py`](nemo_curator/stages/base.py) | Add module-level `assign_child_lineage(parent_paths, result)` helper; default `process_batch` delegates to it; docstring updates the override contract. |
| [`tests/tasks/test_tasks.py`](tests/tasks/test_tasks.py) | Added `test_lineage_path_and_udid_format`, `test_fanout_udid_from_empty_root`, `test_udid_deterministic_across_runs`. Original `_uuid` uniqueness test kept as-is. |
| [`tests/pipelines/test_pipelines.py`](tests/pipelines/test_pipelines.py) | Added `test_pipeline_udid_deterministic_across_runs` and `test_pipeline_udid_fanout_passthrough_fanin_passthrough` (4-stage topology: fan-out → passthrough → fan-in → passthrough; exercises the multi-parent code path). |

### Trade-offs documented in code

- **Hyperparameter changes do not invalidate `_udid`.** Same DAG shape ⇒ same `_udid`. Clear the cache or version output dirs when changing stage config.
- **Stages overriding `process_batch` must call `assign_child_lineage` themselves.** No magic safety net.
- **`_uuid` stays random.** Anything reading `_uuid` today keeps the same per-run behaviour; new code that needs stability reads `_udid`.

### Test plan


- [x] New unit tests cover root tasks, single-parent fanout, multi-parent join, and end-to-end determinism across two independent runs of the same pipeline.
- [x] Original `test_fanout_tasks_have_unique_uuid` still passes (back-compat for `_uuid` confirmed).
- [x] Writer tests in `tests/stages/text/io/writer/` untouched and still pass — their `mock_uuid4.call_count` assertions remain valid because `_uuid` is unchanged.
