### PR TITLE
docs(fern): switch to NVIDIA global theme as source of truth

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -144,7 +144,13 @@ redirects:
 
 title: NeMo Curator
 
-footer: ./components/CustomFooter.tsx
+global-theme: nvidia
+
+# Local override attempt: the `nvidia` global theme hardcodes `right-text: Documentation`.
+# Testing whether a partial child-side `logo:` block can override just the right-text
+# while inheriting the SVGs/height/href from the theme.
+logo:
+  right-text: NeMo Curator
 
 versions:
   - display-name: "Latest · v1.1.2 (26.04)"
@@ -167,47 +173,6 @@ versions:
     path: versions/v25.09.yml
     slug: v25.09
     availability: stable
-
-layout:
-  searchbar-placement: header
-  page-width: 1376px
-  sidebar-width: 248px
-  content-width: 812px
-  tabs-placement: header
-  hide-feedback: true
-
-colors:
-  accentPrimary:
-    dark: "#76B900"
-    light: "#76B900"
-  background:
-    light: "#FFFFFF"
-    dark: "#000000"
-
-theme:
-  page-actions: toolbar
-  footer-nav: minimal
-
-logo:
-  dark: ./assets/NVIDIA_dark.svg
-  light: ./assets/NVIDIA_light.svg
-  height: 20
-  href: /nemo/curator/home/welcome
-  right-text: NeMo Curator
-
-favicon: ./assets/NVIDIA_symbol.svg
-
-js:
-  - url: https://assets.adobedtm.com/5d4962a43b79/c1061d2c5e7b/launch-191c2462b890.min.js
-    strategy: beforeInteractive
-
-
-css:
-  - ./main.css
-
-navbar-links:
-  - type: github
-    value: https://github.com/NVIDIA-NeMo/Curator
 
 libraries:
   nemo-curator:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -8,6 +8,7 @@
 instances:
   - url: nemo-curator.docs.buildwithfern.com/nemo/curator
     custom-domain: docs.nvidia.com/nemo/curator
+    multi-source: true
 
 redirects:
   - source: "/nemo/curator/home"
@@ -186,4 +187,3 @@ libraries:
 experimental:
   mdx-components:
     - ./components
-  basepath-aware: true

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "nvidia",
-  "version": "4.43.1"
+  "version": "5.29.0"
 }


### PR DESCRIPTION
## Summary
- Adopt the `nvidia` global theme published from [NVIDIA/fern-components](https://github.com/NVIDIA/fern-components) by setting `global-theme: nvidia` in `fern/docs.yml`.
- Remove theme-owned fields that will now be inherited at publish time: `logo`, `favicon`, `colors`, `layout`, `theme`, `css`, `js`, `footer`, `navbar-links`.
- Keep child-owned fields: `title`, `instances`, `redirects`, `versions`, `libraries`, `experimental`, and per-version navigation.
- Bump `fern.config.json` to `5.29.0` to align with the theme repo's schema (global-theme requires Fern v5.x).
- Leave a minimal local `logo.right-text: NeMo Curator` to test whether child repos can keep their product name in the header (the theme hardcodes `right-text: Documentation`).

## Why
Centralizes NVIDIA branding so logos, fonts, CSS/JS, and footer policy links live in one upstream repo. Future brand updates land via re-uploading the theme rather than per-repo PRs.

## Open questions for review
- Does the local `logo.right-text` override survive the publish-time merge, or does the theme's value win? Need a Fern cloud preview to confirm — local `fern docs dev` won't fetch the registry theme.
- If the override loses, we'll need to file upstream at `NVIDIA/fern-components` to make `right-text` child-overridable (or drop it from the theme).
- Local theme assets (`fern/main.css`, `fern/assets/NVIDIA_*.svg`, `fern/components/CustomFooter.tsx`) are intentionally left on disk in this PR so we can revert easily. Cleanup PR to follow once the preview looks right.

## Test plan
- [ ] Trigger a Fern cloud preview deploy on this branch.
- [ ] Verify NVIDIA logo, fonts, colors, footer policy links, and OneTrust JS render from the global theme.
- [ ] Verify header shows "NeMo Curator" (override wins) or "Documentation" (theme wins) — record which.
- [ ] Spot-check a couple of pages across `latest`, `main`, `v26.04`, `v26.02`, `v25.09` versions to confirm nav/content are unchanged.
- [ ] Confirm redirects still resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)