### PR TITLE
fix: allow Ray actor pools to scale to zero

### DIFF
--- a/nemo_curator/backends/experimental/ray_data/utils.py
+++ b/nemo_curator/backends/experimental/ray_data/utils.py
@@ -48,9 +48,11 @@ def calculate_concurrency_for_actors_for_stage(
     if stage.resources.gpus > 0:
         max_gpu_actors = available_gpus // stage.resources.gpus
 
-    # Take the minimum of CPU and GPU constraints
+    # Take the minimum of CPU and GPU constraints. Allow Ray Data to scale
+    # the actor pool down to zero so constrained clusters can free resources
+    # for other stages instead of pinning one actor indefinitely.
     max_actors = min(max_cpu_actors, max_gpu_actors)
-    return (1, int(max_actors))
+    return (0, int(max_actors))
 
 
 def is_actor_stage(stage: ProcessingStage) -> bool:

--- a/nemo_curator/backends/experimental/ray_data/utils.py
+++ b/nemo_curator/backends/experimental/ray_data/utils.py
@@ -26,8 +26,11 @@ def calculate_concurrency_for_actors_for_stage(
         int | tuple[int, int]: Number of actors to use.
             int: Explicit number of workers to use.
             tuple[int, int]: Resource-derived ``(min_actors, max_actors)`` range.
-                For resource-derived actor pools, the minimum is now ``0`` so Ray Data
+                For resource-derived actor pools, the minimum is ``0`` so Ray Data
                 can scale the pool down fully when resources are constrained.
+
+    Raises:
+        RuntimeError: If available resources cannot schedule at least one actor.
     """
     # If explicitly set, use the specified number of workers
     num_workers = stage.num_workers()
@@ -54,6 +57,15 @@ def calculate_concurrency_for_actors_for_stage(
     # the actor pool down to zero so constrained clusters can free resources
     # for other stages instead of pinning one actor indefinitely.
     max_actors = min(max_cpu_actors, max_gpu_actors)
+    if max_actors < 1:
+        msg = (
+            "Insufficient available resources to schedule an actor for "
+            f"{stage.__class__.__name__}: available_cpus={available_cpus}, "
+            f"available_gpus={available_gpus}, required_cpus={stage.resources.cpus}, "
+            f"required_gpus={stage.resources.gpus}."
+        )
+        raise RuntimeError(msg)
+
     return (0, int(max_actors))
 
 

--- a/nemo_curator/backends/experimental/ray_data/utils.py
+++ b/nemo_curator/backends/experimental/ray_data/utils.py
@@ -23,9 +23,11 @@ def calculate_concurrency_for_actors_for_stage(
     Calculate concurrency if we want to spin up actors based on available resources and stage requirements.
 
     Returns:
-        int | tuple[int, int]: Number of actors to use
-            int: Number of workers to use
-            tuple[int, int]: tuple of min / max actors to use and number of workers to use
+        int | tuple[int, int]: Number of actors to use.
+            int: Explicit number of workers to use.
+            tuple[int, int]: Resource-derived ``(min_actors, max_actors)`` range.
+                For resource-derived actor pools, the minimum is now ``0`` so Ray Data
+                can scale the pool down fully when resources are constrained.
     """
     # If explicitly set, use the specified number of workers
     num_workers = stage.num_workers()

--- a/tests/backends/experimental/ray_data/test_utils.py
+++ b/tests/backends/experimental/ray_data/test_utils.py
@@ -77,7 +77,7 @@ class TestCalculateConcurrencyForActorsForStage:
     def test_calculate_concurrency_explicit_num_workers_zero_or_negative(self, mock_get_resources: MagicMock):
         """Test calculate_concurrency when num_workers is explicitly set to 0 or negative."""
         mock_stage = Mock(num_workers=lambda: 0, resources=Resources(cpus=2.0, gpus=0.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 4)
+        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (0, 4)
         mock_get_resources.assert_called_once()
 
     @patch(
@@ -86,7 +86,7 @@ class TestCalculateConcurrencyForActorsForStage:
     def test_calculate_concurrency_cpu_only_constraint(self, mock_get_resources: MagicMock):
         """Test calculate_concurrency with CPU-only constraint."""
         mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=2.0, gpus=0.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 4)
+        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (0, 4)
         mock_get_resources.assert_called_once()
 
     @patch(
@@ -95,7 +95,7 @@ class TestCalculateConcurrencyForActorsForStage:
     def test_calculate_concurrency_gpu_only_constraint(self, mock_get_resources: MagicMock):
         """Test calculate_concurrency with GPU-only constraint."""
         mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=0.0, gpus=1.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 4)
+        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (0, 4)
         mock_get_resources.assert_called_once()
 
     @patch(
@@ -104,7 +104,7 @@ class TestCalculateConcurrencyForActorsForStage:
     def test_calculate_concurrency_both_cpu_gpu_constraints(self, mock_get_resources: MagicMock):
         """Test calculate_concurrency with both CPU and GPU constraints."""
         mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=2.0, gpus=1.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 4)
+        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (0, 4)
         mock_get_resources.assert_called_once()
 
     @patch(
@@ -113,7 +113,7 @@ class TestCalculateConcurrencyForActorsForStage:
     def test_calculate_concurrency_cpu_more_limiting(self, mock_get_resources: MagicMock):
         """Test calculate_concurrency when CPU is more limiting than GPU."""
         mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=2.0, gpus=1.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 2)
+        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (0, 2)
         mock_get_resources.assert_called_once()
 
     @patch(
@@ -122,7 +122,7 @@ class TestCalculateConcurrencyForActorsForStage:
     def test_calculate_concurrency_gpu_more_limiting(self, mock_get_resources: MagicMock):
         """Test calculate_concurrency when GPU is more limiting than CPU."""
         mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=2.0, gpus=1.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 2)
+        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (0, 2)
         mock_get_resources.assert_called_once()
 
     @patch(
@@ -142,7 +142,7 @@ class TestCalculateConcurrencyForActorsForStage:
     def test_calculate_concurrency_insufficient_resources(self, mock_get_resources: MagicMock):
         """Test calculate_concurrency when there are insufficient resources."""
         mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=4.0, gpus=2.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 0)
+        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (0, 0)
         mock_get_resources.assert_called_once()
 
     @patch(
@@ -151,5 +151,5 @@ class TestCalculateConcurrencyForActorsForStage:
     def test_calculate_concurrency_fractional_resources(self, mock_get_resources: MagicMock):
         """Test calculate_concurrency with fractional resource requirements."""
         mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=0.5, gpus=0.25))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 8)
+        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (0, 8)
         mock_get_resources.assert_called_once()

--- a/tests/backends/experimental/ray_data/test_utils.py
+++ b/tests/backends/experimental/ray_data/test_utils.py
@@ -142,7 +142,8 @@ class TestCalculateConcurrencyForActorsForStage:
     def test_calculate_concurrency_insufficient_resources(self, mock_get_resources: MagicMock):
         """Test calculate_concurrency when there are insufficient resources."""
         mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=4.0, gpus=2.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (0, 0)
+        with pytest.raises(RuntimeError, match="Insufficient available resources to schedule an actor"):
+            calculate_concurrency_for_actors_for_stage(mock_stage)
         mock_get_resources.assert_called_once()
 
     @patch(


### PR DESCRIPTION
## Description
Allow Ray Data actor stage concurrency to use a minimum actor count of `0` when it is derived from available resources.

This lets Ray Data scale an actor pool down and free resources for other stages in constrained clusters instead of pinning at least one actor.

Closes #1544.

## Usage
```python
calculate_concurrency_for_actors_for_stage(stage)
# returns (0, max_actors) for resource-derived actor pool concurrency
```

## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Testing
- `uv run ruff check nemo_curator/backends/experimental/ray_data/utils.py tests/backends/experimental/ray_data/test_utils.py`
- `uv run ruff format --check nemo_curator/backends/experimental/ray_data/utils.py tests/backends/experimental/ray_data/test_utils.py`
- `uv run --python 3.12 pytest tests/backends/experimental/ray_data/test_utils.py -q` (blocked locally: NeMo-Curator currently only supports Linux systems; this machine is Darwin)
