### PR TITLE
docs(governance): bootstrap AGENTS.md steward network

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@ tests/stages/deduplication/ @ayushdg @praateekmahajan
 
 # Documentation
 docs/ @NVIDIA-NeMo/docs_team
+fern/ @NVIDIA-NeMo/docs_team
 
 # CI/CD and Build Configuration
 .github/ @NVIDIA-NeMo/automation

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -438,7 +438,7 @@ This framework enables data scientists and engineers to focus on pipeline logic 
 **Status:** Pre Release - This API design is currently under development and may change.
 
 ### Examples and Usage
-For practical examples of the API in action, refer to the quickstart examples in `nemo_curator/examples/quickstart.py` and the tutorial notebooks that demonstrate complete pipeline workflows following these design patterns.
+For practical examples of the API in action, refer to the quickstart in `tutorials/quickstart.py` and the tutorial notebooks under `tutorials/` that demonstrate complete pipeline workflows following these design patterns.
 
 ## File Structure Conventions
 

--- a/.gitignore
+++ b/.gitignore
@@ -155,7 +155,6 @@ data/
 
 # macOS Files
 .DS_Store
-AGENTS.md
 alm_output/
 benchmark_results/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,26 @@
 
 ## North Star
 
-NeMo Curator is a Ray-based, backend-agnostic framework for distributed
-data-curation pipelines across text, image, audio, and video. The same
-pipeline definition must run unchanged on three executors (Xenna, Ray
-Actor Pool, Ray Data). We protect the **single pipeline / many backends**
-contract and the user-facing surfaces that depend on it.
+NeMo Curator builds scalable, configurable pipelines to curate text,
+image, audio, and video datasets for accurate AI applications. Customers
+run trillion-token pretraining, multi-modal corpora, and synthetic data
+generation at multi-node GPU scale. We protect the conditions that make
+this possible:
+
+- **Higher accuracy** — better data, less training compute
+- **Faster processing** — RAPIDS-accelerated dedup, classification, and inference
+- **Scalability** — multi-node, multi-GPU, designed for PB-scale workloads
+- **Classifier models** — state-of-the-art open quality/domain/safety models
+- **Deploy anywhere** — Python APIs, runnable on CSP and on-prem
+
+The architecture rests on three design pillars:
+
+- **Task-centric** — Tasks (`DocumentBatch`, `ImageBatch`, `VideoTask`, `AudioTask`) are the unit of data flowing through pipelines
+- **Map-style** — every stage transforms tasks to tasks; this constraint enables auto-balancing and streaming
+- **Fault tolerant** — stages survive preemption and reschedule; partial state is recoverable
+
+The same pipeline definition must run unchanged across Xenna, Ray Actor
+Pool, and Ray Data executors.
 
 ## Non-Negotiables
 
@@ -19,12 +34,12 @@ contract and the user-facing surfaces that depend on it.
   `Resources` are public ABI (`nemo_curator/stages/base.py`,
   `tasks/tasks.py`, `pipeline/pipeline.py`, `backends/base.py`,
   `stages/resources.py`). Breaks here are Stop-And-Ask.
-- **All stages MUST be fault-tolerant and retry-safe.** Xenna preempts
-  and reschedules; partial state must be idempotent or recoverable.
-- Same pipeline → equivalent results across all three backends. Any
-  executor-specific behavior must be explicitly documented.
+- All stages MUST be fault-tolerant and retry-safe. Xenna preempts and
+  reschedules; partial state must be idempotent or recoverable.
+- Same pipeline → equivalent results across all three backends.
+  Executor-specific behavior must be explicitly documented.
 - GPU code paths degrade gracefully when CUDA/RAPIDS aren't installed.
-  Guard imports; don't crash CPU-only installs.
+  Guard imports outside the dedup tree; don't crash CPU-only installs.
 
 ## Architecture Boundaries
 
@@ -43,15 +58,15 @@ contract and the user-facing surfaces that depend on it.
 ## Governance Alignment
 
 `.github/CODEOWNERS` is the source of truth for human review. AI
-stewards **advise**; CODEOWNERS approve. Route review to the named
-humans when a change crosses their lines — never replace them.
+stewards advise; CODEOWNERS approve. Route review to the named humans
+when a change crosses their lines — never replace them.
 
 Canonical knowledge lives in `fern/`. Cursor rules
 (`.cursor/rules/*.mdc`), Copilot instructions
 (`.github/copilot-instructions.md`), Claude skills (`.claude/skills/`),
 and `AGENTS.md` files extend canonical docs — they do not replace them.
-If important product knowledge is only in an agent artifact, fix `fern/`
-first.
+If important product knowledge is only in an agent artifact, fix
+`fern/` first.
 
 Cross-repo terminology or duplicate-fact conflicts route to
 `@NVIDIA-NeMo/docs_team`. Stewards are repo-local; escalate rather than
@@ -76,7 +91,7 @@ Pause for human review before:
   knobs.
 - Tests and code disagree, or a bug can't be reproduced locally.
 
-## Anti-Patterns (repo-specific)
+## Anti-Patterns
 
 - Adding a backend-specific code path inside a `ProcessingStage`.
   Differences belong in `nemo_curator/backends/<name>/`.
@@ -97,7 +112,7 @@ Pause for human review before:
 
 Each scoped steward is a domain agent with the same operating model:
 
-- **Point of View** — what the domain represents
+- **Point of View** — what the domain represents and why it matters
 - **Protect** — invariants, contracts, quality bars
 - **Contract Checklist** — surfaces to inspect when this domain changes
 - **Advocate** — investments to push for
@@ -106,14 +121,48 @@ Each scoped steward is a domain agent with the same operating model:
 Optional sections — include only when they carry weight a careful
 reader can't infer from the other sections:
 
-- **Do Not** — only for non-obvious local anti-patterns. If a bullet
-  inverts a Protect item, drop it.
-- **Serve Peers** — only for explicit cross-domain obligations. If a
-  bullet just says "keep things in sync," drop it.
+- **Do Not** — only for non-obvious local anti-patterns
+- **Serve Peers** — only for explicit cross-domain obligations
 
 Cross-boundary work includes a **Steward Notes** block in the PR
 description naming consulted stewards, accepted/deferred findings,
 merged duplicates, and required collateral.
+
+## Inference Acceleration Steward (cross-cutting)
+
+The Inference Acceleration Steward is a cross-cutting steward, not
+tied to a single directory. It coordinates the modality, backends,
+synthetic-data, and dedup stewards whenever a change touches an
+inference-bearing stage or the model-serving surface.
+
+Consult it when work changes or creates: a classifier or embedder
+stage, a VLM or LLM stage (captioning, scoring, generation), an
+embedding-model integration for semantic dedup, a `runtime_env` carrying
+model-serving deps (vLLM, TensorRT-LLM, NIM client, Ray Serve, Dynamo),
+or any documented throughput / latency / GPU-utilization claim.
+
+Inference acceleration review asks:
+
+- Is the model running at speed-of-light for its hardware? (TensorRT-LLM,
+  memory optimization, FP8/INT8 quantization, paged attention)
+- Is the serving pattern explicit: in-process (model loaded per stage
+  worker) or server-endpoint (CPU-only Curator stages calling a local
+  model server)?
+- Which model server is used: vLLM is canonical; Ray Serve is preferred
+  for Ray-native ergonomics; Dynamo is supported when NV-optimized
+  inference matters more than integration cost.
+- Does the benchmark capture model + serving stack + hardware? Numbers
+  without that context are noise.
+- For server-endpoint patterns: replica count, concurrency per client,
+  and queue behavior are documented; serialization overhead is measured.
+- For in-process patterns: model fits within stage worker memory budget;
+  GPU memory budgeting is honest.
+- Async scheduling features (e.g., vLLM's `RayExecutorV2`) are adopted
+  when they reduce GPU idle time.
+
+This steward does not replace the modality, backends, or SDG stewards
+— it creates tension when an inference-bearing change crosses their
+boundaries so model serving choices stay coherent across the framework.
 
 ### Contract Checklist (repo-wide)
 
@@ -170,10 +219,12 @@ misleading. P2/P3 = polish or advocacy.
 
 **When to consult:** nearest steward for local work; multiple stewards
 when ownership lines cross; full swarm for site-wide `fern/` IA
-refactors or cross-cutting refactors. Parallelize only when the
-questions are independent — independent stewards surface convergence.
-Route structural, cross-domain, standards-impacting, or
-ownership-affecting decisions to human governance stewards.
+refactors or cross-cutting refactors. **Consult the Inference
+Acceleration Steward** for any inference-bearing or model-serving
+change. Parallelize only when the questions are independent — independent
+stewards surface convergence. Route structural, cross-domain,
+standards-impacting, or ownership-affecting decisions to human
+governance stewards.
 
 Match depth to risk: typo and link fixes ship after automated checks;
 technical-accuracy changes need agent first-pass plus human review;
@@ -240,6 +291,12 @@ the verification recipe.
   but the implementation differs across
   `backends/{xenna,ray_data,ray_actor_pool}/`. *Verify:* grep all
   three adapters for the named feature.
+- **Inference performance regression.** A model-bearing stage's
+  throughput, latency, or GPU utilization drops without explanation,
+  or a new inference path lands without speed-of-light benchmarks
+  (TensorRT-LLM, quantization, paged attention). *Verify:* every
+  inference change carries a benchmark capturing model + serving
+  stack + hardware.
 - **Deduplication CUDA gating.** Dedup example doesn't name the
   `deduplication_cuda12` extras or GPU requirement. Today, importing
   the dedup package itself requires `deduplication_cuda12` (RAPIDS at
@@ -315,7 +372,8 @@ terminology drift. Tune quarterly.
   for user-visible behavior. Release notes in `fern/` only.
 - Tutorials / `quickstart.py` updated when public surface changes, or
   an explicit `no-impact: <reason>` note.
-- Benchmark notes for perf-sensitive changes.
+- Benchmark notes for perf-sensitive changes; inference-bearing
+  changes carry model + serving-stack + hardware context.
 - Every accepted steward finding has proof or an explicit no-impact
   note. Factual P0/P1 findings carry verification status.
 - For doc-shaped PRs: a Content Audit ran; accepted P0s were

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,480 @@
+# Agent Constitution
+
+> Read this file first, then the closest scoped `AGENTS.md` to your change.
+> Scoped stewards live under `nemo_curator/`, `nemo_curator/backends/`,
+> `nemo_curator/stages/{text,video,synthetic,deduplication}/`, `tests/`,
+> `fern/`, `benchmarking/`, and `tutorials/`.
+
+## North Star
+
+NeMo Curator is a Ray-based, backend-agnostic framework for building
+distributed data-curation pipelines across text, image, audio, and video
+modalities. The same pipeline definition must run unchanged on three
+executors (Xenna, Ray Actor Pool, Ray Data). What we protect is the
+**single pipeline / many backends** contract and the user-facing surfaces
+that depend on it.
+
+## Non-Negotiables
+
+- The `ProcessingStage[X, Y]` / `Task[T]` / `Pipeline` / `BaseExecutor`
+  contracts in `nemo_curator/stages/base.py`, `nemo_curator/tasks/tasks.py`,
+  `nemo_curator/pipeline/pipeline.py`, and `nemo_curator/backends/base.py`
+  are the public ABI. Breaking them requires Stop-And-Ask.
+- **All stages MUST be fault-tolerant and retry-safe.** Xenna can preempt
+  and reschedule running tasks. Partial state (half-written files, mutated
+  caches) must be either idempotent on retry or detected and recovered.
+- Same pipeline must produce equivalent results across all three backends.
+  Executor-specific behavior is a leak unless explicitly documented.
+- GPU code paths must degrade gracefully when CUDA/RAPIDS are unavailable.
+  Guard imports; do not crash CPU-only installs.
+- Ruff is the formatter and linter (line length 119). Run `pre-commit run
+  --all-files` before pushing.
+- Commits are signed and signed-off (`git commit -sS`). The DCO and signing
+  steps in `CONTRIBUTING.md` are enforced.
+- `uv.lock` and `pyproject.toml` move together. The `uv-lock` pre-commit
+  hook enforces this.
+
+## Architecture Boundaries
+
+- `nemo_curator/tasks/` — `Task[T]` and modality task types
+  (`DocumentBatch`, `ImageBatch`, `VideoTask`, `AudioTask`,
+  `FileGroupTask`, `InterleavedBatch`). Owner: pipeline-contract steward.
+- `nemo_curator/stages/` — `ProcessingStage[X, Y]`, `CompositeStage`,
+  resources, decorators. Modality subtrees own their own stewards.
+- `nemo_curator/backends/` — Executors and stage adapters. Backend parity
+  steward owns cross-executor equivalence.
+- `nemo_curator/pipeline/` — `Pipeline` and `Workflow` orchestration.
+- `nemo_curator/core/` — `RayClient`, constants, serve. Touches Ray
+  cluster lifecycle.
+- `fern/` — canonical user-facing documentation (Fern site published at
+  `docs.nvidia.com/nemo/curator`). **`docs/` is deprecated**; do not add
+  pages there.
+- `tests/` — mirrors source layout. CPU-default; GPU tests via
+  `@pytest.mark.gpu`. `tests/L0_Unit_Test_CPU.sh` and
+  `tests/L0_Unit_Test_GPU.sh` are the CI entrypoints.
+- `tutorials/` — runnable user-facing examples per modality.
+- `benchmarking/` — perf gates, ALM/audio profiling, nightly benchmarks.
+
+## Governance Alignment
+
+- **Domain/page owners**: `.github/CODEOWNERS` is the source of truth for
+  human review routing. AI stewards advise; CODEOWNERS approve. Stewards
+  must route review to the listed humans when a change crosses their lines
+  (deduplication, text embedders/classifiers, backends, synthetic, video,
+  docs, automation, benchmarking).
+- **Human governance stewards**: `@NVIDIA-NeMo/curator_reviewers` (default),
+  `@NVIDIA-NeMo/docs_team` (docs), `@NVIDIA-NeMo/automation` (CI/build).
+- **Canonical knowledge**: product documentation in `fern/` is the
+  authoritative user-facing layer. Cursor rules (`.cursor/rules/*.mdc`),
+  Copilot instructions (`.github/copilot-instructions.md`), Claude skills
+  (`.claude/skills/`), and these `AGENTS.md` files are agent-facing
+  artifacts that **extend** canonical docs. If important product knowledge
+  is only in an agent artifact, that is a docs bug — fix `fern/` first,
+  then point the artifact at it.
+- **Portfolio coordination**: this repo's docs publish into the NVIDIA
+  NeMo docs portfolio. Cross-repo terminology and duplicate-fact conflicts
+  route to `@NVIDIA-NeMo/docs_team`. Stewards are repo-local; do not add a
+  steward to mediate a cross-repo concern — escalate instead.
+
+## Stakes
+
+- **Users**: copy-paste of stage imports, CLI invocations, or YAML config
+  must work as documented. Fabricated flags or wrong defaults break the
+  first thing a new user tries.
+- **Operators**: Ray cluster lifecycle, GPU memory limits, and autoscaling
+  behavior must match what the docs claim. A wrong retry-policy claim
+  costs node-hours.
+- **Contributors**: the `ProcessingStage` contract is the extension point.
+  Silent breaks in `process()` signature, resource shape, or
+  `inputs/outputs` validation cascade to every downstream stage.
+- **Extension authors** (custom stages, custom executors): the public
+  abstract methods on `ProcessingStage`, `Task`, and `BaseExecutor` are
+  the contract.
+- **Agents** (Claude / Cursor / Copilot): if `AGENTS.md`, cursor rules,
+  copilot instructions, and `fern/` disagree on the same fact, agents
+  produce wrong code. Convergence across these surfaces is non-optional.
+
+## Stop And Ask
+
+Pause and request human review before:
+
+- Changing any signature, default, or return shape on `ProcessingStage`,
+  `Task`, `Pipeline`, `BaseExecutor`, `BaseStageAdapter`, `Resources`, or
+  `RayClient`.
+- Adding a new runtime dependency or a new optional-extras group in
+  `pyproject.toml`.
+- Touching `pyproject.toml`, `uv.lock`, `docker/`, or `.github/workflows/`
+  in ways that change build/release surface.
+- Changing migration paths, on-disk cache layouts, ID-generator behavior
+  in deduplication, or any persistent artifact schema.
+- Anything irreversible: deleting cached artifacts, force-pushing, mass
+  doc deletions, renaming public modules.
+- Security/auth changes, including credentials flows in Ray cluster setup.
+- Changing concurrency model: stage `batch_size`, executor parallelism
+  defaults, autoscaling knobs.
+- Tests and code disagree about behavior, or a bug cannot be reproduced
+  locally.
+
+## Anti-Patterns
+
+- Adding a backend-specific code path inside a `ProcessingStage`. Backend
+  differences belong in adapters under `nemo_curator/backends/<name>/`.
+- Importing `cudf`, `cupy`, `cuml`, or other RAPIDS/CUDA libs at module
+  top level **outside `nemo_curator/stages/deduplication/`**. Use lazy
+  imports inside GPU-only methods so CPU installs still load the module.
+  (Deduplication today imports RAPIDS at module top level and therefore
+  requires `deduplication_cuda12` to import at all — see the
+  Deduplication steward; making those imports lazy is tracked there as
+  active advocacy.)
+- Editing `docs/` to fix a documentation issue. `docs/` is deprecated —
+  fix `fern/` instead. See [fern/AGENTS.md](fern/AGENTS.md).
+- Adding a YAML config field or CLI flag without a corresponding Pydantic
+  / dataclass / argparse declaration. Documented surfaces must trace to
+  a typed source of truth.
+- Skipping `git commit -sS`. Unsigned/un-DCO commits get rejected.
+- Bypassing `uv-lock` pre-commit when `pyproject.toml` changes.
+- Treating `.cursor/rules/`, `.github/copilot-instructions.md`, and these
+  `AGENTS.md` files as redundant. They serve different agents but must
+  agree on facts. Update them together when shared facts change.
+
+## Steward System
+
+Agents read this file plus the closest scoped `AGENTS.md` for the path
+they are touching. Root is the constitution and routing guide. Scoped
+files are domain stewards that own local invariants, refusal patterns,
+docs, tests, examples, and checks.
+
+Each scoped steward follows the same operating model:
+
+- **Point of View** — who/what the domain represents
+- **Protect** — invariants, contracts, quality bars, failure modes
+- **Contract Checklist** — concrete surfaces to inspect when this domain
+  changes
+- **Advocate** — features, fixes, investments to push for
+- **Serve Peers** — upstream/downstream domains needing better contracts,
+  diagnostics, docs, tests
+- **Do Not** — local anti-patterns
+- **Own** — tests, docs, examples, fixtures, maintenance checks
+
+Cross-boundary work includes a **Steward Notes** block in the PR
+description naming which stewards were consulted, which findings were
+accepted, deferred, or merged-as-duplicate, and any required collateral
+(docs/tests/examples) updated in the same PR.
+
+Stewards respect `.github/CODEOWNERS`. When a change affects a path with
+named human owners, the steward's job is to surface the relevant
+invariants and route review to those humans — not to replace them.
+
+### Contract Checklist (repo-wide)
+
+For any cross-surface change, identify every surface that should agree:
+
+- Public API: `ProcessingStage` subclasses, public functions in
+  `nemo_curator/__init__.py`, factory exports
+- Programmatic surface: imports used in tutorials and quickstarts
+- Schema / types: `Task` dataclass fields, `Resources` fields, Pydantic
+  config models
+- Backend adapters: Xenna, Ray Data, Ray Actor Pool — does the change
+  hold across all three?
+- Docs: `fern/` pages that describe the changed surface (find via grep)
+- Examples: `tutorials/<modality>/`, `tutorials/quickstart.py`
+- Tests: unit tests, GPU tests, backend-parity tests
+- Benchmarks: `benchmarking/` configs and runners
+- Changelog: `CHANGELOG.md` for user-visible behavior changes
+- Cursor rules / Copilot instructions: if they describe the changed
+  surface, update them in the same PR
+
+Every accepted finding names required proof and collateral, or
+explicitly says `no collateral: <reason>`. Docs and examples move in the
+same PR as user-facing behavior changes unless synthesis records why
+they are unaffected. Contract-affecting PRs that span backends include a
+parity matrix (API / Xenna / Ray Data / Ray Actor Pool / Docs / Tests).
+
+### Steward Signal Format
+
+```text
+Steward:
+Area:
+Severity: P0/P1/P2/P3
+Invariant:
+Evidence: <source-file:line> [→ <doc-file:line> for content audit]
+User Impact:
+Required Fix:
+Required Proof:
+Collateral:
+Confidence:
+Verification Status: machine-verified / manual-confirmation-needed / not-machine-verifiable
+```
+
+Before synthesis, factual findings must pass a verification gate when
+machine-checkable: grep the source for the flag, trace the schema, run
+the snippet. Findings that cannot be machine-verified must carry
+`manual-confirmation-needed` or `not-machine-verifiable`.
+
+### Convergence
+
+When two or more stewards independently flag the same finding, it is
+automatically P0 regardless of individual severity. Call it out
+explicitly in synthesis: "X stewards independently flagged Y." When the
+same *shape* of finding recurs across audits (fabricated flag,
+miscounted entity, stale version pin, cross-page disagreement), escalate
+to a **Known Regression Pattern** below.
+
+### Steward Swarms
+
+Stewards spawn as independent agents, each reading root plus its closest
+scoped `AGENTS.md`, each advocating only for its domain, each returning
+findings in the Steward Signal Format. The implementing agent owns
+synthesis and final decisions. Keep PR scope bounded to accepted
+findings; defer unrelated suggestions to not-now.
+
+**Triggers**: `ask stewards`, `bugbash`, `review swarm`, `steward
+synthesis` → Implementation Review. `audit docs`, `content audit`,
+`accuracy pass` → Content Audit.
+
+**Implementation Review** (default) — Stewards defend invariants
+against the diff. Severity: P0 breaks a shipped contract, P1 degrades
+without breaking, P2/P3 polish or advocacy. Match depth to risk: typo
+and link fixes move after automated checks; technical-accuracy changes
+need agent first-pass plus human review; cross-domain or
+standards-impacting changes route to human governance stewards.
+
+**Content Audit** — Stewards verify doc claims against source code.
+Findings cite `<source-file:line> → <doc-file:line>` divergence and the
+corrected text. P0: factually wrong (wrong default, missing flag, named
+entity does not exist, copy-paste would break). P1: incomplete, stale,
+or misleading but not wrong. P2/P3: voice and polish. Initial rollout
+gates merge on verified P0; mature rollout gates on P0+P1.
+
+### Global Sweep On Accepted P0s
+
+When a P0 names a wrong factual claim (wrong default, endpoint shape,
+flag name, file path, retry behavior), the fix is not "edit the page
+where it was flagged." The fix is: grep the entire `fern/` site (and
+`tutorials/`, cursor rules, copilot instructions, root `README.md`,
+`api-design.md`) for the same claim and correct every instance before
+the P0 is closed. Stewards check their primary owned surfaces;
+cross-surface propagation is the dominant failure mode of narrow fixes.
+
+### Doc Autopilot
+
+The Content Audit mode is the primary mechanism for keeping docs
+accurate over time. The Docs Steward ([fern/AGENTS.md](fern/AGENTS.md))
+owns the recurring ritual:
+
+1. **Merge gate** — Doc-shaped PRs (IA refactors, release notes, large
+   content updates, README sweeps) gate on a Content Audit having run.
+   Initial rollout: verified P0 only. Mature rollout: P0 and P1
+   actioned or explicitly deferred.
+2. **Periodic re-audit** — Spawn the full swarm at every release
+   boundary (when `fern/versions/v*.yml` lands) and on a recurring
+   cadence (every 4–6 weeks).
+3. **Source-triggered targeted re-audit** — When code touching a
+   documented public surface changes, the relevant scoped steward's
+   Content Audit runs against its owned doc pages (`Own:` list in that
+   steward).
+
+### Docs-First Agent Artifact Evaluation
+
+Before creating or expanding a `.cursor/rules/*.mdc` rule, a
+`.claude/skills/<skill>`, an MCP workflow, a script, a CLI helper, or a
+prompt template:
+
+1. Identify where agents struggle.
+2. Check whether `fern/` is missing, unclear, stale, or scattered.
+3. Fix or restructure `fern/` first when that would solve the problem
+   for both humans and agents.
+4. Create or expand the agent-facing artifact only when docs alone
+   cannot reliably support the workflow.
+5. Record ownership, review path, source docs, maintenance trigger, and
+   evaluation proof for the artifact.
+
+Important product knowledge belongs in `fern/`; agent artifacts point
+back to it.
+
+## Backlog / Roadmap / Prioritization
+
+When asked for prioritization, consult all scoped stewards and produce:
+raw steward signals, confidence, dependencies, risks, convergence,
+minority reports, ranked backlog, not-now items.
+
+## Known Regression Patterns
+
+Seeded from this repo's actual structure and recurring failure modes.
+Stewards in autopilot mode hunt these by default. Each pattern names
+the verification recipe.
+
+- **Fabricated CLI / config fields.** Doc claims a flag, env var, or
+  YAML key that does not exist in source. *Verify*: every flag or config
+  field documented anywhere must trace to a `pyproject.toml` script
+  entry, an argparse declaration, a Pydantic class field, or a
+  dataclass field. Grep the source file.
+- **Stage-contract drift.** Doc claims a `ProcessingStage` accepts /
+  produces a task type or has a resource shape that no longer matches
+  `nemo_curator/stages/base.py` or the stage's own definition. *Verify*:
+  read the stage's `inputs`, `outputs`, `process`, and `resources` and
+  cross-check the doc.
+- **Executor parity drift.** Doc claims a behavior holds for all
+  executors but the implementation differs across
+  `nemo_curator/backends/{xenna,ray_data,ray_actor_pool}/`. *Verify*:
+  grep all three adapters/executors for the named feature.
+- **Deduplication CUDA gating.** Doc or example uses a deduplication
+  stage without naming the `deduplication_cuda12` extras requirement
+  or the GPU prerequisite. *Verify*: every dedup example must state
+  the install extras and minimum GPU. Current reality: top-level RAPIDS
+  imports in `nemo_curator/stages/deduplication/{io_utils.py,
+  exact/identification.py, fuzzy/*.py, semantic/*.py,
+  shuffle_utils/rapidsmpf_shuffler.py}` mean *importing* the dedup
+  package requires `deduplication_cuda12`. Making these lazy is an
+  open advocacy item with the Deduplication steward; until then, dedup
+  docs and tutorials must say so explicitly.
+- **`docs/` vs `fern/` regression.** Edits land in `docs/` instead of
+  `fern/`. *Verify*: `docs/` is deprecated. Any new doc-changing PR
+  that touches `docs/` is a P0 unless it is an explicit
+  decommissioning change.
+- **Doc-snippet rot.** Tutorial or quickstart imports / CLI lines drift
+  from current public surface. *Verify*: every `from nemo_curator...`
+  import in `tutorials/` and `fern/` round-trips against current
+  `nemo_curator/` modules; every CLI invocation matches an actual
+  argparse entrypoint.
+- **Naming and counting drift.** Any doc claim with a count (number of
+  classifiers, supported modalities, backends), a version pin, or an
+  entity name is stale-by-default. *Verify*: re-count or re-verify
+  against current source on every audit pass.
+- **Cross-page inconsistency.** Same fact stated differently across
+  `fern/` pages and `README.md` / `CONTRIBUTING.md` / cursor rules.
+  *Verify*: cross-steward synthesis checks for two surfaces disagreeing
+  on the same fact.
+- **Narrow-fix regression.** A P0 corrected on one page survives on
+  sibling pages and resurfaces in the next audit. *Verify*: every
+  accepted P0 closure runs a global grep for the corrected claim across
+  the entire `fern/` site, plus `tutorials/`, `README.md`,
+  `api-design.md`, `.cursor/rules/`, `.github/copilot-instructions.md`.
+- **Unverified finding regression.** A steward reports a divergence
+  that a source grep would have disproved. *Verify*: every factual P0/P1
+  carries machine-verified / manual-confirmation-needed /
+  not-machine-verifiable before triage.
+
+Add new patterns as audits surface them, each with a verification
+recipe.
+
+## Steward Feedback Loop
+
+- **Steward miss**: when a bug escapes an applicable steward, update
+  the checklist, add a regression test, add a docs/snippet check, or
+  record why the miss should not become policy.
+- **Steward overreach**: when a steward repeatedly pulls unrelated work
+  into PRs, narrow the checklist, split the steward, or move the
+  concern to follow-up.
+- Repeated high-quality findings become checklist items. Repeated
+  convergent findings become Known Regression Patterns.
+- Repeated noisy findings get pruned, clarified, auto-suppressed, or
+  scoped down before reviewers learn to ignore the swarm.
+- **Signal budget**: cap each audit pass at ~10 P2/P3 findings. Beyond
+  that, move to not-now unless convergent.
+- **False-positive target**: track disputed P0/P1; aim under 15% before
+  tightening gates.
+- **Steward health**: track signal-to-noise per steward; below
+  threshold gets reviewed for reduction or retirement.
+
+## Measurement
+
+- **Content health**: owner coverage (CODEOWNERS), `fern/` freshness,
+  broken-link rate (`fern/_fix_broken_links.py` output).
+- **Process health**: PR-to-merge time, pre-commit pass rate, review
+  SLA, steward finding acceptance rate.
+- **Agent readiness**: cursor rules / copilot instructions / `fern/`
+  parity, agent task completion rates.
+- **Steward health**: false-positive rate, P2/P3 volume, convergence
+  rate, recurring Known Regression Patterns.
+- **Cross-domain health**: duplicate-fact incidents, terminology drift,
+  unresolved ownership conflicts.
+
+Tune quarterly: tighten gates that catch real issues, relax gates that
+create friction without value, split or retire noisy stewards, promote
+repeated high-quality findings to checklists or automation.
+
+## When To Consult
+
+- **Proactively consult** stewards for cross-boundary, public-facing,
+  hard-to-reverse, performance-sensitive, concurrency-sensitive,
+  security-sensitive, or contract-affecting work.
+- Use the **nearest** steward for local work.
+- Use **multiple** stewards when ownership lines cross.
+- Parallelize steward consultation only when the questions are
+  independent — independent stewards surface convergence.
+- Keep final synthesis and implementation accountability with the
+  implementing agent.
+- Route structural, cross-domain, standards-impacting,
+  ownership-affecting, or exception/waiver decisions to human governance
+  stewards (CODEOWNERS teams).
+
+### Ask Stewards
+
+For implementation work: consult affected stewards, return synthesis
+before or during the change, include accepted/deferred findings, merged
+duplicates, minority reports, required proof, collateral updates, and
+not-now items.
+
+For content audits: spawn stewards across all domains the docs touch;
+default to all scoped stewards on a site-wide `fern/` IA refactor; run
+the swarm in parallel; synthesize into a triaged P0/P1/P2 punch list
+cited at `file:line`; machine-verify factual claims before triage; for
+every accepted P0 that names a wrong factual claim, grep the whole
+docs site and fix every instance; gate merge on verified P0 during
+initial rollout; keep P2/P3 inside the signal budget; route cross-domain
+conflicts to human governance stewards.
+
+For multi-surface work, include a parity matrix:
+
+| Contract | Public API | Xenna | Ray Data | Ray Actor Pool | Docs (fern) | Tutorials | Tests |
+| -------- | ---------- | ----- | -------- | -------------- | ----------- | --------- | ----- |
+
+## Extension Routing
+
+- Custom stages: subclass `ProcessingStage` in
+  `nemo_curator/stages/<modality>/<area>/`. Register is automatic via
+  `StageMeta`.
+- Custom tasks: subclass `Task[T]` in `nemo_curator/tasks/`.
+- Custom executors: subclass `BaseExecutor` in
+  `nemo_curator/backends/<name>/` with a matching `BaseStageAdapter`.
+- Composite stages: `CompositeStage` in `nemo_curator/stages/base.py`.
+- Per-modality patterns are documented in
+  `.cursor/rules/modality-structure.mdc` and
+  `.cursor/rules/processing-stage-patterns.mdc`.
+
+## Done Criteria
+
+- `pytest` (and `pytest -m gpu` on GPU branches) passes; ruff lint/format
+  passes; `pre-commit run --all-files` is clean
+- `uv.lock` in sync if `pyproject.toml` changed
+- Docs changes land in `fern/` (not `docs/`); changelog updated for
+  user-visible behavior changes; release notes go in `fern/` only
+- Tutorials / `quickstart.py` updated when public surface changes; or an
+  explicit `no-impact: <reason>` note
+- Benchmark notes updated for perf-sensitive changes
+- Every accepted steward finding has test/docs/example/benchmark proof
+  or an explicit no-impact note
+- Factual P0/P1 findings carry verification status
+- For doc-shaped PRs: a Content Audit has run; accepted P0s have been
+  globally grep-swept across `fern/`, `tutorials/`, root docs, cursor
+  rules, and copilot instructions
+- Agent-facing artifact changes (`.cursor/rules/`, `.claude/skills/`,
+  `.github/copilot-instructions.md`) record source docs, owner, review
+  trigger, and docs-first evaluation
+- Commits signed (`-sS`); DCO satisfied
+
+## Review Notes
+
+PR descriptions should flag:
+
+- Weird tests, unused public names, suppressions, dead code
+- Benchmark gaps for perf-sensitive changes
+- Steward disagreement; convergent findings (multiple stewards flagging
+  the same thing)
+- Unverified factual findings
+- Signal/noise threshold breaches
+- Governance exceptions, waivers, timeboxed deferrals
+- Ownership or CODEOWNERS gaps
+- Docs-first evaluation gaps for new agent-facing artifacts
+- Deferred / not-now findings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,194 +1,130 @@
 # Agent Constitution
 
-> Read this file first, then the closest scoped `AGENTS.md` to your change.
-> Scoped stewards live under `nemo_curator/`, `nemo_curator/backends/`,
+> Read this file plus the closest scoped `AGENTS.md` before acting. Scoped
+> stewards: `nemo_curator/`, `nemo_curator/backends/`,
 > `nemo_curator/stages/{text,video,synthetic,deduplication}/`, `tests/`,
-> `fern/`, `benchmarking/`, and `tutorials/`.
+> `fern/`, `benchmarking/`, `tutorials/`.
 
 ## North Star
 
-NeMo Curator is a Ray-based, backend-agnostic framework for building
-distributed data-curation pipelines across text, image, audio, and video
-modalities. The same pipeline definition must run unchanged on three
-executors (Xenna, Ray Actor Pool, Ray Data). What we protect is the
-**single pipeline / many backends** contract and the user-facing surfaces
-that depend on it.
+NeMo Curator is a Ray-based, backend-agnostic framework for distributed
+data-curation pipelines across text, image, audio, and video. The same
+pipeline definition must run unchanged on three executors (Xenna, Ray
+Actor Pool, Ray Data). We protect the **single pipeline / many backends**
+contract and the user-facing surfaces that depend on it.
 
 ## Non-Negotiables
 
-- The `ProcessingStage[X, Y]` / `Task[T]` / `Pipeline` / `BaseExecutor`
-  contracts in `nemo_curator/stages/base.py`, `nemo_curator/tasks/tasks.py`,
-  `nemo_curator/pipeline/pipeline.py`, and `nemo_curator/backends/base.py`
-  are the public ABI. Breaking them requires Stop-And-Ask.
-- **All stages MUST be fault-tolerant and retry-safe.** Xenna can preempt
-  and reschedule running tasks. Partial state (half-written files, mutated
-  caches) must be either idempotent on retry or detected and recovered.
-- Same pipeline must produce equivalent results across all three backends.
-  Executor-specific behavior is a leak unless explicitly documented.
-- GPU code paths must degrade gracefully when CUDA/RAPIDS are unavailable.
-  Guard imports; do not crash CPU-only installs.
-- Ruff is the formatter and linter (line length 119). Run `pre-commit run
-  --all-files` before pushing.
-- Commits are signed and signed-off (`git commit -sS`). The DCO and signing
-  steps in `CONTRIBUTING.md` are enforced.
-- `uv.lock` and `pyproject.toml` move together. The `uv-lock` pre-commit
-  hook enforces this.
+- `ProcessingStage[X, Y]`, `Task[T]`, `Pipeline`, `BaseExecutor`, and
+  `Resources` are public ABI (`nemo_curator/stages/base.py`,
+  `tasks/tasks.py`, `pipeline/pipeline.py`, `backends/base.py`,
+  `stages/resources.py`). Breaks here are Stop-And-Ask.
+- **All stages MUST be fault-tolerant and retry-safe.** Xenna preempts
+  and reschedules; partial state must be idempotent or recoverable.
+- Same pipeline → equivalent results across all three backends. Any
+  executor-specific behavior must be explicitly documented.
+- GPU code paths degrade gracefully when CUDA/RAPIDS aren't installed.
+  Guard imports; don't crash CPU-only installs.
 
 ## Architecture Boundaries
 
-- `nemo_curator/tasks/` — `Task[T]` and modality task types
-  (`DocumentBatch`, `ImageBatch`, `VideoTask`, `AudioTask`,
-  `FileGroupTask`, `InterleavedBatch`). Owner: pipeline-contract steward.
-- `nemo_curator/stages/` — `ProcessingStage[X, Y]`, `CompositeStage`,
-  resources, decorators. Modality subtrees own their own stewards.
-- `nemo_curator/backends/` — Executors and stage adapters. Backend parity
-  steward owns cross-executor equivalence.
-- `nemo_curator/pipeline/` — `Pipeline` and `Workflow` orchestration.
-- `nemo_curator/core/` — `RayClient`, constants, serve. Touches Ray
-  cluster lifecycle.
-- `fern/` — canonical user-facing documentation (Fern site published at
-  `docs.nvidia.com/nemo/curator`). **`docs/` is deprecated**; do not add
-  pages there.
-- `tests/` — mirrors source layout. CPU-default; GPU tests via
-  `@pytest.mark.gpu`. `tests/L0_Unit_Test_CPU.sh` and
-  `tests/L0_Unit_Test_GPU.sh` are the CI entrypoints.
-- `tutorials/` — runnable user-facing examples per modality.
-- `benchmarking/` — perf gates, ALM/audio profiling, nightly benchmarks.
+| Path | Steward / contract |
+| --- | --- |
+| `nemo_curator/tasks/` | `Task[T]` and modality tasks (`DocumentBatch`, `ImageBatch`, `VideoTask`, `AudioTask`, `FileGroupTask`, `InterleavedBatch`) |
+| `nemo_curator/stages/` | `ProcessingStage`, `CompositeStage`, `Resources`. Modality subtrees have their own stewards |
+| `nemo_curator/backends/` | Executors + adapters. Backend parity steward |
+| `nemo_curator/pipeline/` | `Pipeline`, `Workflow` |
+| `nemo_curator/core/` | `RayClient`, Ray cluster lifecycle |
+| `fern/` | **Canonical** user-facing docs (`docs.nvidia.com/nemo/curator`). `docs/` is deprecated |
+| `tests/` | Mirrors source. CPU-default; `@pytest.mark.gpu` for GPU. L0 scripts are CI entrypoints |
+| `tutorials/` | Runnable examples per modality |
+| `benchmarking/` | Perf gates, nightly benchmarks |
 
 ## Governance Alignment
 
-- **Domain/page owners**: `.github/CODEOWNERS` is the source of truth for
-  human review routing. AI stewards advise; CODEOWNERS approve. Stewards
-  must route review to the listed humans when a change crosses their lines
-  (deduplication, text embedders/classifiers, backends, synthetic, video,
-  docs, automation, benchmarking).
-- **Human governance stewards**: `@NVIDIA-NeMo/curator_reviewers` (default),
-  `@NVIDIA-NeMo/docs_team` (docs), `@NVIDIA-NeMo/automation` (CI/build).
-- **Canonical knowledge**: product documentation in `fern/` is the
-  authoritative user-facing layer. Cursor rules (`.cursor/rules/*.mdc`),
-  Copilot instructions (`.github/copilot-instructions.md`), Claude skills
-  (`.claude/skills/`), and these `AGENTS.md` files are agent-facing
-  artifacts that **extend** canonical docs. If important product knowledge
-  is only in an agent artifact, that is a docs bug — fix `fern/` first,
-  then point the artifact at it.
-- **Portfolio coordination**: this repo's docs publish into the NVIDIA
-  NeMo docs portfolio. Cross-repo terminology and duplicate-fact conflicts
-  route to `@NVIDIA-NeMo/docs_team`. Stewards are repo-local; do not add a
-  steward to mediate a cross-repo concern — escalate instead.
+`.github/CODEOWNERS` is the source of truth for human review. AI
+stewards **advise**; CODEOWNERS approve. Route review to the named
+humans when a change crosses their lines — never replace them.
 
-## Stakes
+Canonical knowledge lives in `fern/`. Cursor rules
+(`.cursor/rules/*.mdc`), Copilot instructions
+(`.github/copilot-instructions.md`), Claude skills (`.claude/skills/`),
+and `AGENTS.md` files extend canonical docs — they do not replace them.
+If important product knowledge is only in an agent artifact, fix `fern/`
+first.
 
-- **Users**: copy-paste of stage imports, CLI invocations, or YAML config
-  must work as documented. Fabricated flags or wrong defaults break the
-  first thing a new user tries.
-- **Operators**: Ray cluster lifecycle, GPU memory limits, and autoscaling
-  behavior must match what the docs claim. A wrong retry-policy claim
-  costs node-hours.
-- **Contributors**: the `ProcessingStage` contract is the extension point.
-  Silent breaks in `process()` signature, resource shape, or
-  `inputs/outputs` validation cascade to every downstream stage.
-- **Extension authors** (custom stages, custom executors): the public
-  abstract methods on `ProcessingStage`, `Task`, and `BaseExecutor` are
-  the contract.
-- **Agents** (Claude / Cursor / Copilot): if `AGENTS.md`, cursor rules,
-  copilot instructions, and `fern/` disagree on the same fact, agents
-  produce wrong code. Convergence across these surfaces is non-optional.
+Cross-repo terminology or duplicate-fact conflicts route to
+`@NVIDIA-NeMo/docs_team`. Stewards are repo-local; escalate rather than
+spawning a steward to mediate a cross-repo concern.
 
 ## Stop And Ask
 
-Pause and request human review before:
+Pause for human review before:
 
 - Changing any signature, default, or return shape on `ProcessingStage`,
-  `Task`, `Pipeline`, `BaseExecutor`, `BaseStageAdapter`, `Resources`, or
+  `Task`, `Pipeline`, `BaseExecutor`, `BaseStageAdapter`, `Resources`,
   `RayClient`.
-- Adding a new runtime dependency or a new optional-extras group in
-  `pyproject.toml`.
-- Touching `pyproject.toml`, `uv.lock`, `docker/`, or `.github/workflows/`
-  in ways that change build/release surface.
-- Changing migration paths, on-disk cache layouts, ID-generator behavior
-  in deduplication, or any persistent artifact schema.
-- Anything irreversible: deleting cached artifacts, force-pushing, mass
-  doc deletions, renaming public modules.
-- Security/auth changes, including credentials flows in Ray cluster setup.
-- Changing concurrency model: stage `batch_size`, executor parallelism
-  defaults, autoscaling knobs.
-- Tests and code disagree about behavior, or a bug cannot be reproduced
-  locally.
+- Adding a runtime dependency or extras group; touching `pyproject.toml`
+  / `uv.lock` / `docker/` / `.github/workflows/` in ways that change
+  build or release surface.
+- Migrations, on-disk cache layouts, dedup ID-generator behavior, or
+  any persistent artifact schema.
+- Irreversible operations (mass deletions, force-push, public-module
+  rename).
+- Security / auth changes, Ray cluster auth flows.
+- Concurrency changes: `batch_size`, executor parallelism, autoscaling
+  knobs.
+- Tests and code disagree, or a bug can't be reproduced locally.
 
-## Anti-Patterns
+## Anti-Patterns (repo-specific)
 
-- Adding a backend-specific code path inside a `ProcessingStage`. Backend
-  differences belong in adapters under `nemo_curator/backends/<name>/`.
-- Importing `cudf`, `cupy`, `cuml`, or other RAPIDS/CUDA libs at module
-  top level **outside `nemo_curator/stages/deduplication/`**. Use lazy
-  imports inside GPU-only methods so CPU installs still load the module.
-  (Deduplication today imports RAPIDS at module top level and therefore
-  requires `deduplication_cuda12` to import at all — see the
-  Deduplication steward; making those imports lazy is tracked there as
-  active advocacy.)
-- Editing `docs/` to fix a documentation issue. `docs/` is deprecated —
-  fix `fern/` instead. See [fern/AGENTS.md](fern/AGENTS.md).
-- Adding a YAML config field or CLI flag without a corresponding Pydantic
-  / dataclass / argparse declaration. Documented surfaces must trace to
-  a typed source of truth.
-- Skipping `git commit -sS`. Unsigned/un-DCO commits get rejected.
-- Bypassing `uv-lock` pre-commit when `pyproject.toml` changes.
-- Treating `.cursor/rules/`, `.github/copilot-instructions.md`, and these
-  `AGENTS.md` files as redundant. They serve different agents but must
-  agree on facts. Update them together when shared facts change.
+- Adding a backend-specific code path inside a `ProcessingStage`.
+  Differences belong in `nemo_curator/backends/<name>/`.
+- Importing `cudf`, `cupy`, `cuml`, or other RAPIDS libs at module top
+  level **outside `nemo_curator/stages/deduplication/`**. (Deduplication
+  imports RAPIDS at module top level today; lazy-import work is open
+  advocacy with the Dedup steward.)
+- Editing `docs/` for product reasons — it's deprecated. See
+  [fern/AGENTS.md](fern/AGENTS.md).
+- Documenting a flag, config field, classifier name, codec, or default
+  that doesn't trace to a Pydantic / dataclass / argparse declaration in
+  source.
+- Treating `.cursor/rules/`, `copilot-instructions.md`, and `AGENTS.md`
+  as redundant. They serve different agents but must agree on facts;
+  update them together when shared facts change.
 
 ## Steward System
 
-Agents read this file plus the closest scoped `AGENTS.md` for the path
-they are touching. Root is the constitution and routing guide. Scoped
-files are domain stewards that own local invariants, refusal patterns,
-docs, tests, examples, and checks.
+Each scoped steward is a domain agent with the same operating model:
 
-Each scoped steward follows the same operating model:
+- **Point of View** — what the domain represents
+- **Protect** — invariants, contracts, quality bars
+- **Contract Checklist** — surfaces to inspect when this domain changes
+- **Advocate** — investments to push for
+- **Own** — code, tests, docs, fixtures, checks (with CODEOWNERS routing)
 
-- **Point of View** — who/what the domain represents
-- **Protect** — invariants, contracts, quality bars, failure modes
-- **Contract Checklist** — concrete surfaces to inspect when this domain
-  changes
-- **Advocate** — features, fixes, investments to push for
-- **Serve Peers** — upstream/downstream domains needing better contracts,
-  diagnostics, docs, tests
-- **Do Not** — local anti-patterns
-- **Own** — tests, docs, examples, fixtures, maintenance checks
+Optional sections — include only when they carry weight a careful
+reader can't infer from the other sections:
+
+- **Do Not** — only for non-obvious local anti-patterns. If a bullet
+  inverts a Protect item, drop it.
+- **Serve Peers** — only for explicit cross-domain obligations. If a
+  bullet just says "keep things in sync," drop it.
 
 Cross-boundary work includes a **Steward Notes** block in the PR
-description naming which stewards were consulted, which findings were
-accepted, deferred, or merged-as-duplicate, and any required collateral
-(docs/tests/examples) updated in the same PR.
-
-Stewards respect `.github/CODEOWNERS`. When a change affects a path with
-named human owners, the steward's job is to surface the relevant
-invariants and route review to those humans — not to replace them.
+description naming consulted stewards, accepted/deferred findings,
+merged duplicates, and required collateral.
 
 ### Contract Checklist (repo-wide)
 
-For any cross-surface change, identify every surface that should agree:
-
-- Public API: `ProcessingStage` subclasses, public functions in
-  `nemo_curator/__init__.py`, factory exports
-- Programmatic surface: imports used in tutorials and quickstarts
-- Schema / types: `Task` dataclass fields, `Resources` fields, Pydantic
-  config models
-- Backend adapters: Xenna, Ray Data, Ray Actor Pool — does the change
-  hold across all three?
-- Docs: `fern/` pages that describe the changed surface (find via grep)
-- Examples: `tutorials/<modality>/`, `tutorials/quickstart.py`
-- Tests: unit tests, GPU tests, backend-parity tests
-- Benchmarks: `benchmarking/` configs and runners
-- Changelog: `CHANGELOG.md` for user-visible behavior changes
-- Cursor rules / Copilot instructions: if they describe the changed
-  surface, update them in the same PR
-
-Every accepted finding names required proof and collateral, or
-explicitly says `no collateral: <reason>`. Docs and examples move in the
-same PR as user-facing behavior changes unless synthesis records why
-they are unaffected. Contract-affecting PRs that span backends include a
-parity matrix (API / Xenna / Ray Data / Ray Actor Pool / Docs / Tests).
+For cross-surface changes identify every surface that should agree:
+public API (`ProcessingStage` subclasses, `nemo_curator/__init__.py`),
+schema (`Task`, `Resources`, Pydantic models), all three backend
+adapters, `fern/` pages, `tutorials/`, tests, benchmarks, `CHANGELOG.md`,
+and matching agent artifacts. Every accepted finding names required
+proof and collateral, or explicitly says `no collateral: <reason>`.
+Contract-affecting PRs that span backends include a parity matrix
+(API / Xenna / Ray Data / Ray Actor Pool / Docs / Tests).
 
 ### Steward Signal Format
 
@@ -206,275 +142,189 @@ Confidence:
 Verification Status: machine-verified / manual-confirmation-needed / not-machine-verifiable
 ```
 
-Before synthesis, factual findings must pass a verification gate when
-machine-checkable: grep the source for the flag, trace the schema, run
-the snippet. Findings that cannot be machine-verified must carry
+Factual claims that are machine-checkable must pass a verification gate
+before triage — grep, schema-trace, or signature-check the source.
+Findings that cannot be machine-verified must carry
 `manual-confirmation-needed` or `not-machine-verifiable`.
 
 ### Convergence
 
-When two or more stewards independently flag the same finding, it is
+When two or more stewards independently flag the same finding it is
 automatically P0 regardless of individual severity. Call it out
-explicitly in synthesis: "X stewards independently flagged Y." When the
-same *shape* of finding recurs across audits (fabricated flag,
-miscounted entity, stale version pin, cross-page disagreement), escalate
-to a **Known Regression Pattern** below.
+explicitly in synthesis. When the same *shape* of finding recurs across
+audits, promote it to a **Known Regression Pattern** below.
 
 ### Steward Swarms
 
-Stewards spawn as independent agents, each reading root plus its closest
-scoped `AGENTS.md`, each advocating only for its domain, each returning
-findings in the Steward Signal Format. The implementing agent owns
-synthesis and final decisions. Keep PR scope bounded to accepted
-findings; defer unrelated suggestions to not-now.
+Stewards spawn as independent agents, each reading root plus their
+closest scoped file, each advocating only for their domain, each
+returning findings in the Steward Signal Format. The implementing agent
+owns synthesis and final decisions; stewards advise.
 
-**Triggers**: `ask stewards`, `bugbash`, `review swarm`, `steward
-synthesis` → Implementation Review. `audit docs`, `content audit`,
-`accuracy pass` → Content Audit.
+**Triggers:** `ask stewards`, `bugbash`, `review swarm`, `steward
+synthesis` → **Implementation Review** (defend invariants against the
+diff). `audit docs`, `content audit`, `accuracy pass` → **Content
+Audit** (verify doc claims against source). P0 = breaks a shipped
+contract or names a wrong factual claim. P1 = degrades / stale /
+misleading. P2/P3 = polish or advocacy.
 
-**Implementation Review** (default) — Stewards defend invariants
-against the diff. Severity: P0 breaks a shipped contract, P1 degrades
-without breaking, P2/P3 polish or advocacy. Match depth to risk: typo
-and link fixes move after automated checks; technical-accuracy changes
-need agent first-pass plus human review; cross-domain or
-standards-impacting changes route to human governance stewards.
+**When to consult:** nearest steward for local work; multiple stewards
+when ownership lines cross; full swarm for site-wide `fern/` IA
+refactors or cross-cutting refactors. Parallelize only when the
+questions are independent — independent stewards surface convergence.
+Route structural, cross-domain, standards-impacting, or
+ownership-affecting decisions to human governance stewards.
 
-**Content Audit** — Stewards verify doc claims against source code.
-Findings cite `<source-file:line> → <doc-file:line>` divergence and the
-corrected text. P0: factually wrong (wrong default, missing flag, named
-entity does not exist, copy-paste would break). P1: incomplete, stale,
-or misleading but not wrong. P2/P3: voice and polish. Initial rollout
-gates merge on verified P0; mature rollout gates on P0+P1.
+Match depth to risk: typo and link fixes ship after automated checks;
+technical-accuracy changes need agent first-pass plus human review;
+standards-impacting changes route to `@NVIDIA-NeMo/docs_team` or
+`curator_reviewers`.
 
 ### Global Sweep On Accepted P0s
 
 When a P0 names a wrong factual claim (wrong default, endpoint shape,
-flag name, file path, retry behavior), the fix is not "edit the page
-where it was flagged." The fix is: grep the entire `fern/` site (and
-`tutorials/`, cursor rules, copilot instructions, root `README.md`,
+flag name, file path), the fix is *not* "edit the page where it was
+flagged." The fix is: grep the entire `fern/` site (and `tutorials/`,
+`.cursor/rules/`, `.github/copilot-instructions.md`, `README.md`,
 `api-design.md`) for the same claim and correct every instance before
-the P0 is closed. Stewards check their primary owned surfaces;
-cross-surface propagation is the dominant failure mode of narrow fixes.
+the P0 is closed. Cross-surface propagation is the dominant failure
+mode of narrow fixes.
 
 ### Doc Autopilot
 
-The Content Audit mode is the primary mechanism for keeping docs
+The Content Audit swarm is the primary mechanism for keeping docs
 accurate over time. The Docs Steward ([fern/AGENTS.md](fern/AGENTS.md))
-owns the recurring ritual:
+owns three triggers:
 
 1. **Merge gate** — Doc-shaped PRs (IA refactors, release notes, large
    content updates, README sweeps) gate on a Content Audit having run.
-   Initial rollout: verified P0 only. Mature rollout: P0 and P1
-   actioned or explicitly deferred.
-2. **Periodic re-audit** — Spawn the full swarm at every release
-   boundary (when `fern/versions/v*.yml` lands) and on a recurring
-   cadence (every 4–6 weeks).
-3. **Source-triggered targeted re-audit** — When code touching a
-   documented public surface changes, the relevant scoped steward's
-   Content Audit runs against its owned doc pages (`Own:` list in that
-   steward).
+   Initial rollout: verified P0 only. Mature rollout: P0 + P1.
+2. **Periodic re-audit** — Full swarm at every release boundary (a new
+   `fern/versions/v*.yml` lands) and on a 4–6 week cadence.
+3. **Source-triggered re-audit** — When code touching a documented
+   public surface changes, the relevant scoped steward's Content Audit
+   runs against its owned doc pages.
+
+Each scoped steward's **Own** list is its audit surface in autopilot
+mode. Current state is manual rollout; wiring these into CI is open
+advocacy with the Docs Steward.
 
 ### Docs-First Agent Artifact Evaluation
 
-Before creating or expanding a `.cursor/rules/*.mdc` rule, a
-`.claude/skills/<skill>`, an MCP workflow, a script, a CLI helper, or a
-prompt template:
+Before creating or expanding a cursor rule, Claude skill, MCP workflow,
+script, CLI helper, or prompt template:
 
 1. Identify where agents struggle.
 2. Check whether `fern/` is missing, unclear, stale, or scattered.
-3. Fix or restructure `fern/` first when that would solve the problem
-   for both humans and agents.
-4. Create or expand the agent-facing artifact only when docs alone
-   cannot reliably support the workflow.
-5. Record ownership, review path, source docs, maintenance trigger, and
-   evaluation proof for the artifact.
-
-Important product knowledge belongs in `fern/`; agent artifacts point
-back to it.
-
-## Backlog / Roadmap / Prioritization
-
-When asked for prioritization, consult all scoped stewards and produce:
-raw steward signals, confidence, dependencies, risks, convergence,
-minority reports, ranked backlog, not-now items.
+3. Fix `fern/` first when that would solve the problem for humans and
+   agents alike.
+4. Create the artifact only when docs alone cannot reliably support
+   the workflow.
+5. Record ownership, review path, source docs, maintenance trigger,
+   and evaluation proof for the artifact.
 
 ## Known Regression Patterns
 
-Seeded from this repo's actual structure and recurring failure modes.
 Stewards in autopilot mode hunt these by default. Each pattern names
 the verification recipe.
 
 - **Fabricated CLI / config fields.** Doc claims a flag, env var, or
-  YAML key that does not exist in source. *Verify*: every flag or config
-  field documented anywhere must trace to a `pyproject.toml` script
-  entry, an argparse declaration, a Pydantic class field, or a
-  dataclass field. Grep the source file.
-- **Stage-contract drift.** Doc claims a `ProcessingStage` accepts /
-  produces a task type or has a resource shape that no longer matches
-  `nemo_curator/stages/base.py` or the stage's own definition. *Verify*:
-  read the stage's `inputs`, `outputs`, `process`, and `resources` and
-  cross-check the doc.
-- **Executor parity drift.** Doc claims a behavior holds for all
-  executors but the implementation differs across
-  `nemo_curator/backends/{xenna,ray_data,ray_actor_pool}/`. *Verify*:
-  grep all three adapters/executors for the named feature.
-- **Deduplication CUDA gating.** Doc or example uses a deduplication
-  stage without naming the `deduplication_cuda12` extras requirement
-  or the GPU prerequisite. *Verify*: every dedup example must state
-  the install extras and minimum GPU. Current reality: top-level RAPIDS
-  imports in `nemo_curator/stages/deduplication/{io_utils.py,
-  exact/identification.py, fuzzy/*.py, semantic/*.py,
-  shuffle_utils/rapidsmpf_shuffler.py}` mean *importing* the dedup
-  package requires `deduplication_cuda12`. Making these lazy is an
-  open advocacy item with the Deduplication steward; until then, dedup
-  docs and tutorials must say so explicitly.
-- **`docs/` vs `fern/` regression.** Edits land in `docs/` instead of
-  `fern/`. *Verify*: `docs/` is deprecated. Any new doc-changing PR
-  that touches `docs/` is a P0 unless it is an explicit
-  decommissioning change.
-- **Doc-snippet rot.** Tutorial or quickstart imports / CLI lines drift
-  from current public surface. *Verify*: every `from nemo_curator...`
-  import in `tutorials/` and `fern/` round-trips against current
-  `nemo_curator/` modules; every CLI invocation matches an actual
-  argparse entrypoint.
-- **Naming and counting drift.** Any doc claim with a count (number of
-  classifiers, supported modalities, backends), a version pin, or an
-  entity name is stale-by-default. *Verify*: re-count or re-verify
+  YAML key that doesn't exist. *Verify:* every flag traces to a
+  `pyproject.toml` entry, argparse declaration, Pydantic field, or
+  dataclass field. Grep the source.
+- **Stage-contract drift.** Doc claims `ProcessingStage` input/output
+  types or resource shapes that no longer match
+  `stages/base.py` or the stage's definition. *Verify:* read
+  `inputs`, `outputs`, `process`, `resources` and cross-check.
+- **Executor parity drift.** Doc claims a behavior across executors
+  but the implementation differs across
+  `backends/{xenna,ray_data,ray_actor_pool}/`. *Verify:* grep all
+  three adapters for the named feature.
+- **Deduplication CUDA gating.** Dedup example doesn't name the
+  `deduplication_cuda12` extras or GPU requirement. Today, importing
+  the dedup package itself requires `deduplication_cuda12` (RAPIDS at
+  module top level); until lazy-import work lands, docs and tutorials
+  must say so. *Verify:* grep dedup docs for the install prereq.
+- **`docs/` vs `fern/` regression.** Product edits land in `docs/`
+  instead of `fern/`. *Verify:* any new doc-changing PR that touches
+  `docs/` is a P0 unless explicit decommissioning.
+- **Doc-snippet rot.** `from nemo_curator…` imports or CLI lines in
+  `tutorials/` and `fern/` drift from current public surface.
+  *Verify:* round-trip imports against the package; round-trip CLI
+  lines against argparse.
+- **Naming and counting drift.** Any doc claim with a count, version
+  pin, or named entity is stale-by-default. *Verify:* re-check
   against current source on every audit pass.
 - **Cross-page inconsistency.** Same fact stated differently across
-  `fern/` pages and `README.md` / `CONTRIBUTING.md` / cursor rules.
-  *Verify*: cross-steward synthesis checks for two surfaces disagreeing
-  on the same fact.
-- **Narrow-fix regression.** A P0 corrected on one page survives on
-  sibling pages and resurfaces in the next audit. *Verify*: every
-  accepted P0 closure runs a global grep for the corrected claim across
-  the entire `fern/` site, plus `tutorials/`, `README.md`,
-  `api-design.md`, `.cursor/rules/`, `.github/copilot-instructions.md`.
+  `fern/`, `README.md`, `CONTRIBUTING.md`, cursor rules. *Verify:*
+  cross-steward synthesis explicitly checks for disagreement.
+- **Narrow-fix regression.** A P0 fixed on the flagged page survives
+  on sibling pages. *Verify:* every accepted P0 closure runs the
+  Global Sweep above.
 - **Unverified finding regression.** A steward reports a divergence
-  that a source grep would have disproved. *Verify*: every factual P0/P1
-  carries machine-verified / manual-confirmation-needed /
-  not-machine-verifiable before triage.
+  that a source grep would have disproved. *Verify:* every factual
+  P0/P1 carries a verification status before triage.
 
 Add new patterns as audits surface them, each with a verification
 recipe.
 
 ## Steward Feedback Loop
 
-- **Steward miss**: when a bug escapes an applicable steward, update
-  the checklist, add a regression test, add a docs/snippet check, or
-  record why the miss should not become policy.
-- **Steward overreach**: when a steward repeatedly pulls unrelated work
-  into PRs, narrow the checklist, split the steward, or move the
-  concern to follow-up.
-- Repeated high-quality findings become checklist items. Repeated
-  convergent findings become Known Regression Patterns.
-- Repeated noisy findings get pruned, clarified, auto-suppressed, or
-  scoped down before reviewers learn to ignore the swarm.
-- **Signal budget**: cap each audit pass at ~10 P2/P3 findings. Beyond
-  that, move to not-now unless convergent.
-- **False-positive target**: track disputed P0/P1; aim under 15% before
-  tightening gates.
+- **Miss**: bug escaped an applicable steward → update the checklist,
+  add a regression test, or record why this miss shouldn't become
+  policy.
+- **Overreach**: steward pulls unrelated work into PRs → narrow the
+  checklist, split the steward, move concerns to follow-up.
+- Repeated high-quality findings become checklist items; repeated
+  convergent findings become Known Regression Patterns; repeated
+  noisy findings get pruned or scoped down.
+- **Signal budget**: cap each audit pass at ~10 P2/P3 findings —
+  beyond that, move to not-now unless convergent.
+- **False-positive target**: track disputed P0/P1, aim under 15%
+  before tightening gates.
 - **Steward health**: track signal-to-noise per steward; below
-  threshold gets reviewed for reduction or retirement.
+  threshold gets reduced or retired.
 
 ## Measurement
 
-- **Content health**: owner coverage (CODEOWNERS), `fern/` freshness,
-  broken-link rate (`fern/_fix_broken_links.py` output).
-- **Process health**: PR-to-merge time, pre-commit pass rate, review
-  SLA, steward finding acceptance rate.
-- **Agent readiness**: cursor rules / copilot instructions / `fern/`
-  parity, agent task completion rates.
-- **Steward health**: false-positive rate, P2/P3 volume, convergence
-  rate, recurring Known Regression Patterns.
-- **Cross-domain health**: duplicate-fact incidents, terminology drift,
-  unresolved ownership conflicts.
-
-Tune quarterly: tighten gates that catch real issues, relax gates that
-create friction without value, split or retire noisy stewards, promote
-repeated high-quality findings to checklists or automation.
-
-## When To Consult
-
-- **Proactively consult** stewards for cross-boundary, public-facing,
-  hard-to-reverse, performance-sensitive, concurrency-sensitive,
-  security-sensitive, or contract-affecting work.
-- Use the **nearest** steward for local work.
-- Use **multiple** stewards when ownership lines cross.
-- Parallelize steward consultation only when the questions are
-  independent — independent stewards surface convergence.
-- Keep final synthesis and implementation accountability with the
-  implementing agent.
-- Route structural, cross-domain, standards-impacting,
-  ownership-affecting, or exception/waiver decisions to human governance
-  stewards (CODEOWNERS teams).
-
-### Ask Stewards
-
-For implementation work: consult affected stewards, return synthesis
-before or during the change, include accepted/deferred findings, merged
-duplicates, minority reports, required proof, collateral updates, and
-not-now items.
-
-For content audits: spawn stewards across all domains the docs touch;
-default to all scoped stewards on a site-wide `fern/` IA refactor; run
-the swarm in parallel; synthesize into a triaged P0/P1/P2 punch list
-cited at `file:line`; machine-verify factual claims before triage; for
-every accepted P0 that names a wrong factual claim, grep the whole
-docs site and fix every instance; gate merge on verified P0 during
-initial rollout; keep P2/P3 inside the signal budget; route cross-domain
-conflicts to human governance stewards.
-
-For multi-surface work, include a parity matrix:
-
-| Contract | Public API | Xenna | Ray Data | Ray Actor Pool | Docs (fern) | Tutorials | Tests |
-| -------- | ---------- | ----- | -------- | -------------- | ----------- | --------- | ----- |
+Track: owner coverage (CODEOWNERS), `fern/` freshness and broken-link
+rate, PR-to-merge time, pre-commit pass rate, steward finding
+acceptance rate, false-positive rate, P2/P3 volume, convergence rate,
+recurring Known Regression Patterns, duplicate-fact incidents,
+terminology drift. Tune quarterly.
 
 ## Extension Routing
 
 - Custom stages: subclass `ProcessingStage` in
-  `nemo_curator/stages/<modality>/<area>/`. Register is automatic via
+  `nemo_curator/stages/<modality>/<area>/`. Auto-registered by
   `StageMeta`.
 - Custom tasks: subclass `Task[T]` in `nemo_curator/tasks/`.
 - Custom executors: subclass `BaseExecutor` in
   `nemo_curator/backends/<name>/` with a matching `BaseStageAdapter`.
 - Composite stages: `CompositeStage` in `nemo_curator/stages/base.py`.
-- Per-modality patterns are documented in
-  `.cursor/rules/modality-structure.mdc` and
+- Per-modality patterns documented in
+  `.cursor/rules/modality-structure.mdc`,
   `.cursor/rules/processing-stage-patterns.mdc`.
 
 ## Done Criteria
 
-- `pytest` (and `pytest -m gpu` on GPU branches) passes; ruff lint/format
-  passes; `pre-commit run --all-files` is clean
-- `uv.lock` in sync if `pyproject.toml` changed
-- Docs changes land in `fern/` (not `docs/`); changelog updated for
-  user-visible behavior changes; release notes go in `fern/` only
-- Tutorials / `quickstart.py` updated when public surface changes; or an
-  explicit `no-impact: <reason>` note
-- Benchmark notes updated for perf-sensitive changes
-- Every accepted steward finding has test/docs/example/benchmark proof
-  or an explicit no-impact note
-- Factual P0/P1 findings carry verification status
-- For doc-shaped PRs: a Content Audit has run; accepted P0s have been
-  globally grep-swept across `fern/`, `tutorials/`, root docs, cursor
-  rules, and copilot instructions
-- Agent-facing artifact changes (`.cursor/rules/`, `.claude/skills/`,
-  `.github/copilot-instructions.md`) record source docs, owner, review
-  trigger, and docs-first evaluation
-- Commits signed (`-sS`); DCO satisfied
+- `pytest` (and `pytest -m gpu` for GPU branches), ruff lint/format,
+  and `pre-commit run --all-files` clean.
+- `uv.lock` in sync if `pyproject.toml` changed.
+- Docs changes land in `fern/` (not `docs/`). `CHANGELOG.md` updated
+  for user-visible behavior. Release notes in `fern/` only.
+- Tutorials / `quickstart.py` updated when public surface changes, or
+  an explicit `no-impact: <reason>` note.
+- Benchmark notes for perf-sensitive changes.
+- Every accepted steward finding has proof or an explicit no-impact
+  note. Factual P0/P1 findings carry verification status.
+- For doc-shaped PRs: a Content Audit ran; accepted P0s were
+  globally grep-swept.
+- Agent-facing artifact changes record source docs, owner, review
+  trigger, and docs-first evaluation.
+- Commits signed and signed-off (`-sS`).
 
-## Review Notes
-
-PR descriptions should flag:
-
-- Weird tests, unused public names, suppressions, dead code
-- Benchmark gaps for perf-sensitive changes
-- Steward disagreement; convergent findings (multiple stewards flagging
-  the same thing)
-- Unverified factual findings
-- Signal/noise threshold breaches
-- Governance exceptions, waivers, timeboxed deferrals
-- Ownership or CODEOWNERS gaps
-- Docs-first evaluation gaps for new agent-facing artifacts
-- Deferred / not-now findings
+PR descriptions should flag: convergent findings, unverified factual
+findings, signal/noise breaches, governance exceptions, CODEOWNERS
+gaps, docs-first evaluation gaps for new agent artifacts, deferred /
+not-now findings.

--- a/api-design.md
+++ b/api-design.md
@@ -197,4 +197,4 @@ class RayDataExecutor(BaseExecutor):
 
 ## Examples
 
-Please refer to the [quickstart](./nemo_curator/examples/quickstart.py) for a basic example.
+Please refer to the [quickstart](./tutorials/quickstart.py) for a basic example.

--- a/benchmarking/AGENTS.md
+++ b/benchmarking/AGENTS.md
@@ -1,15 +1,13 @@
 # Steward: Benchmarking & Performance
 
-Performance gates and profiling for NeMo Curator. Covers the nightly
-benchmark suite, ALM (audio language model) and audio profiling, and
-the runners/tools that produce comparable numbers across runs.
+Performance gates and profiling: nightly benchmark suite, ALM (audio
+language model) profiling, audio profiling, and the runners that
+produce comparable numbers across runs.
 
-Related docs:
-
-- root [AGENTS.md](../AGENTS.md)
-- [benchmarking/README.md](README.md)
-- [benchmarking/ALM_BENCHMARK.md](ALM_BENCHMARK.md)
-- [benchmarking/AUDIO_PROFILING.md](AUDIO_PROFILING.md)
+Related: root [AGENTS.md](../AGENTS.md),
+[benchmarking/README.md](README.md),
+[ALM_BENCHMARK.md](ALM_BENCHMARK.md),
+[AUDIO_PROFILING.md](AUDIO_PROFILING.md).
 
 ## Point Of View
 
@@ -19,85 +17,51 @@ and backends — without comparability, benchmarks become noise.
 
 ## Protect
 
-- **Run reproducibility**: a benchmark configuration must produce
-  comparable results when re-run on the same hardware. Pin seeds,
-  data, and software versions where it matters.
-- **Hardware capture**: every result must record what it ran on.
-  Numbers without hardware context cannot be compared.
-- **`benchmarking/test-paths.yaml`** is the canonical list of what
-  the suite runs; PRs that change scope update it.
-- **`nightly-benchmark.yaml`** is wired into CI; changes there
-  require automation team review (per CODEOWNERS).
-- **Result format stability**: downstream tooling consumes results;
+- **Reproducibility.** A benchmark config produces comparable results
+  when re-run on the same hardware. Pin seeds, data, and software
+  versions where it matters.
+- **Hardware capture.** Every result records what it ran on. Numbers
+  without hardware context cannot be compared.
+- **`test-paths.yaml`** is the canonical scope of the suite.
+- **`nightly-benchmark.yaml`** is wired into CI; changes route to
+  automation per CODEOWNERS.
+- **Result schema stability.** Downstream tooling consumes results;
   schema changes are user-visible.
-- **Data preparation isolation** (`data_prep/`): bench input
-  preparation must not silently change between runs.
+- **Data-prep isolation** (`data_prep/`): bench input prep must not
+  silently change between runs.
 
 ## Contract Checklist
 
 When this domain changes:
 
-- `benchmarking/run.py`, `benchmarking/runner/`,
-  `benchmarking/scripts/`, `benchmarking/tools/`
-- `benchmarking/test-paths.yaml`
-- `benchmarking/nightly-benchmark.yaml`
-- `benchmarking/data_prep/`, `benchmarking/tools/`
-- `benchmarking/Dockerfile` — keep aligned with `docker/`
-- `benchmarking/ALM_BENCHMARK.md`, `AUDIO_PROFILING.md`, `README.md`
+- `benchmarking/{run.py,runner/,scripts/,tools/,data_prep/,Dockerfile,test-paths.yaml,nightly-benchmark.yaml}`
+- `benchmarking/{ALM_BENCHMARK,AUDIO_PROFILING,README}.md`
+- `docker/` for runtime-dependency alignment
 - `fern/` performance / benchmarking pages if present
 - `CHANGELOG.md` for user-visible perf regressions or improvements
 
 ## Advocate
 
-- A regression-detection step that compares current results against a
-  baseline and flags > N% slowdowns.
+- Regression detection: compare current results against a baseline
+  and flag > N% slowdowns.
 - A "minimum viable benchmark" recipe for new modality work so perf
   gates exist from day one.
-- Clearer cost/throughput reporting per executor (Xenna vs Ray Data
-  vs Ray Actor Pool).
+- Per-executor cost/throughput reporting (Xenna vs Ray Data vs Ray
+  Actor Pool).
 - Reproducibility instructions in `README.md` that round-trip
   against current runner code.
 
-## Serve Peers
-
-- **To deduplication, video, text stewards**: provide perf signal
-  when their stages change.
-- **To backends steward**: cross-executor perf parity is a primary
-  concern; surface where one executor falls behind another.
-- **To docs steward**: keep perf numbers in `fern/` aligned with
-  current bench output; flag stale numbers.
-
-## Do Not
-
-- Compare numbers across different hardware or software versions
-  without flagging the change.
-- Land a perf-affecting change without re-running affected
-  benchmarks.
-- Edit `nightly-benchmark.yaml` or `scripts/` without routing to
-  `@NVIDIA-NeMo/curator_reviewers` per CODEOWNERS.
-- Use private model artifacts or licensed data that cannot be
-  re-run by other contributors.
-
 ## Own
 
-**Code surfaces**:
+**Code:** `benchmarking/` (entire tree).
 
-- `benchmarking/` (entire tree, minus `scripts/` and
-  `nightly-benchmark.yaml` which route to `curator_reviewers`)
+**Docs (autopilot surface):** `benchmarking/README.md`,
+`ALM_BENCHMARK.md`, `AUDIO_PROFILING.md`; `fern/` performance pages if
+present.
 
-**Tests**: benchmark runs themselves; surface failures as test
-failures where practical.
+**CODEOWNERS:**
 
-**Docs (autopilot audit surface)**:
-
-- `benchmarking/README.md`, `ALM_BENCHMARK.md`, `AUDIO_PROFILING.md`
-- `fern/` benchmarking / performance pages if present (to be pinned
-  in the next docs autopilot pass)
-
-**Agent-facing artifacts**: none scoped to benchmarking yet.
-
-**CODEOWNERS routing**:
-
-- `benchmarking/`: `@rlratzel @praateekmahajan @sarahyurick @ayushdg`
-- `benchmarking/scripts/` and `benchmarking/nightly-benchmark.yaml`:
+- `benchmarking/` → `@rlratzel @praateekmahajan @sarahyurick
+  @ayushdg`
+- `benchmarking/scripts/` and `nightly-benchmark.yaml` →
   `@NVIDIA-NeMo/curator_reviewers` (excludes Rick)

--- a/benchmarking/AGENTS.md
+++ b/benchmarking/AGENTS.md
@@ -1,0 +1,103 @@
+# Steward: Benchmarking & Performance
+
+Performance gates and profiling for NeMo Curator. Covers the nightly
+benchmark suite, ALM (audio language model) and audio profiling, and
+the runners/tools that produce comparable numbers across runs.
+
+Related docs:
+
+- root [AGENTS.md](../AGENTS.md)
+- [benchmarking/README.md](README.md)
+- [benchmarking/ALM_BENCHMARK.md](ALM_BENCHMARK.md)
+- [benchmarking/AUDIO_PROFILING.md](AUDIO_PROFILING.md)
+
+## Point Of View
+
+The numbers that decide whether a change is shippable from a
+performance perspective. Defends comparability across runs, hardware,
+and backends — without comparability, benchmarks become noise.
+
+## Protect
+
+- **Run reproducibility**: a benchmark configuration must produce
+  comparable results when re-run on the same hardware. Pin seeds,
+  data, and software versions where it matters.
+- **Hardware capture**: every result must record what it ran on.
+  Numbers without hardware context cannot be compared.
+- **`benchmarking/test-paths.yaml`** is the canonical list of what
+  the suite runs; PRs that change scope update it.
+- **`nightly-benchmark.yaml`** is wired into CI; changes there
+  require automation team review (per CODEOWNERS).
+- **Result format stability**: downstream tooling consumes results;
+  schema changes are user-visible.
+- **Data preparation isolation** (`data_prep/`): bench input
+  preparation must not silently change between runs.
+
+## Contract Checklist
+
+When this domain changes:
+
+- `benchmarking/run.py`, `benchmarking/runner/`,
+  `benchmarking/scripts/`, `benchmarking/tools/`
+- `benchmarking/test-paths.yaml`
+- `benchmarking/nightly-benchmark.yaml`
+- `benchmarking/data_prep/`, `benchmarking/tools/`
+- `benchmarking/Dockerfile` — keep aligned with `docker/`
+- `benchmarking/ALM_BENCHMARK.md`, `AUDIO_PROFILING.md`, `README.md`
+- `fern/` performance / benchmarking pages if present
+- `CHANGELOG.md` for user-visible perf regressions or improvements
+
+## Advocate
+
+- A regression-detection step that compares current results against a
+  baseline and flags > N% slowdowns.
+- A "minimum viable benchmark" recipe for new modality work so perf
+  gates exist from day one.
+- Clearer cost/throughput reporting per executor (Xenna vs Ray Data
+  vs Ray Actor Pool).
+- Reproducibility instructions in `README.md` that round-trip
+  against current runner code.
+
+## Serve Peers
+
+- **To deduplication, video, text stewards**: provide perf signal
+  when their stages change.
+- **To backends steward**: cross-executor perf parity is a primary
+  concern; surface where one executor falls behind another.
+- **To docs steward**: keep perf numbers in `fern/` aligned with
+  current bench output; flag stale numbers.
+
+## Do Not
+
+- Compare numbers across different hardware or software versions
+  without flagging the change.
+- Land a perf-affecting change without re-running affected
+  benchmarks.
+- Edit `nightly-benchmark.yaml` or `scripts/` without routing to
+  `@NVIDIA-NeMo/curator_reviewers` per CODEOWNERS.
+- Use private model artifacts or licensed data that cannot be
+  re-run by other contributors.
+
+## Own
+
+**Code surfaces**:
+
+- `benchmarking/` (entire tree, minus `scripts/` and
+  `nightly-benchmark.yaml` which route to `curator_reviewers`)
+
+**Tests**: benchmark runs themselves; surface failures as test
+failures where practical.
+
+**Docs (autopilot audit surface)**:
+
+- `benchmarking/README.md`, `ALM_BENCHMARK.md`, `AUDIO_PROFILING.md`
+- `fern/` benchmarking / performance pages if present (to be pinned
+  in the next docs autopilot pass)
+
+**Agent-facing artifacts**: none scoped to benchmarking yet.
+
+**CODEOWNERS routing**:
+
+- `benchmarking/`: `@rlratzel @praateekmahajan @sarahyurick @ayushdg`
+- `benchmarking/scripts/` and `benchmarking/nightly-benchmark.yaml`:
+  `@NVIDIA-NeMo/curator_reviewers` (excludes Rick)

--- a/benchmarking/AGENTS.md
+++ b/benchmarking/AGENTS.md
@@ -1,8 +1,11 @@
 # Steward: Benchmarking & Performance
 
-Performance gates and profiling: nightly benchmark suite, ALM (audio
-language model) profiling, audio profiling, and the runners that
-produce comparable numbers across runs.
+This domain exists because the framework's performance claims need to
+be defensible and reproducible. Curator's value proposition rests on
+specific speedup numbers against CPU baselines and near-linear scaling
+across multi-node multi-GPU setups. Benchmarks that aren't reproducible
+— or aren't captured with hardware and software context — are noise
+that erodes the claims they're meant to support.
 
 Related: root [AGENTS.md](../AGENTS.md),
 [benchmarking/README.md](README.md),
@@ -13,15 +16,18 @@ Related: root [AGENTS.md](../AGENTS.md),
 
 The numbers that decide whether a change is shippable from a
 performance perspective. Defends comparability across runs, hardware,
-and backends — without comparability, benchmarks become noise.
+backends, and software versions. Special concern for
+inference-bearing benchmarks: model + serving stack + hardware are
+always captured; otherwise the result is unattributable.
 
 ## Protect
 
 - **Reproducibility.** A benchmark config produces comparable results
   when re-run on the same hardware. Pin seeds, data, and software
   versions where it matters.
-- **Hardware capture.** Every result records what it ran on. Numbers
-  without hardware context cannot be compared.
+- **Hardware + software capture.** Every result records node type,
+  GPU SKU, software versions, dataset, and (for inference) the model
+  plus serving stack. Numbers without this context cannot be compared.
 - **`test-paths.yaml`** is the canonical scope of the suite.
 - **`nightly-benchmark.yaml`** is wired into CI; changes route to
   automation per CODEOWNERS.
@@ -42,22 +48,29 @@ When this domain changes:
 
 ## Advocate
 
-- Regression detection: compare current results against a baseline
-  and flag > N% slowdowns.
-- A "minimum viable benchmark" recipe for new modality work so perf
-  gates exist from day one.
-- Per-executor cost/throughput reporting (Xenna vs Ray Data vs Ray
-  Actor Pool).
-- Reproducibility instructions in `README.md` that round-trip
+- **Regression detection** — compare current results against a
+  baseline and flag > N% slowdowns.
+- **A "minimum viable benchmark" recipe** for new modality work so
+  perf gates exist from day one.
+- **Per-executor cost/throughput reporting** (Xenna vs Ray Data vs
+  Ray Actor Pool).
+- **Cost framing.** Cost-per-token and cost-per-hour-of-video are
+  the customer-facing metrics; raw throughput is underspecified
+  without them.
+- **Reproducibility instructions** in `README.md` that round-trip
   against current runner code.
+- **Inference benchmark coverage** that captures model + serving
+  stack + hardware on every run, including async-scheduling
+  measurements where supported (coordinate with the Inference
+  Acceleration Steward in root AGENTS.md).
 
 ## Own
 
 **Code:** `benchmarking/` (entire tree).
 
 **Docs (autopilot surface):** `benchmarking/README.md`,
-`ALM_BENCHMARK.md`, `AUDIO_PROFILING.md`; `fern/` performance pages if
-present.
+`ALM_BENCHMARK.md`, `AUDIO_PROFILING.md`; `fern/` performance pages
+if present.
 
 **CODEOWNERS:**
 

--- a/fern/AGENTS.md
+++ b/fern/AGENTS.md
@@ -1,205 +1,120 @@
 # Steward: Documentation (Fern, Canonical)
 
-`fern/` is the canonical, user-facing documentation site published at
-`docs.nvidia.com/nemo/curator`. **`docs/` is deprecated** — do not add
-or edit pages there for product reasons; only decommissioning changes
-land in `docs/`. Release notes go in `fern/` only.
+`fern/` is the canonical user-facing docs site, published at
+`docs.nvidia.com/nemo/curator`. **`docs/` is under a write-freeze
+effective 2026-05-20** — only decommissioning steps land there.
+Release notes go in `fern/` only. This steward owns the Doc Autopilot
+ritual defined in root [AGENTS.md](../AGENTS.md).
 
-This is the **Docs Steward**. It owns the Doc Autopilot ritual that
-keeps the whole docs surface accurate over time.
-
-Related docs:
-
-- root [AGENTS.md](../AGENTS.md) — Doc Autopilot section, Known
-  Regression Patterns
-- `fern/README.md`, `fern/AUTODOCS_GUIDE.md`
-- `requirements-docs.txt`
-- `.claude/skills/nemo-curator-docs/` — the docs skill, which should
-  point back here
+Related: `fern/README.md`, `fern/AUTODOCS_GUIDE.md`,
+`requirements-docs.txt`, `.claude/skills/nemo-curator-docs/`.
 
 ## Point Of View
 
-The user's first contact with NeMo Curator. Defends accuracy of every
-claim made about the product: install steps, CLI flags, classifier
-names, executor selection, GPU prerequisites. Owns the cadence of
-content audits, not just the response to individual doc PRs.
+The user's first contact with NeMo Curator. Defends the accuracy of
+every claim made about the product: install steps, CLI flags,
+classifier names, executor selection, GPU prerequisites. Owns the
+cadence of content audits, not just the response to individual doc
+PRs.
 
 ## Protect
 
-- **Canonicality**: `fern/` is the authoritative user-facing docs
-  source. If an agent-facing artifact (cursor rule, copilot
-  instruction, Claude skill, `AGENTS.md`) carries product knowledge
-  that should be public, fix `fern/` first.
-- **`docs/` write-freeze**: `docs/` is being decommissioned. From
-  this PR forward (2026-05-20), new product-facing changes to `docs/`
-  are a P0; only decommissioning steps (removing pages, deleting
-  redirects, retiring `docs/conf.py`) land there. Existing content
-  in `docs/` (including historical release notes under
-  `docs/about/release-notes/`) is tracked for removal — see Advocate.
-- **Release notes location**: from 2026-05-20 onward, release notes
-  land in `fern/` only. Historical release notes under
-  `docs/about/release-notes/` are scheduled for removal as part of
-  the `docs/` decommission.
-- **Version structure**: `fern/versions/{latest,main,v25.09,v26.02,v26.04}.yml`
-  and matching directories. Adding a version is a coordinated change
-  (versions, redirects, `docs.yml`).
-- **Redirects in `fern/docs.yml`** carry years of inbound links;
-  removing one without checking inbound traffic breaks SEO and
-  bookmarks.
-- **No fabricated CLI flags, config fields, classifier names, codec
-  lists, or version pins.** Every documented surface must trace to a
-  Pydantic field, argparse declaration, class definition, or
-  configuration schema in source.
-- **Snippets and code blocks** must round-trip against current public
-  API: `from nemo_curator…` imports must resolve, CLI invocations
-  must match argparse, `pipeline.add_stage(...)` examples must
-  type-check.
-- **Cross-page consistency**: same fact stated identically across
-  Fern pages, `README.md`, `CONTRIBUTING.md`, `api-design.md`, cursor
+- **Canonicality.** `fern/` is authoritative. Agent-facing artifacts
+  (cursor rules, copilot instructions, Claude skills, AGENTS.md)
+  extend `fern/`; they never replace it. Product knowledge that
+  surfaces only in an agent artifact is a docs bug — fix `fern/`
+  first.
+- **`docs/` write-freeze (effective 2026-05-20).** New product-facing
+  changes to `docs/` are P0. Existing content under `docs/`,
+  including `docs/about/release-notes/`, is tracked for removal — see
+  Advocate.
+- **Versions and redirects.**
+  `fern/versions/{latest,main,v25.09,v26.02,v26.04}.yml` and matching
+  directories. Adding a version coordinates `fern/docs.yml` redirects
+  and inbound-link impact. `fern/docs.yml` redirects carry years of
+  inbound traffic; don't remove without checking traffic.
+- **No fabricated claims.** Every documented flag, config field,
+  classifier name, codec, default, or version pin must trace to source
+  (Pydantic field, argparse declaration, dataclass, class definition,
+  config schema). Every snippet must round-trip:
+  `from nemo_curator…` imports resolve, CLI lines match argparse,
+  `pipeline.add_stage(...)` examples type-check.
+- **Cross-page consistency.** Same fact must read identically across
+  `fern/`, `README.md`, `CONTRIBUTING.md`, `api-design.md`, cursor
   rules, copilot instructions, and tutorials.
-- **Broken-link hygiene**: `fern/_fix_broken_links.py` is the
-  internal tool; `docs/broken_links_*.json` reflects the deprecated
-  Sphinx site's state and is **not** the source of truth for Fern.
-- **Variable substitution**: `fern/substitute_variables.py`
-  (e.g. `{{ current_release }}`, `<release/>`) — do not hand-edit
-  versions where a substitution would apply.
+- **Broken-link tooling.** `fern/_fix_broken_links.py` is the
+  authoritative tool. `docs/broken_links_*.json` reflects the
+  deprecated Sphinx site — ignore it for Fern.
+- **Variable substitution.** `fern/substitute_variables.py` rewrites
+  `{{ current_release }}` / `<release/>`. Don't hand-pin versions
+  where substitution would apply.
 
 ## Contract Checklist
 
-When this domain changes:
+When `fern/` changes:
 
-- `fern/docs.yml` (redirects, instances, structure)
-- `fern/versions/*.yml` and `fern/versions/<name>/` directories
-- `fern/AUTODOCS_GUIDE.md`, `fern/README.md`
-- `fern/components/` — custom React components
-- `fern/main.css`, `fern/assets/`, `fern/package.json`,
+- `fern/docs.yml`, `fern/versions/*.yml` and matching directories
+- `fern/AUTODOCS_GUIDE.md`, `fern/README.md`, `fern/components/`,
+  `fern/main.css`, `fern/assets/`, `fern/package.json`,
   `fern/fern.config.json`
 - `fern/_fix_broken_links.py`, `fern/substitute_variables.py`
 - `requirements-docs.txt`
 - `.claude/skills/nemo-curator-docs/` — keep aligned
-- `.cursor/rules/*.mdc` and `.github/copilot-instructions.md` —
-  any product fact also stated here
+- `.cursor/rules/*.mdc`, `.github/copilot-instructions.md` — any
+  product fact shared with `fern/`
 - `CHANGELOG.md` and release notes (in `fern/`)
 
 For IA refactors, version cuts, and large content updates, run the
-full Content Audit swarm (see root AGENTS.md) and gate merge on
-verified P0.
+full Content Audit swarm and gate merge on verified P0.
 
-## Doc Autopilot (this steward's recurring ritual)
+## Doc Autopilot
 
-The Docs Steward owns three triggers. **Current state: manual
-rollout, automation pending** — there is no CI gate, scheduled job, or
-source-watch wiring yet. Wiring these into `.github/workflows/` is
-open advocacy (below).
+Three triggers defined in root [AGENTS.md](../AGENTS.md) — merge gate,
+periodic re-audit, source-triggered re-audit. **Current state:
+manual rollout, automation pending.** No CI gate, scheduled job, or
+source-watch wiring exists yet. Wiring these into
+`.github/workflows/` is open advocacy below.
 
-1. **Merge gate (per-PR)** — Doc-shaped PRs (IA refactors, release
-   notes, large content updates, README sweeps, any PR touching
-   `fern/`) gate on a Content Audit having run. Initial rollout:
-   verified P0 only. Mature rollout: P0 + P1.
-2. **Periodic re-audit** — At every release boundary (a new
-   `fern/versions/v*.yml` lands or a new tag in `CHANGELOG.md`) and
-   on a recurring 4–6 week cadence, spawn the full Content Audit
-   swarm against the live `fern/` surface.
-3. **Source-triggered targeted re-audit** — When source files change
-   in ways a scoped steward owns (e.g., a classifier renamed in
-   `nemo_curator/stages/text/classifiers/`), that steward's Content
-   Audit runs against its owned doc pages. The Docs Steward surfaces
-   this trigger when reviewing code PRs that touch documented public
-   surface.
-
-Each scoped steward lists its owned doc pages under `Own`. That list
-is the audit surface for that steward in autopilot mode.
+Each scoped steward lists its owned doc pages under **Own**. That
+list is the audit surface for that steward in autopilot mode.
 
 ## Advocate
 
-- Pin the **owned doc paths** in every scoped `AGENTS.md` in the next
-  audit pass. Today most are listed as "canonical paths to be pinned"
-  — close that gap.
-- A site-wide grep tool for the Global Sweep On Accepted P0s rule.
-- Surfacing internal counts (classifiers, embedders, supported
-  codecs) programmatically so docs do not hand-count.
-- A `fern/`-only release-notes template so contributors stop adding
-  notes to `docs/`.
-- Decommission `docs/`: with the 2026-05-20 write-freeze in place,
-  drive the removal — confirm Fern parity for every `docs/` page,
-  delete migrated pages, retire `docs/conf.py`, drop
-  `docs/about/release-notes/`, and remove or rebase any stale
-  redirects.
+- **Pin owned doc paths** in every scoped `AGENTS.md`. Most currently
+  defer this to "the next docs autopilot pass" — close the gap.
+- **Decommission `docs/`** under the 2026-05-20 freeze: confirm Fern
+  parity for every migrated page, retire `docs/conf.py`, drop
+  `docs/about/release-notes/`, remove or rebase stale redirects.
 - **Wire Doc Autopilot triggers into CI**: a `docs-audit-required`
-  PR check for the merge gate; a scheduled workflow for the periodic
-  re-audit; a labels-or-paths trigger for source-triggered re-audits.
-  Mandate is policy until this lands.
-- Track and publish docs health metrics (broken links, freshness,
-  owner coverage) on the cadence in root AGENTS.md Measurement.
-
-## Serve Peers
-
-- **To every scoped steward**: provide a current map of
-  `fern/` pages that touch their domain, so their `Own` list stays
-  pinned to real paths.
-- **To pipeline-contract steward**: keep `api-design.md` and the
-  Fern pipeline/stage/task pages in sync; flag when source-of-truth
-  disagrees with itself.
-- **To backends steward**: keep executor-selection guidance current.
-- **To deduplication, video, synthetic stewards**: surface install
-  prereqs / GPU requirements consistently.
-- **To text steward**: classifier and embedder name lists are the
-  single highest doc-rot surface — audit them on every text-public
-  change.
-- **To human governance stewards** (`@NVIDIA-NeMo/docs_team`): route
-  IA refactors, terminology decisions, cross-repo conflicts, and
-  ownership changes to them.
-
-## Do Not
-
-- Add or edit pages in `docs/` for product reasons. `docs/` is
-  deprecated; release notes and product docs go in `fern/` only.
-- Hand-edit `fern/versions/*.yml` without coordinating
-  redirect changes in `fern/docs.yml`.
-- Document a flag, config field, classifier name, codec, or version
-  pin without verifying it against source.
-- Remove a redirect in `fern/docs.yml` without checking inbound link
-  traffic and search-index coverage.
-- Treat `docs/broken_links_*.json` as authoritative for the Fern
-  site.
-- Pin version numbers where `{{ current_release }}` / `<release/>`
-  substitution should be used.
-- Land a doc-shaped PR without running a Content Audit.
+  PR check for the merge gate, a scheduled workflow for periodic
+  re-audit, a labels-or-paths trigger for source-triggered re-audits.
+- **Programmatic counts** — surface classifier / embedder / codec
+  inventories from source so docs don't hand-count.
+- **Site-wide grep tool** for the Global Sweep On Accepted P0s rule
+  in root AGENTS.md.
+- **Health metrics** — track broken-link rate, freshness, owner
+  coverage on the cadence in root AGENTS.md Measurement.
 
 ## Own
 
-**Code/content surfaces**:
+**Content:**
 
-- `fern/` (entire tree)
+- `fern/` (entire tree); cross-cutting concerns (welcome,
+  getting-started, install, glossary, contributor pages,
+  release-notes) are this steward's direct audit surface. Scoped
+  stewards own their domain pages.
 - `requirements-docs.txt`
+- Release notes (in `fern/`)
 - `CHANGELOG.md` (cross-owned with the implementing area)
-- Release notes (always in `fern/`)
 
-**Tests**:
+**Tests:** any link / lint / structural checks for `fern/` (add a CI
+gate if not present — see Advocate).
 
-- Any link / lint / structural checks for `fern/` (add a CI gate if
-  not present)
+**Agent artifacts:** `.claude/skills/nemo-curator-docs/` (this
+steward owns the skill's accuracy; apply the Docs-First evaluation
+gate before expanding).
 
-**Docs (autopilot audit surface)**:
-
-The Docs Steward audits **every** `fern/` page. Scoped stewards own
-their domain pages; the Docs Steward owns the cross-cutting concerns:
-
-- `fern/docs.yml` — navigation, redirects
-- `fern/versions/*` — version-pinned content
-- Welcome / getting-started / install pages
-- Cross-modality concept pages
-- Release notes
-- Glossary / terminology
-- Contributor / developer pages (cross-owned with tests steward)
-
-**Agent-facing artifacts**:
-
-- `.claude/skills/nemo-curator-docs/` — this steward is the human
-  owner of the skill's accuracy. Apply the Docs-First Agent Artifact
-  Evaluation gate (root AGENTS.md) before expanding it.
-
-**CODEOWNERS routing**: `@NVIDIA-NeMo/docs_team` for both
-`docs/` and `fern/` (the `fern/` entry was added alongside this
-steward; before that, `fern/` fell through to the default reviewers
-team — a real governance gap).
+**CODEOWNERS:** `@NVIDIA-NeMo/docs_team` for both `docs/` and
+`fern/`. The `fern/` entry was added alongside this steward — before
+that, `fern/` fell through to the default reviewers team, a real
+governance gap.

--- a/fern/AGENTS.md
+++ b/fern/AGENTS.md
@@ -1,0 +1,205 @@
+# Steward: Documentation (Fern, Canonical)
+
+`fern/` is the canonical, user-facing documentation site published at
+`docs.nvidia.com/nemo/curator`. **`docs/` is deprecated** — do not add
+or edit pages there for product reasons; only decommissioning changes
+land in `docs/`. Release notes go in `fern/` only.
+
+This is the **Docs Steward**. It owns the Doc Autopilot ritual that
+keeps the whole docs surface accurate over time.
+
+Related docs:
+
+- root [AGENTS.md](../AGENTS.md) — Doc Autopilot section, Known
+  Regression Patterns
+- `fern/README.md`, `fern/AUTODOCS_GUIDE.md`
+- `requirements-docs.txt`
+- `.claude/skills/nemo-curator-docs/` — the docs skill, which should
+  point back here
+
+## Point Of View
+
+The user's first contact with NeMo Curator. Defends accuracy of every
+claim made about the product: install steps, CLI flags, classifier
+names, executor selection, GPU prerequisites. Owns the cadence of
+content audits, not just the response to individual doc PRs.
+
+## Protect
+
+- **Canonicality**: `fern/` is the authoritative user-facing docs
+  source. If an agent-facing artifact (cursor rule, copilot
+  instruction, Claude skill, `AGENTS.md`) carries product knowledge
+  that should be public, fix `fern/` first.
+- **`docs/` write-freeze**: `docs/` is being decommissioned. From
+  this PR forward (2026-05-20), new product-facing changes to `docs/`
+  are a P0; only decommissioning steps (removing pages, deleting
+  redirects, retiring `docs/conf.py`) land there. Existing content
+  in `docs/` (including historical release notes under
+  `docs/about/release-notes/`) is tracked for removal — see Advocate.
+- **Release notes location**: from 2026-05-20 onward, release notes
+  land in `fern/` only. Historical release notes under
+  `docs/about/release-notes/` are scheduled for removal as part of
+  the `docs/` decommission.
+- **Version structure**: `fern/versions/{latest,main,v25.09,v26.02,v26.04}.yml`
+  and matching directories. Adding a version is a coordinated change
+  (versions, redirects, `docs.yml`).
+- **Redirects in `fern/docs.yml`** carry years of inbound links;
+  removing one without checking inbound traffic breaks SEO and
+  bookmarks.
+- **No fabricated CLI flags, config fields, classifier names, codec
+  lists, or version pins.** Every documented surface must trace to a
+  Pydantic field, argparse declaration, class definition, or
+  configuration schema in source.
+- **Snippets and code blocks** must round-trip against current public
+  API: `from nemo_curator…` imports must resolve, CLI invocations
+  must match argparse, `pipeline.add_stage(...)` examples must
+  type-check.
+- **Cross-page consistency**: same fact stated identically across
+  Fern pages, `README.md`, `CONTRIBUTING.md`, `api-design.md`, cursor
+  rules, copilot instructions, and tutorials.
+- **Broken-link hygiene**: `fern/_fix_broken_links.py` is the
+  internal tool; `docs/broken_links_*.json` reflects the deprecated
+  Sphinx site's state and is **not** the source of truth for Fern.
+- **Variable substitution**: `fern/substitute_variables.py`
+  (e.g. `{{ current_release }}`, `<release/>`) — do not hand-edit
+  versions where a substitution would apply.
+
+## Contract Checklist
+
+When this domain changes:
+
+- `fern/docs.yml` (redirects, instances, structure)
+- `fern/versions/*.yml` and `fern/versions/<name>/` directories
+- `fern/AUTODOCS_GUIDE.md`, `fern/README.md`
+- `fern/components/` — custom React components
+- `fern/main.css`, `fern/assets/`, `fern/package.json`,
+  `fern/fern.config.json`
+- `fern/_fix_broken_links.py`, `fern/substitute_variables.py`
+- `requirements-docs.txt`
+- `.claude/skills/nemo-curator-docs/` — keep aligned
+- `.cursor/rules/*.mdc` and `.github/copilot-instructions.md` —
+  any product fact also stated here
+- `CHANGELOG.md` and release notes (in `fern/`)
+
+For IA refactors, version cuts, and large content updates, run the
+full Content Audit swarm (see root AGENTS.md) and gate merge on
+verified P0.
+
+## Doc Autopilot (this steward's recurring ritual)
+
+The Docs Steward owns three triggers. **Current state: manual
+rollout, automation pending** — there is no CI gate, scheduled job, or
+source-watch wiring yet. Wiring these into `.github/workflows/` is
+open advocacy (below).
+
+1. **Merge gate (per-PR)** — Doc-shaped PRs (IA refactors, release
+   notes, large content updates, README sweeps, any PR touching
+   `fern/`) gate on a Content Audit having run. Initial rollout:
+   verified P0 only. Mature rollout: P0 + P1.
+2. **Periodic re-audit** — At every release boundary (a new
+   `fern/versions/v*.yml` lands or a new tag in `CHANGELOG.md`) and
+   on a recurring 4–6 week cadence, spawn the full Content Audit
+   swarm against the live `fern/` surface.
+3. **Source-triggered targeted re-audit** — When source files change
+   in ways a scoped steward owns (e.g., a classifier renamed in
+   `nemo_curator/stages/text/classifiers/`), that steward's Content
+   Audit runs against its owned doc pages. The Docs Steward surfaces
+   this trigger when reviewing code PRs that touch documented public
+   surface.
+
+Each scoped steward lists its owned doc pages under `Own`. That list
+is the audit surface for that steward in autopilot mode.
+
+## Advocate
+
+- Pin the **owned doc paths** in every scoped `AGENTS.md` in the next
+  audit pass. Today most are listed as "canonical paths to be pinned"
+  — close that gap.
+- A site-wide grep tool for the Global Sweep On Accepted P0s rule.
+- Surfacing internal counts (classifiers, embedders, supported
+  codecs) programmatically so docs do not hand-count.
+- A `fern/`-only release-notes template so contributors stop adding
+  notes to `docs/`.
+- Decommission `docs/`: with the 2026-05-20 write-freeze in place,
+  drive the removal — confirm Fern parity for every `docs/` page,
+  delete migrated pages, retire `docs/conf.py`, drop
+  `docs/about/release-notes/`, and remove or rebase any stale
+  redirects.
+- **Wire Doc Autopilot triggers into CI**: a `docs-audit-required`
+  PR check for the merge gate; a scheduled workflow for the periodic
+  re-audit; a labels-or-paths trigger for source-triggered re-audits.
+  Mandate is policy until this lands.
+- Track and publish docs health metrics (broken links, freshness,
+  owner coverage) on the cadence in root AGENTS.md Measurement.
+
+## Serve Peers
+
+- **To every scoped steward**: provide a current map of
+  `fern/` pages that touch their domain, so their `Own` list stays
+  pinned to real paths.
+- **To pipeline-contract steward**: keep `api-design.md` and the
+  Fern pipeline/stage/task pages in sync; flag when source-of-truth
+  disagrees with itself.
+- **To backends steward**: keep executor-selection guidance current.
+- **To deduplication, video, synthetic stewards**: surface install
+  prereqs / GPU requirements consistently.
+- **To text steward**: classifier and embedder name lists are the
+  single highest doc-rot surface — audit them on every text-public
+  change.
+- **To human governance stewards** (`@NVIDIA-NeMo/docs_team`): route
+  IA refactors, terminology decisions, cross-repo conflicts, and
+  ownership changes to them.
+
+## Do Not
+
+- Add or edit pages in `docs/` for product reasons. `docs/` is
+  deprecated; release notes and product docs go in `fern/` only.
+- Hand-edit `fern/versions/*.yml` without coordinating
+  redirect changes in `fern/docs.yml`.
+- Document a flag, config field, classifier name, codec, or version
+  pin without verifying it against source.
+- Remove a redirect in `fern/docs.yml` without checking inbound link
+  traffic and search-index coverage.
+- Treat `docs/broken_links_*.json` as authoritative for the Fern
+  site.
+- Pin version numbers where `{{ current_release }}` / `<release/>`
+  substitution should be used.
+- Land a doc-shaped PR without running a Content Audit.
+
+## Own
+
+**Code/content surfaces**:
+
+- `fern/` (entire tree)
+- `requirements-docs.txt`
+- `CHANGELOG.md` (cross-owned with the implementing area)
+- Release notes (always in `fern/`)
+
+**Tests**:
+
+- Any link / lint / structural checks for `fern/` (add a CI gate if
+  not present)
+
+**Docs (autopilot audit surface)**:
+
+The Docs Steward audits **every** `fern/` page. Scoped stewards own
+their domain pages; the Docs Steward owns the cross-cutting concerns:
+
+- `fern/docs.yml` — navigation, redirects
+- `fern/versions/*` — version-pinned content
+- Welcome / getting-started / install pages
+- Cross-modality concept pages
+- Release notes
+- Glossary / terminology
+- Contributor / developer pages (cross-owned with tests steward)
+
+**Agent-facing artifacts**:
+
+- `.claude/skills/nemo-curator-docs/` — this steward is the human
+  owner of the skill's accuracy. Apply the Docs-First Agent Artifact
+  Evaluation gate (root AGENTS.md) before expanding it.
+
+**CODEOWNERS routing**: `@NVIDIA-NeMo/docs_team` for both
+`docs/` and `fern/` (the `fern/` entry was added alongside this
+steward; before that, `fern/` fell through to the default reviewers
+team — a real governance gap).

--- a/fern/AGENTS.md
+++ b/fern/AGENTS.md
@@ -1,52 +1,63 @@
 # Steward: Documentation (Fern, Canonical)
 
-`fern/` is the canonical user-facing docs site, published at
-`docs.nvidia.com/nemo/curator`. **`docs/` is under a write-freeze
-effective 2026-05-20** — only decommissioning steps land there.
-Release notes go in `fern/` only. This steward owns the Doc Autopilot
-ritual defined in root [AGENTS.md](../AGENTS.md).
+This domain exists because documentation is now consumed by humans
+*and* agents — both are first-class users. Modern documentation has to
+support local and global chat, MCP-driven workflows, `llms.txt`,
+agent-readable markdown, and fast publishing without sacrificing
+search or human navigation. `fern/` is the canonical site
+(`docs.nvidia.com/nemo/curator`) that meets those needs; `docs/` is
+the deprecated Sphinx tree being decommissioned. **A write-freeze on
+`docs/` is in effect from 2026-05-20** — only decommissioning steps
+land there. Release notes go in `fern/` only. This steward owns the
+Doc Autopilot ritual defined in root [AGENTS.md](../AGENTS.md).
 
 Related: `fern/README.md`, `fern/AUTODOCS_GUIDE.md`,
 `requirements-docs.txt`, `.claude/skills/nemo-curator-docs/`.
 
 ## Point Of View
 
-The user's first contact with NeMo Curator. Defends the accuracy of
-every claim made about the product: install steps, CLI flags,
-classifier names, executor selection, GPU prerequisites. Owns the
-cadence of content audits, not just the response to individual doc
-PRs.
+The user's first contact with NeMo Curator — and increasingly an
+agent's first contact too. Defends accuracy of every product claim
+(install steps, CLI flags, classifier names, executor selection, GPU
+prerequisites), the agentic surface features that let other agents
+work the docs (Ask AI, llms.txt, View as Markdown, MCP), and the
+cadence of content audits over time. Treats canonicality of `fern/`
+as a load-bearing rule, not a preference: when an agent-facing
+artifact carries product knowledge that should be public, that's a
+docs bug — fix `fern/` first.
 
 ## Protect
 
 - **Canonicality.** `fern/` is authoritative. Agent-facing artifacts
   (cursor rules, copilot instructions, Claude skills, AGENTS.md)
-  extend `fern/`; they never replace it. Product knowledge that
-  surfaces only in an agent artifact is a docs bug — fix `fern/`
-  first.
+  extend `fern/`; they never replace it.
 - **`docs/` write-freeze (effective 2026-05-20).** New product-facing
   changes to `docs/` are P0. Existing content under `docs/`,
-  including `docs/about/release-notes/`, is tracked for removal — see
-  Advocate.
+  including `docs/about/release-notes/`, is tracked for removal —
+  see Advocate.
+- **Agentic surface features** are product features, not extras:
+  - Local and global chat (Ask AI on every page)
+  - `llms.txt` and machine-readable markdown views
+  - Copy page, View as Markdown, Open in Cloud
+  - MCP server integration
+  - Algolia-powered search
+  - Dashboard for search and chat analytics
 - **Versions and redirects.**
   `fern/versions/{latest,main,v25.09,v26.02,v26.04}.yml`, with
-  matching directories for `main` and each `vYY.MM`. `latest.yml`
-  is redirect-only (no `latest/` directory). Adding a version
-  coordinates `fern/docs.yml` redirects and inbound-link impact;
-  redirects carry years of inbound traffic, so don't remove without
-  checking traffic.
+  matching directories for `main` and each `vYY.MM` (`latest.yml`
+  is redirect-only — no `latest/` directory). Adding a version
+  coordinates `fern/docs.yml` redirects and inbound-link impact.
 - **No fabricated claims.** Every documented flag, config field,
-  classifier name, codec, default, or version pin must trace to source
-  (Pydantic field, argparse declaration, dataclass, class definition,
-  config schema). Every snippet must round-trip:
-  `from nemo_curator…` imports resolve, CLI lines match argparse,
+  classifier name, codec, default, or version pin must trace to
+  source. Every snippet must round-trip: `from nemo_curator…`
+  imports resolve, CLI lines match argparse,
   `pipeline.add_stage(...)` examples type-check.
 - **Cross-page consistency.** Same fact must read identically across
   `fern/`, `README.md`, `CONTRIBUTING.md`, `api-design.md`, cursor
   rules, copilot instructions, and tutorials.
-- **Broken-link tooling.** `fern/_fix_broken_links.py` is the
-  authoritative tool. `docs/broken_links_*.json` reflects the
-  deprecated Sphinx site — ignore it for Fern.
+- **Broken-link tooling.** `fern/_fix_broken_links.py` is
+  authoritative for Fern. `docs/broken_links_*.json` reflects the
+  deprecated Sphinx site — ignore for Fern.
 - **Variable substitution.** `fern/substitute_variables.py` rewrites
   `{{ current_release }}` / `<release/>`. Don't hand-pin versions
   where substitution would apply.
@@ -117,6 +128,4 @@ steward owns the skill's accuracy; apply the Docs-First evaluation
 gate before expanding).
 
 **CODEOWNERS:** `@NVIDIA-NeMo/docs_team` for both `docs/` and
-`fern/`. The `fern/` entry was added alongside this steward — before
-that, `fern/` fell through to the default reviewers team, a real
-governance gap.
+`fern/`.

--- a/fern/AGENTS.md
+++ b/fern/AGENTS.md
@@ -29,10 +29,12 @@ PRs.
   including `docs/about/release-notes/`, is tracked for removal — see
   Advocate.
 - **Versions and redirects.**
-  `fern/versions/{latest,main,v25.09,v26.02,v26.04}.yml` and matching
-  directories. Adding a version coordinates `fern/docs.yml` redirects
-  and inbound-link impact. `fern/docs.yml` redirects carry years of
-  inbound traffic; don't remove without checking traffic.
+  `fern/versions/{latest,main,v25.09,v26.02,v26.04}.yml`, with
+  matching directories for `main` and each `vYY.MM`. `latest.yml`
+  is redirect-only (no `latest/` directory). Adding a version
+  coordinates `fern/docs.yml` redirects and inbound-link impact;
+  redirects carry years of inbound traffic, so don't remove without
+  checking traffic.
 - **No fabricated claims.** Every documented flag, config field,
   classifier name, codec, default, or version pin must trace to source
   (Pydantic field, argparse declaration, dataclass, class definition,

--- a/nemo_curator/AGENTS.md
+++ b/nemo_curator/AGENTS.md
@@ -1,0 +1,185 @@
+# Steward: Pipeline & Stage Contract
+
+The `Task` / `ProcessingStage` / `Pipeline` triad is the public ABI of
+NeMo Curator. Every modality stage, every backend adapter, and every
+tutorial depends on it. Breaks here cascade to everything downstream.
+
+Related docs:
+
+- root [AGENTS.md](../AGENTS.md)
+- [api-design.md](../api-design.md) — the canonical design statement
+- `.cursor/rules/pipeline-structure.mdc`,
+  `processing-stage-patterns.mdc`, `task-patterns.mdc`,
+  `composite-stage-patterns.mdc`, `resources-configuration.mdc`
+- `fern/` pipeline/stage/task concept pages
+
+## Point Of View
+
+The framework's spine — the contract that lets users define a pipeline
+once and run it across Xenna, Ray Data, and Ray Actor Pool. Defends
+abstractions against backend leakage, modality leakage, and convenience
+shortcuts that quietly break the parity promise.
+
+## Protect
+
+- **Public ABI surfaces** (changes here are Stop-And-Ask):
+  - `ProcessingStage[X, Y]` in `stages/base.py`: `name`, `resources`,
+    `batch_size` (class attribute; the read-side `_batch_size` property
+    is what backends consume), `runtime_env`, `process`, `inputs`,
+    `outputs`, `setup`, `setup_on_node`, `teardown`, `with_` builders,
+    `xenna_stage_spec`, `ray_stage_spec`.
+  - `CompositeStage` composition contract.
+  - `Task[T]` in `tasks/tasks.py`: `task_id`, `dataset_name`, `data`,
+    `_stage_perf`, `_metadata`, `_uuid`, `num_items`, `validate`.
+  - Modality tasks: `DocumentBatch`, `ImageBatch`, `VideoTask`,
+    `AudioTask`, `FileGroupTask`, `InterleavedBatch`.
+  - `Pipeline` in `pipeline/pipeline.py`: `add_stage`, `run`,
+    `describe`; pipeline-level `config` semantics.
+  - `Resources` in `stages/resources.py`: `cpus`, `gpu_memory_gb`,
+    `gpus`. The order and meaning of these fields is part of the
+    contract; adding fields requires Stop-And-Ask and updates to every
+    modality task subclass and backend adapter.
+  - `RayClient` in `core/client.py`: `start`, `stop`, lifecycle
+    expectations.
+  - `StageMeta` auto-registration: stage class names must remain unique
+    across the registry.
+- **Stage invariants**:
+  - `process(task: X) -> Y | list[Y]` is the abstract signature in
+    `stages/base.py`. Backend adapters and runtime helpers in
+    `backends/utils.py` additionally tolerate `None` returns (used by
+    filter stages); treat `None` as adapter-tolerated, not part of the
+    declared ABI. If a future change widens the abstract signature to
+    include `None`, propagate it here and in
+    `.cursor/rules/processing-stage-patterns.mdc`.
+  - All stages are fault-tolerant and retry-safe (Xenna preemption).
+  - Stage code must not import RAPIDS/CUDA libs at module top level;
+    lazy-import inside GPU methods.
+  - Resource declarations must reflect actual usage; mis-declared
+    resources break the scheduler.
+- **Task invariants**:
+  - `__post_init__` calls `validate()`; invalid tasks must raise, not
+    silently degrade.
+  - `_uuid` is auto-generated; do not set externally.
+  - `num_items` reflects payload, not bytes.
+- **Pipeline invariants**:
+  - Adjacent stages' `outputs` ⊆ next stage's `inputs` (type-check
+    happens at `add_stage` time or `run` time depending on stage
+    declaration).
+  - Pipeline is backend-agnostic; running it on a different executor
+    must not change the user-visible result modulo documented
+    nondeterminism (ordering of unordered outputs).
+
+## Contract Checklist
+
+When this domain changes, check:
+
+- `stages/base.py`, `tasks/tasks.py`, `pipeline/pipeline.py`,
+  `pipeline/workflow.py`, `backends/base.py`, `stages/resources.py`
+- All three backend adapters import / wrap `ProcessingStage` correctly:
+  `backends/xenna/adapter.py`, `backends/ray_data/adapter.py`,
+  `backends/ray_actor_pool/adapter.py`
+- `api-design.md` — keep it aligned with reality
+- `.cursor/rules/pipeline-structure.mdc`,
+  `processing-stage-patterns.mdc`, `task-patterns.mdc`,
+  `composite-stage-patterns.mdc`, `resources-configuration.mdc`
+- `.github/copilot-instructions.md` — the API Design Architecture
+  section
+- `fern/` concept pages (pipeline, stages, tasks, executors,
+  resources) — list under **Own**
+- `tests/stages/test_base.py`, `tests/tasks/`, `tests/pipelines/`,
+  `tests/backends/` parity tests
+- `tutorials/quickstart.py`
+- `CHANGELOG.md`
+
+For ABI changes include a parity matrix (Public API / Xenna / Ray Data
+/ Ray Actor Pool / Docs / Tutorials / Tests / Cursor+Copilot rules).
+
+## Advocate
+
+- Stronger type-checking at `add_stage` time so pipeline composition
+  errors surface before `run()`.
+- Better diagnostics when a stage's declared `inputs`/`outputs` do not
+  match what `process()` actually returns at runtime.
+- Clear fault-tolerance contract docs: what each stage owes Xenna on
+  preemption (idempotency, partial-state cleanup).
+- Lower-friction extension paths for users who want custom stages or
+  custom tasks without forking the framework.
+- Performance counters on every stage by default
+  (`StagePerfStats` is the hook).
+
+## Serve Peers
+
+- **To modality stewards** (text, image, audio, video, synthetic): give
+  them a stable, well-documented base class with examples of correct
+  resource declaration, fault-tolerance patterns, and composite stage
+  composition.
+- **To backends steward**: keep `ProcessingStage` and `Task` shaped so
+  adapters can wrap them without reaching into private attributes.
+  Surface any backend-relevant hook (`xenna_stage_spec`,
+  `ray_stage_spec`, `runtime_env`) explicitly.
+- **To tests steward**: provide pipeline test fixtures and a stable
+  contract for `validate()` so test stages don't drift from real ones.
+- **To docs steward**: keep `api-design.md` in sync with code so the
+  Fern pipeline/stage/task pages have a single source of truth.
+- **To extension authors**: keep `StageMeta` registry semantics
+  documented.
+
+## Do Not
+
+- Add backend-specific code paths inside `ProcessingStage` subclasses.
+  Differences belong in `nemo_curator/backends/<name>/`.
+- Import `cudf`, `cupy`, `cuml`, or RAPIDS libs at module top level
+  anywhere in `nemo_curator/`.
+- Mutate `_uuid` or set `_stage_perf` externally.
+- Add fields to `Task` or `Resources` without updating all modality
+  task subclasses, all backend adapters, and the relevant Fern concept
+  pages.
+- Silently change `process()` return semantics (list vs single vs
+  None) — that is a public-ABI change.
+- Wrap `Pipeline.run()` in a way that bypasses executor selection
+  logic.
+- Add a config knob to `Pipeline.config` without documenting which
+  executors honor it.
+
+## Own
+
+**Code surfaces**:
+
+- `nemo_curator/stages/base.py`
+- `nemo_curator/tasks/` (all task types)
+- `nemo_curator/pipeline/`
+- `nemo_curator/core/client.py`
+- `nemo_curator/stages/resources.py`
+- `nemo_curator/stages/function_decorators.py`,
+  `client_partitioning.py`, `file_partitioning.py`
+
+**Tests**:
+
+- `tests/tasks/`
+- `tests/pipelines/`
+- `tests/backends/test_integration.py` (exercises the ABI today;
+  consider adding dedicated `tests/stages/test_base.py` coverage —
+  open advocacy)
+
+**Docs (autopilot audit surface — keep this list current)**:
+
+- Any `fern/` page under the pipeline / stages / tasks / executors /
+  resources concept sections (canonical paths to be confirmed in the
+  next docs autopilot pass and pinned here)
+- `api-design.md`
+- Root `README.md` quickstart section
+
+**Agent-facing artifacts**:
+
+- `.cursor/rules/pipeline-structure.mdc`
+- `.cursor/rules/processing-stage-patterns.mdc`
+- `.cursor/rules/task-patterns.mdc`
+- `.cursor/rules/composite-stage-patterns.mdc`
+- `.cursor/rules/resources-configuration.mdc`
+- `.cursor/rules/executors.mdc`
+- `.cursor/rules/coding-standards.mdc`
+- The "API Design Architecture" / "Core Components" sections of
+  `.github/copilot-instructions.md`
+
+**CODEOWNERS routing**: default `@NVIDIA-NeMo/curator_reviewers`. Backends
+overlap: `@oyilmaz-nvidia @praateekmahajan @abhinavg4 @ayushdg`.

--- a/nemo_curator/AGENTS.md
+++ b/nemo_curator/AGENTS.md
@@ -39,9 +39,10 @@ parity promise.
     across the registry.
 - **Stage invariants:**
   - `process(task: X) -> Y | list[Y]` is the abstract signature.
-    Backend adapters and helpers in `backends/utils.py` additionally
-    tolerate `None` (for filters); treat `None` as
-    adapter-tolerated, not declared ABI.
+    Backend adapters (e.g. `xenna/adapter.py`'s `process_data`,
+    which returns `list[Task] | None`) additionally tolerate `None`
+    for filter stages — treat `None` as adapter-tolerated, not
+    declared ABI.
   - Fault-tolerant and retry-safe (Xenna preempts).
   - Resource declarations must reflect real usage — mis-declared
     resources break the scheduler.

--- a/nemo_curator/AGENTS.md
+++ b/nemo_curator/AGENTS.md
@@ -1,8 +1,11 @@
 # Steward: Pipeline & Stage Contract
 
-The `Task` / `ProcessingStage` / `Pipeline` triad is the public ABI of
-NeMo Curator. Every modality stage, every backend adapter, and every
-tutorial depends on it.
+This domain exists because pipeline portability across executors is the
+framework's value proposition. The `Task` / `ProcessingStage` /
+`Pipeline` / `Resources` ABI is what lets a user write a curation
+pipeline once and run it across Xenna, Ray Actor Pool, and Ray Data
+without code changes. Every modality stage, every backend adapter,
+every tutorial depends on this contract holding.
 
 Related: root [AGENTS.md](../AGENTS.md),
 [api-design.md](../api-design.md),
@@ -10,9 +13,13 @@ Related: root [AGENTS.md](../AGENTS.md),
 
 ## Point Of View
 
-The framework's spine. Defends abstractions against backend leakage,
-modality leakage, and convenience shortcuts that quietly break the
-parity promise.
+The framework's spine. Defends three design pillars — task-centric,
+map-style, fault-tolerant — against abstractions that would leak
+backend concerns into stages, modality concerns into the base, or
+convenience shortcuts that quietly break portability. Per-stage
+resource declaration is the framework's signature ergonomic, and it
+must stay simple enough for extension authors to use correctly without
+deep framework knowledge.
 
 ## Protect
 
@@ -31,24 +38,30 @@ parity promise.
   - `Pipeline` in `pipeline/pipeline.py` — `add_stage`, `run`,
     `describe`, `config` semantics.
   - `Resources` in `stages/resources.py` — `cpus`, `gpu_memory_gb`,
-    `gpus`. The order and meaning are part of the contract; adding
-    fields requires Stop-And-Ask and updates to every modality task
-    subclass and backend adapter.
+    `gpus`. Field order and meaning are contract; adding fields
+    requires Stop-And-Ask and updates to every modality task subclass
+    and backend adapter.
   - `RayClient` in `core/client.py` — `start`, `stop`.
   - `StageMeta` auto-registration: stage class names must stay unique
     across the registry.
-- **Stage invariants:**
-  - `process(task: X) -> Y | list[Y]` is the abstract signature.
-    Backend adapters (e.g. `xenna/adapter.py`'s `process_data`,
-    which returns `list[Task] | None`) additionally tolerate `None`
-    for filter stages — treat `None` as adapter-tolerated, not
-    declared ABI.
-  - Fault-tolerant and retry-safe (Xenna preempts).
-  - Resource declarations must reflect real usage — mis-declared
-    resources break the scheduler.
-- **Task invariants:** `__post_init__` calls `validate()`, which must
-  raise on invalid data, not silently degrade. `_uuid` is
-  auto-generated. `num_items` reflects payload, not bytes.
+- **Three design pillars** (architectural, not preferential):
+  - *Task-centric* — tasks are the unit of data; finer-grained control
+    and monitoring than dataset-level pipelines.
+  - *Map-style* — every stage transforms tasks to tasks (`X → Y |
+    list[Y]`). This constraint is what enables streaming and
+    auto-balancing; preserving it is more important than supporting a
+    convenient one-off graph pattern.
+  - *Fault tolerant* — stages survive Xenna preemption. Partial state
+    is idempotent or recoverable. Stages don't lose work silently.
+- **Resource declaration as the framework's signature ergonomic.**
+  Setting `Resources(cpus=0.5)` or `gpus=0.5` at the stage level
+  must stay dead-simple. Extension authors who can dial resources
+  per-stage can get heterogeneous CPU/GPU pipelines to perform; those
+  who can't, can't.
+- **`process(task: X) -> Y | list[Y]`** is the abstract signature.
+  Backend adapters (e.g. `xenna/adapter.py`'s `process_data`)
+  additionally tolerate `None` for filter stages — treat `None` as
+  adapter-tolerated, not declared ABI.
 - **Pipeline invariants:** adjacent stages' outputs ⊆ next stage's
   inputs. Pipeline is backend-agnostic; running on a different
   executor must not change user-visible result modulo documented
@@ -78,16 +91,17 @@ Ray Actor Pool / Docs / Tutorials / Tests / Cursor+Copilot rules).
 
 ## Advocate
 
-- Stronger type-checking at `add_stage` time so pipeline composition
-  errors surface before `run()`.
-- Diagnostics when a stage's declared `inputs`/`outputs` don't match
-  what `process()` actually returns at runtime.
-- Documented fault-tolerance contract per stage type: what each owes
-  Xenna on preemption (idempotency, partial-state cleanup).
-- Dedicated `tests/stages/test_base.py` coverage of the ABI (today
-  covered indirectly via `tests/backends/test_integration.py`).
-- Lower-friction extension paths for custom stages / custom tasks
-  without forking.
+- **Pre-flight pipeline validation.** Type errors should surface at
+  `add_stage` time, not after a long run. Composition errors caught
+  before `run()` save the most user pain.
+- **Diagnostics when declared inputs/outputs don't match runtime
+  return shape.** Today this drifts silently.
+- **Documented fault-tolerance contract per stage type** — what each
+  owes on preemption (idempotency, partial-state cleanup).
+- **Dedicated ABI test coverage in `tests/stages/test_base.py`.**
+  Today covered indirectly via integration tests.
+- **Lower-friction extension paths** for custom stages and tasks
+  without forking the framework.
 
 ## Own
 

--- a/nemo_curator/AGENTS.md
+++ b/nemo_curator/AGENTS.md
@@ -2,184 +2,107 @@
 
 The `Task` / `ProcessingStage` / `Pipeline` triad is the public ABI of
 NeMo Curator. Every modality stage, every backend adapter, and every
-tutorial depends on it. Breaks here cascade to everything downstream.
+tutorial depends on it.
 
-Related docs:
-
-- root [AGENTS.md](../AGENTS.md)
-- [api-design.md](../api-design.md) — the canonical design statement
-- `.cursor/rules/pipeline-structure.mdc`,
-  `processing-stage-patterns.mdc`, `task-patterns.mdc`,
-  `composite-stage-patterns.mdc`, `resources-configuration.mdc`
-- `fern/` pipeline/stage/task concept pages
+Related: root [AGENTS.md](../AGENTS.md),
+[api-design.md](../api-design.md),
+`.cursor/rules/{pipeline-structure,processing-stage-patterns,task-patterns,composite-stage-patterns,resources-configuration,executors}.mdc`.
 
 ## Point Of View
 
-The framework's spine — the contract that lets users define a pipeline
-once and run it across Xenna, Ray Data, and Ray Actor Pool. Defends
-abstractions against backend leakage, modality leakage, and convenience
-shortcuts that quietly break the parity promise.
+The framework's spine. Defends abstractions against backend leakage,
+modality leakage, and convenience shortcuts that quietly break the
+parity promise.
 
 ## Protect
 
-- **Public ABI surfaces** (changes here are Stop-And-Ask):
-  - `ProcessingStage[X, Y]` in `stages/base.py`: `name`, `resources`,
-    `batch_size` (class attribute; the read-side `_batch_size` property
-    is what backends consume), `runtime_env`, `process`, `inputs`,
-    `outputs`, `setup`, `setup_on_node`, `teardown`, `with_` builders,
-    `xenna_stage_spec`, `ray_stage_spec`.
+- **Public ABI surfaces** (Stop-And-Ask to change):
+  - `ProcessingStage[X, Y]` in `stages/base.py` — `name`,
+    `resources`, `runtime_env`, `batch_size` (class attribute; the
+    read-side `_batch_size` property is what backends consume),
+    `process`, `inputs`, `outputs`, `setup`, `setup_on_node`,
+    `teardown`, `with_` builders, `xenna_stage_spec`,
+    `ray_stage_spec`.
   - `CompositeStage` composition contract.
-  - `Task[T]` in `tasks/tasks.py`: `task_id`, `dataset_name`, `data`,
-    `_stage_perf`, `_metadata`, `_uuid`, `num_items`, `validate`.
-  - Modality tasks: `DocumentBatch`, `ImageBatch`, `VideoTask`,
-    `AudioTask`, `FileGroupTask`, `InterleavedBatch`.
-  - `Pipeline` in `pipeline/pipeline.py`: `add_stage`, `run`,
-    `describe`; pipeline-level `config` semantics.
-  - `Resources` in `stages/resources.py`: `cpus`, `gpu_memory_gb`,
-    `gpus`. The order and meaning of these fields is part of the
-    contract; adding fields requires Stop-And-Ask and updates to every
-    modality task subclass and backend adapter.
-  - `RayClient` in `core/client.py`: `start`, `stop`, lifecycle
-    expectations.
-  - `StageMeta` auto-registration: stage class names must remain unique
+  - `Task[T]` in `tasks/tasks.py` — `task_id`, `dataset_name`,
+    `data`, `_stage_perf`, `_metadata`, `_uuid`, `num_items`,
+    `validate`. Modality tasks: `DocumentBatch`, `ImageBatch`,
+    `VideoTask`, `AudioTask`, `FileGroupTask`, `InterleavedBatch`.
+  - `Pipeline` in `pipeline/pipeline.py` — `add_stage`, `run`,
+    `describe`, `config` semantics.
+  - `Resources` in `stages/resources.py` — `cpus`, `gpu_memory_gb`,
+    `gpus`. The order and meaning are part of the contract; adding
+    fields requires Stop-And-Ask and updates to every modality task
+    subclass and backend adapter.
+  - `RayClient` in `core/client.py` — `start`, `stop`.
+  - `StageMeta` auto-registration: stage class names must stay unique
     across the registry.
-- **Stage invariants**:
-  - `process(task: X) -> Y | list[Y]` is the abstract signature in
-    `stages/base.py`. Backend adapters and runtime helpers in
-    `backends/utils.py` additionally tolerate `None` returns (used by
-    filter stages); treat `None` as adapter-tolerated, not part of the
-    declared ABI. If a future change widens the abstract signature to
-    include `None`, propagate it here and in
-    `.cursor/rules/processing-stage-patterns.mdc`.
-  - All stages are fault-tolerant and retry-safe (Xenna preemption).
-  - Stage code must not import RAPIDS/CUDA libs at module top level;
-    lazy-import inside GPU methods.
-  - Resource declarations must reflect actual usage; mis-declared
+- **Stage invariants:**
+  - `process(task: X) -> Y | list[Y]` is the abstract signature.
+    Backend adapters and helpers in `backends/utils.py` additionally
+    tolerate `None` (for filters); treat `None` as
+    adapter-tolerated, not declared ABI.
+  - Fault-tolerant and retry-safe (Xenna preempts).
+  - Resource declarations must reflect real usage — mis-declared
     resources break the scheduler.
-- **Task invariants**:
-  - `__post_init__` calls `validate()`; invalid tasks must raise, not
-    silently degrade.
-  - `_uuid` is auto-generated; do not set externally.
-  - `num_items` reflects payload, not bytes.
-- **Pipeline invariants**:
-  - Adjacent stages' `outputs` ⊆ next stage's `inputs` (type-check
-    happens at `add_stage` time or `run` time depending on stage
-    declaration).
-  - Pipeline is backend-agnostic; running it on a different executor
-    must not change the user-visible result modulo documented
-    nondeterminism (ordering of unordered outputs).
+- **Task invariants:** `__post_init__` calls `validate()`, which must
+  raise on invalid data, not silently degrade. `_uuid` is
+  auto-generated. `num_items` reflects payload, not bytes.
+- **Pipeline invariants:** adjacent stages' outputs ⊆ next stage's
+  inputs. Pipeline is backend-agnostic; running on a different
+  executor must not change user-visible result modulo documented
+  ordering nondeterminism.
 
 ## Contract Checklist
 
-When this domain changes, check:
+When this domain changes:
 
-- `stages/base.py`, `tasks/tasks.py`, `pipeline/pipeline.py`,
-  `pipeline/workflow.py`, `backends/base.py`, `stages/resources.py`
-- All three backend adapters import / wrap `ProcessingStage` correctly:
-  `backends/xenna/adapter.py`, `backends/ray_data/adapter.py`,
-  `backends/ray_actor_pool/adapter.py`
-- `api-design.md` — keep it aligned with reality
-- `.cursor/rules/pipeline-structure.mdc`,
-  `processing-stage-patterns.mdc`, `task-patterns.mdc`,
-  `composite-stage-patterns.mdc`, `resources-configuration.mdc`
-- `.github/copilot-instructions.md` — the API Design Architecture
-  section
+- `stages/base.py`, `tasks/tasks.py` (and the modality task files),
+  `pipeline/pipeline.py`, `pipeline/workflow.py`, `backends/base.py`,
+  `stages/resources.py`, `stages/function_decorators.py`,
+  `stages/client_partitioning.py`, `stages/file_partitioning.py`
+- All three backend adapters wrap the new contract:
+  `backends/{xenna,ray_data,ray_actor_pool}/adapter.py`
+- `api-design.md` — keep aligned with reality
+- Cursor rules listed above; the "API Design Architecture" section of
+  `.github/copilot-instructions.md`
 - `fern/` concept pages (pipeline, stages, tasks, executors,
-  resources) — list under **Own**
-- `tests/stages/test_base.py`, `tests/tasks/`, `tests/pipelines/`,
-  `tests/backends/` parity tests
+  resources)
+- `tests/{tasks,pipelines,backends/test_integration.py}/`
 - `tutorials/quickstart.py`
 - `CHANGELOG.md`
 
-For ABI changes include a parity matrix (Public API / Xenna / Ray Data
-/ Ray Actor Pool / Docs / Tutorials / Tests / Cursor+Copilot rules).
+ABI changes include a parity matrix (Public API / Xenna / Ray Data /
+Ray Actor Pool / Docs / Tutorials / Tests / Cursor+Copilot rules).
 
 ## Advocate
 
 - Stronger type-checking at `add_stage` time so pipeline composition
   errors surface before `run()`.
-- Better diagnostics when a stage's declared `inputs`/`outputs` do not
-  match what `process()` actually returns at runtime.
-- Clear fault-tolerance contract docs: what each stage owes Xenna on
-  preemption (idempotency, partial-state cleanup).
-- Lower-friction extension paths for users who want custom stages or
-  custom tasks without forking the framework.
-- Performance counters on every stage by default
-  (`StagePerfStats` is the hook).
-
-## Serve Peers
-
-- **To modality stewards** (text, image, audio, video, synthetic): give
-  them a stable, well-documented base class with examples of correct
-  resource declaration, fault-tolerance patterns, and composite stage
-  composition.
-- **To backends steward**: keep `ProcessingStage` and `Task` shaped so
-  adapters can wrap them without reaching into private attributes.
-  Surface any backend-relevant hook (`xenna_stage_spec`,
-  `ray_stage_spec`, `runtime_env`) explicitly.
-- **To tests steward**: provide pipeline test fixtures and a stable
-  contract for `validate()` so test stages don't drift from real ones.
-- **To docs steward**: keep `api-design.md` in sync with code so the
-  Fern pipeline/stage/task pages have a single source of truth.
-- **To extension authors**: keep `StageMeta` registry semantics
-  documented.
-
-## Do Not
-
-- Add backend-specific code paths inside `ProcessingStage` subclasses.
-  Differences belong in `nemo_curator/backends/<name>/`.
-- Import `cudf`, `cupy`, `cuml`, or RAPIDS libs at module top level
-  anywhere in `nemo_curator/`.
-- Mutate `_uuid` or set `_stage_perf` externally.
-- Add fields to `Task` or `Resources` without updating all modality
-  task subclasses, all backend adapters, and the relevant Fern concept
-  pages.
-- Silently change `process()` return semantics (list vs single vs
-  None) — that is a public-ABI change.
-- Wrap `Pipeline.run()` in a way that bypasses executor selection
-  logic.
-- Add a config knob to `Pipeline.config` without documenting which
-  executors honor it.
+- Diagnostics when a stage's declared `inputs`/`outputs` don't match
+  what `process()` actually returns at runtime.
+- Documented fault-tolerance contract per stage type: what each owes
+  Xenna on preemption (idempotency, partial-state cleanup).
+- Dedicated `tests/stages/test_base.py` coverage of the ABI (today
+  covered indirectly via `tests/backends/test_integration.py`).
+- Lower-friction extension paths for custom stages / custom tasks
+  without forking.
 
 ## Own
 
-**Code surfaces**:
+**Code:** `stages/base.py`, `tasks/`, `pipeline/`, `core/client.py`,
+`stages/{resources,function_decorators,client_partitioning,file_partitioning}.py`.
 
-- `nemo_curator/stages/base.py`
-- `nemo_curator/tasks/` (all task types)
-- `nemo_curator/pipeline/`
-- `nemo_curator/core/client.py`
-- `nemo_curator/stages/resources.py`
-- `nemo_curator/stages/function_decorators.py`,
-  `client_partitioning.py`, `file_partitioning.py`
+**Tests:** `tests/tasks/`, `tests/pipelines/`, `tests/core/`,
+`tests/backends/test_integration.py`.
 
-**Tests**:
+**Docs (autopilot surface — to be pinned by Docs Steward):** `fern/`
+pages under pipeline / stages / tasks / executors / resources
+concepts; `api-design.md`; the quickstart section of `README.md`.
 
-- `tests/tasks/`
-- `tests/pipelines/`
-- `tests/backends/test_integration.py` (exercises the ABI today;
-  consider adding dedicated `tests/stages/test_base.py` coverage —
-  open advocacy)
+**Agent artifacts:** `.cursor/rules/{pipeline-structure,processing-stage-patterns,task-patterns,composite-stage-patterns,resources-configuration,executors,coding-standards}.mdc`;
+the "API Design Architecture" and "Core Components" sections of
+`.github/copilot-instructions.md`.
 
-**Docs (autopilot audit surface — keep this list current)**:
-
-- Any `fern/` page under the pipeline / stages / tasks / executors /
-  resources concept sections (canonical paths to be confirmed in the
-  next docs autopilot pass and pinned here)
-- `api-design.md`
-- Root `README.md` quickstart section
-
-**Agent-facing artifacts**:
-
-- `.cursor/rules/pipeline-structure.mdc`
-- `.cursor/rules/processing-stage-patterns.mdc`
-- `.cursor/rules/task-patterns.mdc`
-- `.cursor/rules/composite-stage-patterns.mdc`
-- `.cursor/rules/resources-configuration.mdc`
-- `.cursor/rules/executors.mdc`
-- `.cursor/rules/coding-standards.mdc`
-- The "API Design Architecture" / "Core Components" sections of
-  `.github/copilot-instructions.md`
-
-**CODEOWNERS routing**: default `@NVIDIA-NeMo/curator_reviewers`. Backends
+**CODEOWNERS:** default `@NVIDIA-NeMo/curator_reviewers`. Backend
 overlap: `@oyilmaz-nvidia @praateekmahajan @abhinavg4 @ayushdg`.

--- a/nemo_curator/backends/AGENTS.md
+++ b/nemo_curator/backends/AGENTS.md
@@ -5,148 +5,96 @@ Three backends — Xenna, Ray Data, Ray Actor Pool — must run the same
 and the adapter boundary between `ProcessingStage` and each backend's
 native execution model.
 
-Related docs:
-
-- root [AGENTS.md](../../AGENTS.md)
-- parent [nemo_curator/AGENTS.md](../AGENTS.md)
-- [api-design.md](../../api-design.md) — Executors section
-- `.cursor/rules/executors.mdc`
+Related: root [AGENTS.md](../../AGENTS.md), parent
+[nemo_curator/AGENTS.md](../AGENTS.md),
+[api-design.md](../../api-design.md) Executors section,
+`.cursor/rules/executors.mdc`.
 
 ## Point Of View
 
-The translation layer. Speaks both `ProcessingStage` upstream and each
+The translation layer. Speaks `ProcessingStage` upstream and each
 backend's native API downstream. When a pipeline behaves differently
 across backends, this is where the bug is — and where the fix belongs.
 
 ## Protect
 
-- **Parity**: same `Pipeline` + same input → equivalent output across
+- **Parity.** Same pipeline + same input → equivalent output across
   Xenna, Ray Data, Ray Actor Pool. Ordering differences for unordered
   outputs are acceptable and must be documented; semantic differences
   are not.
-- **`BaseExecutor` ABI** in `backends/base.py`: `execute(stages,
-  initial_tasks)`, `NodeInfo`, `WorkerMetadata`, `BaseStageAdapter`
-  contract. Adding/removing fields on these is Stop-And-Ask.
-- **Adapter isolation**: each backend's adapter wraps `ProcessingStage`
-  using only its public surface (the methods listed in
-  [../AGENTS.md](../AGENTS.md)'s Protect section). No reaching into
-  private attributes.
-- **Resource honoring**: `Resources(cpus, gpu_memory_gb, gpus)` must
-  map correctly to each backend's scheduler hints. A stage that
-  declares `gpus=1.0` must not run on a CPU-only worker.
-- **Fault tolerance**: Xenna can preempt. Today this is fully
-  delegated to stage idempotency — no retry-context callback is
-  exposed to stages from any adapter. Adding such an API is
-  Stop-And-Ask.
-- **Runtime env**: `stage.runtime_env` (Ray runtime env) is honored by
-  every backend that supports it; backends that cannot must reject the
-  pipeline at adapter construction, not silently ignore it.
-- **Stage decomposition**: `xenna_stage_spec` and `ray_stage_spec`
+- **`BaseExecutor` ABI** in `backends/base.py`:
+  `execute(stages, initial_tasks)`, `NodeInfo`, `WorkerMetadata`,
+  `BaseStageAdapter`. Changes here are Stop-And-Ask.
+- **Adapter isolation.** Each backend wraps `ProcessingStage` using
+  only its public surface (see the parent steward's Protect list).
+  No reaching into private attributes.
+- **Resource honoring.** `Resources(cpus, gpu_memory_gb, gpus)`
+  must map to each backend's scheduler hints. A stage that declares
+  `gpus=1.0` must not run on a CPU-only worker.
+- **Fault tolerance.** Xenna preempts. Today this is fully delegated
+  to stage idempotency — no retry-context callback is exposed from
+  any adapter. Adding such an API is Stop-And-Ask.
+- **`runtime_env`** is honored by every backend that supports it:
+  Xenna via `CuratorRuntimeEnv` (`xenna/adapter.py`), Ray Data via
+  `ray_remote_args` (`ray_data/adapter.py`), Ray Actor Pool via
+  `actor_options` (`ray_actor_pool/executor.py`). Backends that
+  cannot support a hook must reject the pipeline at adapter
+  construction, not silently ignore it.
+- **Stage decomposition.** `xenna_stage_spec` and `ray_stage_spec`
   hooks behave consistently with their declared targets.
 
 ## Contract Checklist
 
 When this domain changes:
 
-- `backends/base.py` (`BaseExecutor`, `BaseStageAdapter`, `NodeInfo`,
-  `WorkerMetadata`, utils)
-- All three executor entrypoints:
-  - `backends/xenna/executor.py`, `xenna/adapter.py`
-  - `backends/ray_data/executor.py`, `ray_data/adapter.py`,
-    `ray_data/utils.py`
-  - `backends/ray_actor_pool/executor.py`,
-    `ray_actor_pool/adapter.py`,
-    `ray_actor_pool/raft_adapter.py`,
-    `ray_actor_pool/shuffle_adapter.py`,
-    `ray_actor_pool/utils.py`
-- `backends/internal/` — internal helpers
-- `backends/utils.py` — shared backend utilities
-- `nemo_curator/core/client.py` — Ray cluster lifecycle (does the
-  change require new Ray init args?)
-- `tests/backends/` — today contains `ray_actor_pool/test_executor.py`,
-  `ray_data/{test_max_calls_pid.py, test_utils.py}`,
-  `test_integration.py`, `test_utils.py`. There is no Xenna parity
-  suite yet; building a canonical cross-executor parity harness is an
-  open advocacy item (below). Until then, executor-affecting changes
-  add coverage to whichever adapter they touch.
-- `api-design.md` — Executors section
-- `.cursor/rules/executors.mdc`
-- The "Backend Implementations" sections of
-  `.github/copilot-instructions.md` and
-  `nemo_curator/AGENTS.md`
+- `backends/base.py` (`BaseExecutor`, `BaseStageAdapter`,
+  `NodeInfo`, `WorkerMetadata`)
+- Each backend tree: `backends/xenna/{executor,adapter}.py`,
+  `backends/ray_data/{executor,adapter,utils}.py`,
+  `backends/ray_actor_pool/{executor,adapter,raft_adapter,shuffle_adapter,utils}.py`
+- `backends/internal/`, `backends/utils.py`
+- `nemo_curator/core/client.py` if Ray init args change
+- `tests/backends/` — today covers `ray_actor_pool/test_executor.py`,
+  `ray_data/{test_max_calls_pid,test_utils}.py`,
+  `test_integration.py`, `test_utils.py`. No Xenna parity suite yet
+  — see Advocate. Executor-affecting changes add coverage to
+  whichever adapter they touch.
+- `api-design.md` Executors section, `.cursor/rules/executors.mdc`,
+  "Backend Implementations" sections of
+  `.github/copilot-instructions.md` and parent steward
 - `fern/` executor / backend concept pages
-- `CHANGELOG.md` for user-visible behavior changes
+- `CHANGELOG.md`
 
-For any executor-affecting change include a parity matrix (API / Xenna
+Any executor-affecting change includes a parity matrix (API / Xenna
 / Ray Data / Ray Actor Pool / Docs / Tests).
 
 ## Advocate
 
-- A canonical parity test suite that every executor must pass before a
-  PR can land. Today parity is implicit; make it a gate.
-- Clear documentation of *intentional* behavioral differences (e.g.,
-  autoscaling, streaming vs batch semantics) so users can choose the
-  right executor.
-- Better diagnostics when a stage cannot be adapted to a given backend
-  (clear error, not a deep stack into adapter internals).
+- **A canonical parity test suite** that every executor must pass
+  before a PR can land. Parity is implicit today; make it a gate.
+- Documentation of *intentional* behavioral differences (autoscaling,
+  streaming vs batch semantics) so users can choose the right
+  executor.
+- Clear diagnostics when a stage cannot be adapted to a given backend
+  — fail at construction with a clear message, not deep stack into
+  adapter internals.
 - A "minimum viable adapter" recipe for extension authors writing a
   fourth backend.
-- Observability parity: stage perf stats, error reporting, and
-  cluster-level metrics should look the same regardless of executor.
-
-## Serve Peers
-
-- **To pipeline-contract steward**: surface which `ProcessingStage`
-  hooks each backend honors; flag silent no-ops.
-- **To modality stewards**: if a stage type cannot run on a given
-  backend (e.g., GPU stage on a CPU-only Ray Data cluster), make the
-  diagnostic clear, ideally at pipeline construction.
-- **To deduplication steward**: shuffle and IPC stages
-  (`shuffle_adapter.py`, `raft_adapter.py`) have specific deduplication
-  use cases — keep their interface stable.
-- **To tests steward**: provide executor-parametrized fixtures so
-  tests can sweep across backends without per-backend boilerplate.
-- **To docs steward**: keep the executor-selection guidance in
-  `fern/` aligned with which executors are recommended for which
-  workloads.
-
-## Do Not
-
-- Add backend-specific knobs to `ProcessingStage`. They belong on the
-  adapter or on the executor `config`.
-- Silently ignore a stage hook (`runtime_env`, `batch_size`,
-  `xenna_stage_spec`, `ray_stage_spec`) on a backend that does not
-  support it. Raise or document.
-- Wrap Ray init/teardown inside an adapter; that belongs in
-  `RayClient`.
-- Add a new executor without parity tests and without updating
-  `api-design.md` + `fern/`.
-- Pin a specific Ray version in adapter code; version constraints
-  belong in `pyproject.toml`.
-- Use `print()`; use `loguru`.
+- Observability parity: stage perf stats, error reporting, cluster
+  metrics should look the same regardless of executor.
 
 ## Own
 
-**Code surfaces**:
+**Code:** `nemo_curator/backends/` (all subpackages).
 
-- `nemo_curator/backends/` (all subpackages)
+**Tests:** `tests/backends/`.
 
-**Tests**:
+**Docs (autopilot surface — to be pinned by Docs Steward):** `fern/`
+pages on executors, backends, Ray cluster setup, executor selection,
+autoscaling; `api-design.md` Executors / Backend Implementations.
 
-- `tests/backends/` (all executor parity + adapter tests)
+**Agent artifacts:** `.cursor/rules/executors.mdc`; the
+"Backends/Executors" sections of `.github/copilot-instructions.md`.
 
-**Docs (autopilot audit surface)**:
-
-- `fern/` pages describing executors, backends, Ray cluster setup,
-  executor selection guidance, autoscaling (canonical paths to be
-  pinned in the next docs autopilot pass)
-- `api-design.md` Executors / Backend Implementations sections
-
-**Agent-facing artifacts**:
-
-- `.cursor/rules/executors.mdc`
-- The "Backends/Executors" and "Backend Implementations" sections of
-  `.github/copilot-instructions.md`
-
-**CODEOWNERS routing**: `@oyilmaz-nvidia @praateekmahajan @abhinavg4
-@ayushdg`. Any executor-touching PR must route to this team.
+**CODEOWNERS:** `@oyilmaz-nvidia @praateekmahajan @abhinavg4
+@ayushdg`.

--- a/nemo_curator/backends/AGENTS.md
+++ b/nemo_curator/backends/AGENTS.md
@@ -1,0 +1,152 @@
+# Steward: Executor Parity & Backend Adapters
+
+Three backends — Xenna, Ray Data, Ray Actor Pool — must run the same
+`Pipeline` to equivalent results. This steward guards executor parity
+and the adapter boundary between `ProcessingStage` and each backend's
+native execution model.
+
+Related docs:
+
+- root [AGENTS.md](../../AGENTS.md)
+- parent [nemo_curator/AGENTS.md](../AGENTS.md)
+- [api-design.md](../../api-design.md) — Executors section
+- `.cursor/rules/executors.mdc`
+
+## Point Of View
+
+The translation layer. Speaks both `ProcessingStage` upstream and each
+backend's native API downstream. When a pipeline behaves differently
+across backends, this is where the bug is — and where the fix belongs.
+
+## Protect
+
+- **Parity**: same `Pipeline` + same input → equivalent output across
+  Xenna, Ray Data, Ray Actor Pool. Ordering differences for unordered
+  outputs are acceptable and must be documented; semantic differences
+  are not.
+- **`BaseExecutor` ABI** in `backends/base.py`: `execute(stages,
+  initial_tasks)`, `NodeInfo`, `WorkerMetadata`, `BaseStageAdapter`
+  contract. Adding/removing fields on these is Stop-And-Ask.
+- **Adapter isolation**: each backend's adapter wraps `ProcessingStage`
+  using only its public surface (the methods listed in
+  [../AGENTS.md](../AGENTS.md)'s Protect section). No reaching into
+  private attributes.
+- **Resource honoring**: `Resources(cpus, gpu_memory_gb, gpus)` must
+  map correctly to each backend's scheduler hints. A stage that
+  declares `gpus=1.0` must not run on a CPU-only worker.
+- **Fault tolerance**: Xenna can preempt. Today this is fully
+  delegated to stage idempotency — no retry-context callback is
+  exposed to stages from any adapter. Adding such an API is
+  Stop-And-Ask.
+- **Runtime env**: `stage.runtime_env` (Ray runtime env) is honored by
+  every backend that supports it; backends that cannot must reject the
+  pipeline at adapter construction, not silently ignore it.
+- **Stage decomposition**: `xenna_stage_spec` and `ray_stage_spec`
+  hooks behave consistently with their declared targets.
+
+## Contract Checklist
+
+When this domain changes:
+
+- `backends/base.py` (`BaseExecutor`, `BaseStageAdapter`, `NodeInfo`,
+  `WorkerMetadata`, utils)
+- All three executor entrypoints:
+  - `backends/xenna/executor.py`, `xenna/adapter.py`
+  - `backends/ray_data/executor.py`, `ray_data/adapter.py`,
+    `ray_data/utils.py`
+  - `backends/ray_actor_pool/executor.py`,
+    `ray_actor_pool/adapter.py`,
+    `ray_actor_pool/raft_adapter.py`,
+    `ray_actor_pool/shuffle_adapter.py`,
+    `ray_actor_pool/utils.py`
+- `backends/internal/` — internal helpers
+- `backends/utils.py` — shared backend utilities
+- `nemo_curator/core/client.py` — Ray cluster lifecycle (does the
+  change require new Ray init args?)
+- `tests/backends/` — today contains `ray_actor_pool/test_executor.py`,
+  `ray_data/{test_max_calls_pid.py, test_utils.py}`,
+  `test_integration.py`, `test_utils.py`. There is no Xenna parity
+  suite yet; building a canonical cross-executor parity harness is an
+  open advocacy item (below). Until then, executor-affecting changes
+  add coverage to whichever adapter they touch.
+- `api-design.md` — Executors section
+- `.cursor/rules/executors.mdc`
+- The "Backend Implementations" sections of
+  `.github/copilot-instructions.md` and
+  `nemo_curator/AGENTS.md`
+- `fern/` executor / backend concept pages
+- `CHANGELOG.md` for user-visible behavior changes
+
+For any executor-affecting change include a parity matrix (API / Xenna
+/ Ray Data / Ray Actor Pool / Docs / Tests).
+
+## Advocate
+
+- A canonical parity test suite that every executor must pass before a
+  PR can land. Today parity is implicit; make it a gate.
+- Clear documentation of *intentional* behavioral differences (e.g.,
+  autoscaling, streaming vs batch semantics) so users can choose the
+  right executor.
+- Better diagnostics when a stage cannot be adapted to a given backend
+  (clear error, not a deep stack into adapter internals).
+- A "minimum viable adapter" recipe for extension authors writing a
+  fourth backend.
+- Observability parity: stage perf stats, error reporting, and
+  cluster-level metrics should look the same regardless of executor.
+
+## Serve Peers
+
+- **To pipeline-contract steward**: surface which `ProcessingStage`
+  hooks each backend honors; flag silent no-ops.
+- **To modality stewards**: if a stage type cannot run on a given
+  backend (e.g., GPU stage on a CPU-only Ray Data cluster), make the
+  diagnostic clear, ideally at pipeline construction.
+- **To deduplication steward**: shuffle and IPC stages
+  (`shuffle_adapter.py`, `raft_adapter.py`) have specific deduplication
+  use cases — keep their interface stable.
+- **To tests steward**: provide executor-parametrized fixtures so
+  tests can sweep across backends without per-backend boilerplate.
+- **To docs steward**: keep the executor-selection guidance in
+  `fern/` aligned with which executors are recommended for which
+  workloads.
+
+## Do Not
+
+- Add backend-specific knobs to `ProcessingStage`. They belong on the
+  adapter or on the executor `config`.
+- Silently ignore a stage hook (`runtime_env`, `batch_size`,
+  `xenna_stage_spec`, `ray_stage_spec`) on a backend that does not
+  support it. Raise or document.
+- Wrap Ray init/teardown inside an adapter; that belongs in
+  `RayClient`.
+- Add a new executor without parity tests and without updating
+  `api-design.md` + `fern/`.
+- Pin a specific Ray version in adapter code; version constraints
+  belong in `pyproject.toml`.
+- Use `print()`; use `loguru`.
+
+## Own
+
+**Code surfaces**:
+
+- `nemo_curator/backends/` (all subpackages)
+
+**Tests**:
+
+- `tests/backends/` (all executor parity + adapter tests)
+
+**Docs (autopilot audit surface)**:
+
+- `fern/` pages describing executors, backends, Ray cluster setup,
+  executor selection guidance, autoscaling (canonical paths to be
+  pinned in the next docs autopilot pass)
+- `api-design.md` Executors / Backend Implementations sections
+
+**Agent-facing artifacts**:
+
+- `.cursor/rules/executors.mdc`
+- The "Backends/Executors" and "Backend Implementations" sections of
+  `.github/copilot-instructions.md`
+
+**CODEOWNERS routing**: `@oyilmaz-nvidia @praateekmahajan @abhinavg4
+@ayushdg`. Any executor-touching PR must route to this team.

--- a/nemo_curator/backends/AGENTS.md
+++ b/nemo_curator/backends/AGENTS.md
@@ -1,9 +1,10 @@
 # Steward: Executor Parity & Backend Adapters
 
-Three backends — Xenna, Ray Data, Ray Actor Pool — must run the same
-`Pipeline` to equivalent results. This steward guards executor parity
-and the adapter boundary between `ProcessingStage` and each backend's
-native execution model.
+This domain exists because pipeline portability — the same `Pipeline`
+running unchanged across Xenna, Ray Actor Pool, and Ray Data — is the
+framework's core promise. When a pipeline behaves differently on
+different executors, this is where the bug is, and where the fix
+belongs.
 
 Related: root [AGENTS.md](../../AGENTS.md), parent
 [nemo_curator/AGENTS.md](../AGENTS.md),
@@ -13,23 +14,34 @@ Related: root [AGENTS.md](../../AGENTS.md), parent
 ## Point Of View
 
 The translation layer. Speaks `ProcessingStage` upstream and each
-backend's native API downstream. When a pipeline behaves differently
-across backends, this is where the bug is — and where the fix belongs.
+backend's native API downstream. The job is not just "run pipelines"
+— it's *streaming with auto-balancing across heterogeneous stages*:
+backpressure that prevents memory spilling, replica counts that match
+each stage's throughput so the slowest stage doesn't starve the rest,
+and GPU workers kept busy at high utilization through the run.
 
 ## Protect
 
 - **Parity.** Same pipeline + same input → equivalent output across
-  Xenna, Ray Data, Ray Actor Pool. Ordering differences for unordered
+  Xenna, Ray Actor Pool, Ray Data. Ordering differences for unordered
   outputs are acceptable and must be documented; semantic differences
   are not.
 - **`BaseExecutor` ABI** in `backends/base.py`:
   `execute(stages, initial_tasks)`, `NodeInfo`, `WorkerMetadata`,
   `BaseStageAdapter`. Changes here are Stop-And-Ask.
+- **Streaming mode is core, not optional.** Batch mode forces video
+  download → cutscene → extraction → transcode to serialize per video.
+  Streaming lets stages with different compute profiles run
+  concurrently, keeping GPU compute and decode units saturated.
+  Backends must support streaming first; batch is the degraded path.
+- **Auto-balancing across heterogeneous stages.** When a slow stage
+  (e.g., VLM captioning) backs up a fast stage (e.g., download), the
+  backend must scale replicas of the slow stage to match upstream
+  throughput. Backpressure prevents memory spilling.
 - **Adapter isolation.** Each backend wraps `ProcessingStage` using
-  only its public surface (see the parent steward's Protect list).
-  No reaching into private attributes.
+  only its public surface. No reaching into private attributes.
 - **Resource honoring.** `Resources(cpus, gpu_memory_gb, gpus)`
-  must map to each backend's scheduler hints. A stage that declares
+  must map to each backend's scheduler hints. A stage declaring
   `gpus=1.0` must not run on a CPU-only worker.
 - **Fault tolerance.** Xenna preempts. Today this is fully delegated
   to stage idempotency — no retry-context callback is exposed from
@@ -42,6 +54,10 @@ across backends, this is where the bug is — and where the fix belongs.
   construction, not silently ignore it.
 - **Stage decomposition.** `xenna_stage_spec` and `ray_stage_spec`
   hooks behave consistently with their declared targets.
+- **Inference-bearing pipelines** route through the Inference
+  Acceleration Steward (root AGENTS.md). Backends own the integration
+  surface (`runtime_env`, model-server deps, async scheduling) but
+  defer model-serving choices to that cross-cutting steward.
 
 ## Contract Checklist
 
@@ -62,26 +78,30 @@ When this domain changes:
 - `api-design.md` Executors section, `.cursor/rules/executors.mdc`,
   "Backend Implementations" sections of
   `.github/copilot-instructions.md` and parent steward
-- `fern/` executor / backend concept pages
+- `fern/` executor / backend concept pages, scaling concepts
 - `CHANGELOG.md`
 
-Any executor-affecting change includes a parity matrix (API / Xenna
-/ Ray Data / Ray Actor Pool / Docs / Tests).
+Any executor-affecting change includes a parity matrix (API / Xenna /
+Ray Data / Ray Actor Pool / Docs / Tests).
 
 ## Advocate
 
-- **A canonical parity test suite** that every executor must pass
-  before a PR can land. Parity is implicit today; make it a gate.
-- Documentation of *intentional* behavioral differences (autoscaling,
-  streaming vs batch semantics) so users can choose the right
-  executor.
-- Clear diagnostics when a stage cannot be adapted to a given backend
-  — fail at construction with a clear message, not deep stack into
-  adapter internals.
-- A "minimum viable adapter" recipe for extension authors writing a
-  fourth backend.
-- Observability parity: stage perf stats, error reporting, cluster
-  metrics should look the same regardless of executor.
+- **A canonical parity test suite** every executor must pass before a
+  PR can land. Parity is implicit today; make it a gate.
+- **Auto-balancing diagnostics** — surface why a stage's replica
+  count was chosen, what its observed throughput is, and where queues
+  are backing up. Today operators reason about this from external
+  metrics; the framework should expose it.
+- **Documented behavioral differences across executors** (autoscaling,
+  streaming vs batch semantics) so users can choose the right backend.
+- **Clear diagnostics when a stage cannot be adapted** to a given
+  backend — fail at construction with a clear message, not deep stack
+  into adapter internals.
+- **A "minimum viable adapter" recipe** for extension authors writing
+  a fourth backend.
+- **Async scheduling parity** — when one backend gains an async path
+  (e.g., vLLM `RayExecutorV2` integration), others should follow or
+  document the gap.
 
 ## Own
 
@@ -91,7 +111,7 @@ Any executor-affecting change includes a parity matrix (API / Xenna
 
 **Docs (autopilot surface — to be pinned by Docs Steward):** `fern/`
 pages on executors, backends, Ray cluster setup, executor selection,
-autoscaling; `api-design.md` Executors / Backend Implementations.
+autoscaling, streaming concepts.
 
 **Agent artifacts:** `.cursor/rules/executors.mdc`; the
 "Backends/Executors" sections of `.github/copilot-instructions.md`.

--- a/nemo_curator/stages/deduplication/AGENTS.md
+++ b/nemo_curator/stages/deduplication/AGENTS.md
@@ -1,46 +1,60 @@
 # Steward: Deduplication
 
-Exact, fuzzy, and semantic deduplication. GPU-accelerated, with
-strict ID-generation and shuffle invariants. The common failure mode
-is silent data loss from a broken dedup pass — this steward exists to
-prevent it.
+This domain exists because deduplication is the pass where mistakes
+silently corrupt training corpora. Over-aggressive dedup quietly drops
+data; under-aggressive dedup leaves duplicates untracked. Both fail
+invisibly until a downstream model trains badly. Curator's bet here is
+that RAPIDS-accelerated dedup at multi-node multi-GPU scale removes
+the iterative CPU bottleneck that otherwise dominates trillion-token
+corpus preparation.
 
 Related: root [AGENTS.md](../../../AGENTS.md), parent
 [nemo_curator/AGENTS.md](../../AGENTS.md).
 
 ## Point Of View
 
-The pass that decides what data survives. Over-aggressive dedup
-silently drops data; under-aggressive dedup leaves duplicates
-untracked. Both are invisible until a downstream model trains on the
-wrong corpus.
+The pass that decides what data survives. Determinism is sacred: the
+same input must produce the same survivor set across runs, across
+backends, across rebuilds. The three modes (exact / fuzzy / semantic)
+exist because they answer different questions about "duplicate," and
+each has its own GPU-acceleration story (cuDF for hashing and string
+ops, cuGraph for fuzzy connected components, cuML for semantic
+clustering).
 
 ## Protect
 
-- **Three-mode coverage.** `exact/`, `fuzzy/`, `semantic/` are all
+- **Three-mode coverage** — `exact/`, `fuzzy/`, `semantic/` are all
   first-class. None can be quietly broken to fix the others.
-- **ID generation determinism** (`id_generator.py`): IDs must be
+- **ID generation determinism** (`id_generator.py`). IDs must be
   reproducible across runs and across backends for the same input.
-  Non-determinism corrupts joins.
+  Non-determinism corrupts downstream joins. Hash/salt changes are
+  migration events with on-disk impact.
 - **Shuffle invariants** (`shuffle_utils/` and
-  `backends/ray_actor_pool/shuffle_adapter.py`): shuffle-based passes
+  `backends/ray_actor_pool/shuffle_adapter.py`). Shuffle-based passes
   must be order-independent on the final survivor set.
 - **CUDA gating (current reality + active advocacy).** RAPIDS imports
   are at module top level today: `io_utils.py:18`,
   `exact/identification.py:17`,
   `fuzzy/{connected_components,minhash}.py:18`, `fuzzy/lsh/lsh.py:20`,
   `semantic/{kmeans,pairwise}.py`,
-  `shuffle_utils/rapidsmpf_shuffler.py:19`. *Importing* the dedup
-  package requires `deduplication_cuda12` installed — CPU-only
-  installs cannot even `import nemo_curator.stages.deduplication`.
-  Until lazy-import work lands, every dedup doc, tutorial, and error
+  `shuffle_utils/rapidsmpf_shuffler.py:19`. Importing the dedup
+  package therefore requires `deduplication_cuda12` installed. Until
+  lazy-import work lands, every dedup doc, tutorial, and error
   message must state the GPU + `deduplication_cuda12` prerequisite.
-- **IO round-trip** (`io_utils.py`): readers and writers used by
-  dedup must preserve IDs, source paths, and dedup keys.
+- **IO round-trip** (`io_utils.py`). Readers and writers used by
+  dedup preserve IDs, source paths, and dedup keys.
 - **Fault tolerance.** Dedup is long-running; partial state on
   preemption must be safely recoverable. Partial output files must
   not be mistaken for completed shards (write atomically or
   stage-then-rename).
+- **Published benchmark surface** — fuzzy dedup on TB-scale corpora
+  with near-linear multi-node scaling. The defended pattern is
+  GPU-accelerated dedup outperforming CPU-based alternatives by an
+  order of magnitude; regressions on these workloads are P0.
+- **Embedding model server for semantic dedup.** NeMo Retriever Text
+  Embedding NIM is the default; the surface accepts custom embedding
+  models. Semantic dedup is inference-bearing — coordinate with the
+  Inference Acceleration Steward.
 
 ## Contract Checklist
 
@@ -64,14 +78,14 @@ When this domain changes:
   CPU-only install and fails loudly only when a dedup stage is
   constructed or run. Closes the gap between the repo-wide invariant
   in root AGENTS.md and current behavior.
-- Per-mode determinism tests on tiny fixtures (exact / fuzzy /
+- **Per-mode determinism tests** on tiny fixtures (exact / fuzzy /
   semantic), run on every PR.
-- Fail-fast diagnostics when running dedup without GPU or
+- **Fail-fast diagnostics** when running dedup without GPU or
   `deduplication_cuda12` installed.
-- Progress reporting on long-running dedup jobs.
-- Documented per-mode memory-budget guidance (GPU memory vs corpus
-  size).
-- Schema-versioned on-disk format for intermediate dedup state so
+- **Progress reporting** on long-running dedup jobs.
+- **Documented per-mode memory-budget guidance** (GPU memory vs
+  corpus size).
+- **Schema-versioned on-disk format** for intermediate dedup state so
   resumed jobs detect incompatible state instead of corrupting
   output.
 

--- a/nemo_curator/stages/deduplication/AGENTS.md
+++ b/nemo_curator/stages/deduplication/AGENTS.md
@@ -1,0 +1,138 @@
+# Steward: Deduplication
+
+Exact, fuzzy, and semantic deduplication. GPU-accelerated, with strict
+ID-generation and shuffle invariants. The most common failure mode is
+silent data loss from a broken dedup pass — this steward exists to
+prevent that.
+
+Related docs:
+
+- root [AGENTS.md](../../../AGENTS.md)
+- parent [nemo_curator/AGENTS.md](../../AGENTS.md)
+- `fern/` deduplication concept and how-to pages
+
+## Point Of View
+
+The pass that decides what data survives. Wrong dedup behavior produces
+either silent data loss (over-aggressive) or untracked duplicates
+(under-aggressive). Both are user-invisible until a downstream model
+trains on the wrong corpus.
+
+## Protect
+
+- **Three-mode coverage**: `exact/`, `fuzzy/`, `semantic/` are all
+  first-class. None can be quietly broken to fix the others.
+- **ID generation determinism** (`id_generator.py`): IDs must be
+  reproducible across runs and across backends for the same input.
+  Non-determinism here corrupts joins.
+- **Shuffle invariants** (`shuffle_utils/` and
+  `backends/ray_actor_pool/shuffle_adapter.py`): shuffle-based passes
+  must be order-independent on the final survivor set.
+- **CUDA gating (current reality + active advocacy)**: deduplication
+  relies on RAPIDS (cuDF/cuML/cuPy). **Today, RAPIDS imports are at
+  module top level** in `io_utils.py:18`, `exact/identification.py:17`,
+  `fuzzy/{connected_components.py:18, minhash.py:18, lsh/lsh.py:20}`,
+  `semantic/{kmeans.py:18, pairwise.py:20-21}`, and
+  `shuffle_utils/rapidsmpf_shuffler.py:19`. That means
+  *importing* the dedup package requires `deduplication_cuda12`
+  installed — CPU-only installs cannot even `import
+  nemo_curator.stages.deduplication`. Until lazy-import work lands,
+  every dedup doc, tutorial, and error message must state the GPU +
+  `deduplication_cuda12` prerequisite explicitly. Making these
+  imports lazy is open advocacy (below).
+- **IO contract** (`io_utils.py`): readers and writers used by dedup
+  must round-trip metadata (IDs, source paths, dedup keys) without
+  loss.
+- **Fault tolerance**: dedup is long-running; partial state on
+  preemption must be safely recoverable. Partial output files must not
+  be mistaken for completed shards.
+
+## Contract Checklist
+
+When this domain changes:
+
+- `nemo_curator/stages/deduplication/exact/`,
+  `fuzzy/`, `semantic/`, `shuffle_utils/`
+- `nemo_curator/stages/deduplication/id_generator.py`,
+  `io_utils.py`, `gpu_utils.py`
+- `nemo_curator/backends/ray_actor_pool/shuffle_adapter.py`,
+  `raft_adapter.py`
+- `tests/stages/deduplication/` — every algorithmic change needs a
+  determinism test on a fixed fixture
+- `pyproject.toml` `deduplication_cuda12` extras group; install docs
+- `fern/` dedup pages — install prerequisites (GPU, extras),
+  configuration examples, performance notes
+- `tutorials/text/` dedup examples if present
+- `CHANGELOG.md` for behavior changes
+
+## Advocate
+
+- **Lazy-import RAPIDS** at module top level across the dedup tree
+  (see Protect bullet 4). Goal: `import
+  nemo_curator.stages.deduplication` succeeds on a CPU-only install
+  and fails loudly only when a dedup stage is constructed or run.
+  This closes the gap between the repo-wide invariant in root
+  AGENTS.md and current behavior.
+- A canonical determinism test on a tiny fixture for each of exact /
+  fuzzy / semantic. Run it on every PR.
+- Clearer CLI / config diagnostics when the user runs dedup without
+  GPU or without `deduplication_cuda12` installed — fail fast with a
+  pointer to install docs.
+- Better progress reporting on long-running dedup jobs.
+- Documented memory-budget guidance per dedup mode (how much GPU
+  memory for how much corpus).
+- A schema-versioned on-disk format for intermediate dedup state so
+  resumed jobs detect incompatible state instead of corrupting output.
+
+## Serve Peers
+
+- **To pipeline-contract steward**: dedup stages exercise composite
+  stages, shuffles, and resource declarations harder than any other
+  modality. Surface places where the base contract is awkward.
+- **To backends steward**: shuffle and RAFT adapters are dedup-driven.
+  Coordinate when adapter interfaces change.
+- **To text steward**: most dedup use cases today are textual. Keep
+  the text-dedup integration documented and tested.
+- **To docs steward**: install prereqs, GPU requirements, and
+  configuration are the most common dedup support questions —
+  prioritize their accuracy.
+- **To benchmarking steward**: dedup is a primary performance gate;
+  keep benchmarks current.
+
+## Do Not
+
+- Add new top-level RAPIDS imports. The existing top-level imports
+  are a known regression we are paying down (see Advocate); do not
+  expand the footprint while that work is open. New code that touches
+  RAPIDS lazy-imports inside the GPU code path.
+- Document a dedup workflow without naming the install extras and GPU
+  prerequisite.
+- Ship a dedup change without a determinism test.
+- Change ID-generation hashing or salting without a migration note in
+  `CHANGELOG.md`. Existing on-disk IDs become invalid.
+- Treat partial output files as completed (write atomically or to
+  staging then rename).
+
+## Own
+
+**Code surfaces**:
+
+- `nemo_curator/stages/deduplication/`
+
+**Tests**:
+
+- `tests/stages/deduplication/`
+
+**Docs (autopilot audit surface)**:
+
+- `fern/` deduplication concept pages, how-to pages, configuration
+  reference, install/prerequisite pages (canonical paths to be pinned
+  in the next docs autopilot pass)
+
+**Agent-facing artifacts**:
+
+- None scoped to dedup yet; if dedup-specific cursor rules or skills
+  emerge, list them here and run the docs-first evaluation gate first.
+
+**CODEOWNERS routing**: `@ayushdg @praateekmahajan`. Every dedup PR
+routes here.

--- a/nemo_curator/stages/deduplication/AGENTS.md
+++ b/nemo_curator/stages/deduplication/AGENTS.md
@@ -1,138 +1,95 @@
 # Steward: Deduplication
 
-Exact, fuzzy, and semantic deduplication. GPU-accelerated, with strict
-ID-generation and shuffle invariants. The most common failure mode is
-silent data loss from a broken dedup pass — this steward exists to
-prevent that.
+Exact, fuzzy, and semantic deduplication. GPU-accelerated, with
+strict ID-generation and shuffle invariants. The common failure mode
+is silent data loss from a broken dedup pass — this steward exists to
+prevent it.
 
-Related docs:
-
-- root [AGENTS.md](../../../AGENTS.md)
-- parent [nemo_curator/AGENTS.md](../../AGENTS.md)
-- `fern/` deduplication concept and how-to pages
+Related: root [AGENTS.md](../../../AGENTS.md), parent
+[nemo_curator/AGENTS.md](../../AGENTS.md).
 
 ## Point Of View
 
-The pass that decides what data survives. Wrong dedup behavior produces
-either silent data loss (over-aggressive) or untracked duplicates
-(under-aggressive). Both are user-invisible until a downstream model
-trains on the wrong corpus.
+The pass that decides what data survives. Over-aggressive dedup
+silently drops data; under-aggressive dedup leaves duplicates
+untracked. Both are invisible until a downstream model trains on the
+wrong corpus.
 
 ## Protect
 
-- **Three-mode coverage**: `exact/`, `fuzzy/`, `semantic/` are all
+- **Three-mode coverage.** `exact/`, `fuzzy/`, `semantic/` are all
   first-class. None can be quietly broken to fix the others.
 - **ID generation determinism** (`id_generator.py`): IDs must be
   reproducible across runs and across backends for the same input.
-  Non-determinism here corrupts joins.
+  Non-determinism corrupts joins.
 - **Shuffle invariants** (`shuffle_utils/` and
   `backends/ray_actor_pool/shuffle_adapter.py`): shuffle-based passes
   must be order-independent on the final survivor set.
-- **CUDA gating (current reality + active advocacy)**: deduplication
-  relies on RAPIDS (cuDF/cuML/cuPy). **Today, RAPIDS imports are at
-  module top level** in `io_utils.py:18`, `exact/identification.py:17`,
-  `fuzzy/{connected_components.py:18, minhash.py:18, lsh/lsh.py:20}`,
-  `semantic/{kmeans.py:18, pairwise.py:20-21}`, and
-  `shuffle_utils/rapidsmpf_shuffler.py:19`. That means
-  *importing* the dedup package requires `deduplication_cuda12`
-  installed — CPU-only installs cannot even `import
-  nemo_curator.stages.deduplication`. Until lazy-import work lands,
-  every dedup doc, tutorial, and error message must state the GPU +
-  `deduplication_cuda12` prerequisite explicitly. Making these
-  imports lazy is open advocacy (below).
-- **IO contract** (`io_utils.py`): readers and writers used by dedup
-  must round-trip metadata (IDs, source paths, dedup keys) without
-  loss.
-- **Fault tolerance**: dedup is long-running; partial state on
-  preemption must be safely recoverable. Partial output files must not
-  be mistaken for completed shards.
+- **CUDA gating (current reality + active advocacy).** RAPIDS imports
+  are at module top level today: `io_utils.py:18`,
+  `exact/identification.py:17`,
+  `fuzzy/{connected_components,minhash}.py:18`, `fuzzy/lsh/lsh.py:20`,
+  `semantic/{kmeans,pairwise}.py`,
+  `shuffle_utils/rapidsmpf_shuffler.py:19`. *Importing* the dedup
+  package requires `deduplication_cuda12` installed — CPU-only
+  installs cannot even `import nemo_curator.stages.deduplication`.
+  Until lazy-import work lands, every dedup doc, tutorial, and error
+  message must state the GPU + `deduplication_cuda12` prerequisite.
+- **IO round-trip** (`io_utils.py`): readers and writers used by
+  dedup must preserve IDs, source paths, and dedup keys.
+- **Fault tolerance.** Dedup is long-running; partial state on
+  preemption must be safely recoverable. Partial output files must
+  not be mistaken for completed shards (write atomically or
+  stage-then-rename).
 
 ## Contract Checklist
 
 When this domain changes:
 
-- `nemo_curator/stages/deduplication/exact/`,
-  `fuzzy/`, `semantic/`, `shuffle_utils/`
-- `nemo_curator/stages/deduplication/id_generator.py`,
-  `io_utils.py`, `gpu_utils.py`
-- `nemo_curator/backends/ray_actor_pool/shuffle_adapter.py`,
-  `raft_adapter.py`
-- `tests/stages/deduplication/` — every algorithmic change needs a
+- `stages/deduplication/{exact,fuzzy,semantic,shuffle_utils}/`,
+  `id_generator.py`, `io_utils.py`, `gpu_utils.py`
+- `backends/ray_actor_pool/{shuffle_adapter,raft_adapter}.py`
+- `tests/stages/deduplication/` — algorithmic changes need a
   determinism test on a fixed fixture
-- `pyproject.toml` `deduplication_cuda12` extras group; install docs
-- `fern/` dedup pages — install prerequisites (GPU, extras),
-  configuration examples, performance notes
+- `pyproject.toml` `deduplication_cuda12` extras group
+- `fern/` dedup concept and how-to pages (install prereqs, GPU
+  requirements, configuration)
 - `tutorials/text/` dedup examples if present
-- `CHANGELOG.md` for behavior changes
+- `CHANGELOG.md`
 
 ## Advocate
 
-- **Lazy-import RAPIDS** at module top level across the dedup tree
-  (see Protect bullet 4). Goal: `import
-  nemo_curator.stages.deduplication` succeeds on a CPU-only install
-  and fails loudly only when a dedup stage is constructed or run.
-  This closes the gap between the repo-wide invariant in root
-  AGENTS.md and current behavior.
-- A canonical determinism test on a tiny fixture for each of exact /
-  fuzzy / semantic. Run it on every PR.
-- Clearer CLI / config diagnostics when the user runs dedup without
-  GPU or without `deduplication_cuda12` installed — fail fast with a
-  pointer to install docs.
-- Better progress reporting on long-running dedup jobs.
-- Documented memory-budget guidance per dedup mode (how much GPU
-  memory for how much corpus).
-- A schema-versioned on-disk format for intermediate dedup state so
-  resumed jobs detect incompatible state instead of corrupting output.
-
-## Serve Peers
-
-- **To pipeline-contract steward**: dedup stages exercise composite
-  stages, shuffles, and resource declarations harder than any other
-  modality. Surface places where the base contract is awkward.
-- **To backends steward**: shuffle and RAFT adapters are dedup-driven.
-  Coordinate when adapter interfaces change.
-- **To text steward**: most dedup use cases today are textual. Keep
-  the text-dedup integration documented and tested.
-- **To docs steward**: install prereqs, GPU requirements, and
-  configuration are the most common dedup support questions —
-  prioritize their accuracy.
-- **To benchmarking steward**: dedup is a primary performance gate;
-  keep benchmarks current.
+- **Lazy-import RAPIDS** at module top level across the dedup tree.
+  Goal: `import nemo_curator.stages.deduplication` succeeds on a
+  CPU-only install and fails loudly only when a dedup stage is
+  constructed or run. Closes the gap between the repo-wide invariant
+  in root AGENTS.md and current behavior.
+- Per-mode determinism tests on tiny fixtures (exact / fuzzy /
+  semantic), run on every PR.
+- Fail-fast diagnostics when running dedup without GPU or
+  `deduplication_cuda12` installed.
+- Progress reporting on long-running dedup jobs.
+- Documented per-mode memory-budget guidance (GPU memory vs corpus
+  size).
+- Schema-versioned on-disk format for intermediate dedup state so
+  resumed jobs detect incompatible state instead of corrupting
+  output.
 
 ## Do Not
 
-- Add new top-level RAPIDS imports. The existing top-level imports
-  are a known regression we are paying down (see Advocate); do not
-  expand the footprint while that work is open. New code that touches
-  RAPIDS lazy-imports inside the GPU code path.
-- Document a dedup workflow without naming the install extras and GPU
-  prerequisite.
-- Ship a dedup change without a determinism test.
-- Change ID-generation hashing or salting without a migration note in
-  `CHANGELOG.md`. Existing on-disk IDs become invalid.
-- Treat partial output files as completed (write atomically or to
-  staging then rename).
+- **Add new top-level RAPIDS imports** — the existing footprint is a
+  known regression being paid down. New code lazy-imports inside the
+  GPU path.
+- **Change ID-generation hashing or salting** without a migration
+  note in `CHANGELOG.md` — existing on-disk IDs become invalid.
 
 ## Own
 
-**Code surfaces**:
+**Code:** `nemo_curator/stages/deduplication/`.
 
-- `nemo_curator/stages/deduplication/`
+**Tests:** `tests/stages/deduplication/`.
 
-**Tests**:
+**Docs (autopilot surface):** `fern/` dedup concept, how-to,
+configuration reference, install/prerequisite pages.
 
-- `tests/stages/deduplication/`
-
-**Docs (autopilot audit surface)**:
-
-- `fern/` deduplication concept pages, how-to pages, configuration
-  reference, install/prerequisite pages (canonical paths to be pinned
-  in the next docs autopilot pass)
-
-**Agent-facing artifacts**:
-
-- None scoped to dedup yet; if dedup-specific cursor rules or skills
-  emerge, list them here and run the docs-first evaluation gate first.
-
-**CODEOWNERS routing**: `@ayushdg @praateekmahajan`. Every dedup PR
-routes here.
+**CODEOWNERS:** `@ayushdg @praateekmahajan`.

--- a/nemo_curator/stages/synthetic/AGENTS.md
+++ b/nemo_curator/stages/synthetic/AGENTS.md
@@ -1,110 +1,78 @@
 # Steward: Synthetic Data Generation
 
-Synthetic data generation pipelines and prompt templates. Outputs from
-this domain seed downstream training corpora — quality and prompt
-fidelity matter more than raw throughput.
+Synthetic data generation pipelines and prompt content. Outputs seed
+downstream training corpora — quality and prompt fidelity matter more
+than raw throughput.
 
-Related docs:
-
-- root [AGENTS.md](../../../AGENTS.md)
-- parent [nemo_curator/AGENTS.md](../../AGENTS.md)
-- `fern/` synthetic data curation pages
+Related: root [AGENTS.md](../../../AGENTS.md), parent
+[nemo_curator/AGENTS.md](../../AGENTS.md).
 
 ## Point Of View
 
-Prompts in, generated samples out. Owners of every prompt template
-the framework ships, every model integration that produces synthetic
-text, and the post-filters that decide which generated samples
-survive.
+Prompts in, generated samples out. Owns every prompt the framework
+ships, every model integration that produces synthetic text, and the
+post-filters that decide which generated samples survive.
 
 ## Protect
 
-- **Prompt template integrity**: today SDG prompts ship as Python
-  string constants in `nemotron_cc/prompts.py` (no YAML/JSON/text
-  template files exist under `stages/synthetic/`). The constants are
-  effectively public API; edits change downstream model behavior —
+- **Prompt content.** SDG prompts today ship as Python string
+  constants in `nemotron_cc/prompts.py` (no YAML/JSON/text template
+  files exist under `stages/synthetic/`). These constants are
+  effectively public API — edits change downstream model behavior, so
   version, document, and changelog them.
-- **Template packaging (if/when file-based templates are
-  introduced)**: `MANIFEST.in` already does `recursive-include
-  nemo_curator *.csv *.json *.yaml *.yml *.txt *.md`, so file-based
-  templates under `nemo_curator/stages/synthetic/` will be packaged
-  by default. For modality-specific prompt directories under other
-  trees, mirror the precedent set by the translation-prompts
-  packaging (see `pyproject.toml`'s `[tool.setuptools.package-data]`
-  section for `nemo_curator.stages.text.experimental.translation`).
-- **Output reproducibility**: given a fixed seed, model, and prompt,
+- **Output reproducibility.** Given a fixed seed, model, and prompt,
   outputs must be reproducible to the extent the underlying model
   allows.
-- **Filter semantics**: any quality / safety / dedup filter applied
+- **Filter semantics.** Any quality / safety / dedup filter applied
   to generated samples must be documented and tested.
-- **Model integration boundaries**: any external LLM API (NIM,
-  OpenAI-compatible, etc.) must surface failures and rate-limits
-  clearly, retry safely, and respect quotas.
+- **Model integration boundaries.** External LLM APIs (NIM,
+  OpenAI-compatible) must surface failures and rate limits clearly,
+  retry safely, respect quotas.
+- **Packaging (if/when file-based templates land).** `MANIFEST.in`
+  already does `recursive-include nemo_curator *.csv *.json *.yaml
+  *.yml *.txt *.md`, so file-based templates under
+  `stages/synthetic/` will be packaged by default. For
+  modality-specific prompt directories elsewhere, mirror the
+  translation-prompts precedent in `pyproject.toml`'s
+  `[tool.setuptools.package-data]` for
+  `nemo_curator.stages.text.experimental.translation`.
 
 ## Contract Checklist
 
 When this domain changes:
 
 - `nemo_curator/stages/synthetic/`
-- Prompt template files (paths and packaging)
+- Prompt strings (paths and content)
 - `MANIFEST.in` and `pyproject.toml` package-data declarations if
-  templates moved
+  file-based templates are added
 - `tests/stages/synthetic/`
-- `fern/` synthetic data curation pages
+- `fern/` synthetic curation pages
 - `tutorials/synthetic/`
 - `CHANGELOG.md`
 
 ## Advocate
 
-- A programmatic registry for the prompt constants currently in
-  `nemotron_cc/prompts.py` (today they are module-level constants
-  with no `__all__` / loader), so docs and tutorials do not
-  hand-enumerate.
-- A test that imports the package and asserts each template loads —
-  catches packaging regressions early.
-- Documentation of each template's intended use, expected output
-  shape, and known failure modes.
+- A programmatic registry for the constants in `nemotron_cc/prompts.py`
+  (module-level constants today, no `__all__` / loader) so docs and
+  tutorials don't hand-enumerate.
+- A test that imports the package and asserts each prompt constant
+  loads — catches packaging regressions early.
+- Documentation of each prompt's intended use, expected output shape,
+  and known failure modes.
 - A consistent seed / determinism story across generators.
-
-## Serve Peers
-
-- **To text steward**: SDG outputs are usually `DocumentBatch`. Keep
-  the integration documented.
-- **To pipeline-contract steward**: SDG often uses long-running
-  external-API stages — surface where fault-tolerance contracts are
-  awkward.
-- **To docs steward**: prompt templates are easy to drift from docs;
-  prioritize accuracy of any "templates we ship" claim.
-
-## Do Not
-
-- Edit a shipped prompt template without a changelog entry and a
-  version bump if downstream behavior changes.
-- Ship a new template without verifying it loads from an installed
-  wheel (not just from source checkout).
-- Hard-code API keys or model endpoints; use environment / config.
-- Document a template that does not exist on disk.
 
 ## Own
 
-**Code surfaces**:
+**Code:**
 
 - `nemo_curator/stages/synthetic/nemo_data_designer/data_designer.py`
-- `nemo_curator/stages/synthetic/nemotron_cc/{base.py, nemotron_cc.py, prompts.py}`
+- `nemo_curator/stages/synthetic/nemotron_cc/{base,nemotron_cc,prompts}.py`
 - `nemo_curator/stages/synthetic/qa_multilingual_synthetic.py`
-- Any future file-based prompt templates under
-  `nemo_curator/stages/synthetic/`
+- Any future file-based prompt templates under `stages/synthetic/`
 
-**Tests**:
+**Tests:** `tests/stages/synthetic/`.
 
-- `tests/stages/synthetic/`
+**Docs (autopilot surface):** `fern/` synthetic curation concepts,
+prompt reference, model integration guides, tutorials.
 
-**Docs (autopilot audit surface)**:
-
-- `fern/` synthetic data curation concept pages, templates reference,
-  model integration guides, tutorials (canonical paths to be pinned
-  in the next docs autopilot pass)
-
-**Agent-facing artifacts**: none scoped to SDG yet.
-
-**CODEOWNERS routing**: `@huvunvidia`. Every SDG PR routes here.
+**CODEOWNERS:** `@huvunvidia`.

--- a/nemo_curator/stages/synthetic/AGENTS.md
+++ b/nemo_curator/stages/synthetic/AGENTS.md
@@ -1,0 +1,110 @@
+# Steward: Synthetic Data Generation
+
+Synthetic data generation pipelines and prompt templates. Outputs from
+this domain seed downstream training corpora — quality and prompt
+fidelity matter more than raw throughput.
+
+Related docs:
+
+- root [AGENTS.md](../../../AGENTS.md)
+- parent [nemo_curator/AGENTS.md](../../AGENTS.md)
+- `fern/` synthetic data curation pages
+
+## Point Of View
+
+Prompts in, generated samples out. Owners of every prompt template
+the framework ships, every model integration that produces synthetic
+text, and the post-filters that decide which generated samples
+survive.
+
+## Protect
+
+- **Prompt template integrity**: today SDG prompts ship as Python
+  string constants in `nemotron_cc/prompts.py` (no YAML/JSON/text
+  template files exist under `stages/synthetic/`). The constants are
+  effectively public API; edits change downstream model behavior —
+  version, document, and changelog them.
+- **Template packaging (if/when file-based templates are
+  introduced)**: `MANIFEST.in` already does `recursive-include
+  nemo_curator *.csv *.json *.yaml *.yml *.txt *.md`, so file-based
+  templates under `nemo_curator/stages/synthetic/` will be packaged
+  by default. For modality-specific prompt directories under other
+  trees, mirror the precedent set by the translation-prompts
+  packaging (see `pyproject.toml`'s `[tool.setuptools.package-data]`
+  section for `nemo_curator.stages.text.experimental.translation`).
+- **Output reproducibility**: given a fixed seed, model, and prompt,
+  outputs must be reproducible to the extent the underlying model
+  allows.
+- **Filter semantics**: any quality / safety / dedup filter applied
+  to generated samples must be documented and tested.
+- **Model integration boundaries**: any external LLM API (NIM,
+  OpenAI-compatible, etc.) must surface failures and rate-limits
+  clearly, retry safely, and respect quotas.
+
+## Contract Checklist
+
+When this domain changes:
+
+- `nemo_curator/stages/synthetic/`
+- Prompt template files (paths and packaging)
+- `MANIFEST.in` and `pyproject.toml` package-data declarations if
+  templates moved
+- `tests/stages/synthetic/`
+- `fern/` synthetic data curation pages
+- `tutorials/synthetic/`
+- `CHANGELOG.md`
+
+## Advocate
+
+- A programmatic registry for the prompt constants currently in
+  `nemotron_cc/prompts.py` (today they are module-level constants
+  with no `__all__` / loader), so docs and tutorials do not
+  hand-enumerate.
+- A test that imports the package and asserts each template loads —
+  catches packaging regressions early.
+- Documentation of each template's intended use, expected output
+  shape, and known failure modes.
+- A consistent seed / determinism story across generators.
+
+## Serve Peers
+
+- **To text steward**: SDG outputs are usually `DocumentBatch`. Keep
+  the integration documented.
+- **To pipeline-contract steward**: SDG often uses long-running
+  external-API stages — surface where fault-tolerance contracts are
+  awkward.
+- **To docs steward**: prompt templates are easy to drift from docs;
+  prioritize accuracy of any "templates we ship" claim.
+
+## Do Not
+
+- Edit a shipped prompt template without a changelog entry and a
+  version bump if downstream behavior changes.
+- Ship a new template without verifying it loads from an installed
+  wheel (not just from source checkout).
+- Hard-code API keys or model endpoints; use environment / config.
+- Document a template that does not exist on disk.
+
+## Own
+
+**Code surfaces**:
+
+- `nemo_curator/stages/synthetic/nemo_data_designer/data_designer.py`
+- `nemo_curator/stages/synthetic/nemotron_cc/{base.py, nemotron_cc.py, prompts.py}`
+- `nemo_curator/stages/synthetic/qa_multilingual_synthetic.py`
+- Any future file-based prompt templates under
+  `nemo_curator/stages/synthetic/`
+
+**Tests**:
+
+- `tests/stages/synthetic/`
+
+**Docs (autopilot audit surface)**:
+
+- `fern/` synthetic data curation concept pages, templates reference,
+  model integration guides, tutorials (canonical paths to be pinned
+  in the next docs autopilot pass)
+
+**Agent-facing artifacts**: none scoped to SDG yet.
+
+**CODEOWNERS routing**: `@huvunvidia`. Every SDG PR routes here.

--- a/nemo_curator/stages/synthetic/AGENTS.md
+++ b/nemo_curator/stages/synthetic/AGENTS.md
@@ -66,7 +66,9 @@ When this domain changes:
 **Code:**
 
 - `nemo_curator/stages/synthetic/nemo_data_designer/data_designer.py`
-- `nemo_curator/stages/synthetic/nemotron_cc/{base,nemotron_cc,prompts}.py`
+- `nemo_curator/stages/synthetic/nemotron_cc/` — top-level
+  (`base.py`, `nemotron_cc.py`, `prompts.py`) plus nested
+  `nemotron_cc/nemo_data_designer/{base,nemotron_cc}.py`
 - `nemo_curator/stages/synthetic/qa_multilingual_synthetic.py`
 - Any future file-based prompt templates under `stages/synthetic/`
 

--- a/nemo_curator/stages/synthetic/AGENTS.md
+++ b/nemo_curator/stages/synthetic/AGENTS.md
@@ -1,41 +1,58 @@
 # Steward: Synthetic Data Generation
 
-Synthetic data generation pipelines and prompt content. Outputs seed
-downstream training corpora — quality and prompt fidelity matter more
-than raw throughput.
+This domain exists because synthetic data generation is an
+inference-dominated workload — the model-serving stack is where cost
+and throughput live. SDG pipelines spend the vast majority of their
+time in LLM inference; everything else (filters, modifiers, post-
+processing) is supporting infrastructure around that core. Curator's
+job here is to compose generation, scoring, and filtering stages over
+an OpenAI-API-compatible model server with predictable throughput.
 
 Related: root [AGENTS.md](../../../AGENTS.md), parent
-[nemo_curator/AGENTS.md](../../AGENTS.md).
+[nemo_curator/AGENTS.md](../../AGENTS.md). Inference choices route
+through the Inference Acceleration Steward (root AGENTS.md).
 
 ## Point Of View
 
 Prompts in, generated samples out. Owns every prompt the framework
 ships, every model integration that produces synthetic text, and the
-post-filters that decide which generated samples survive.
+post-filters that decide which generated samples survive. The
+deployment-pattern choice — in-process model load per stage versus
+CPU-only Curator stages calling a local model server — is a
+first-class user-facing decision, not an implementation detail.
 
 ## Protect
 
-- **Prompt content.** SDG prompts today ship as Python string
+- **Prompt content.** Today SDG prompts ship as Python string
   constants in `nemotron_cc/prompts.py` (no YAML/JSON/text template
-  files exist under `stages/synthetic/`). These constants are
-  effectively public API — edits change downstream model behavior, so
+  files exist under `stages/synthetic/`). The constants are
+  effectively public API; edits change downstream model behavior —
   version, document, and changelog them.
+- **Two deployment patterns are first-class:**
+  - *In-process* — model loaded per stage worker; works when the
+    model fits within a Curator worker's GPU memory budget. Stage
+    owns the model lifecycle.
+  - *Server-endpoint* — Curator stages (CPU-only) call a local model
+    server; N vLLM replicas across multiple nodes; saves infra
+    setup; lets users switch between hosted and self-hosted models
+    without code changes. Coordinate with the Inference
+    Acceleration Steward on serving stack choice.
+- **OpenAI-API compatibility.** SDG stages call OpenAI-compatible
+  endpoints; integration with custom Instruct/Reward models works
+  through that contract.
 - **Output reproducibility.** Given a fixed seed, model, and prompt,
-  outputs must be reproducible to the extent the underlying model
-  allows.
+  outputs are reproducible to the extent the underlying model
+  allows. Document expected variance — without that, every
+  regression looks like "did we break it or did the model drift?"
 - **Filter semantics.** Any quality / safety / dedup filter applied
   to generated samples must be documented and tested.
-- **Model integration boundaries.** External LLM APIs (NIM,
-  OpenAI-compatible) must surface failures and rate limits clearly,
-  retry safely, respect quotas.
 - **Packaging (if/when file-based templates land).** `MANIFEST.in`
   already does `recursive-include nemo_curator *.csv *.json *.yaml
   *.yml *.txt *.md`, so file-based templates under
   `stages/synthetic/` will be packaged by default. For
   modality-specific prompt directories elsewhere, mirror the
   translation-prompts precedent in `pyproject.toml`'s
-  `[tool.setuptools.package-data]` for
-  `nemo_curator.stages.text.experimental.translation`.
+  `[tool.setuptools.package-data]`.
 
 ## Contract Checklist
 
@@ -52,14 +69,14 @@ When this domain changes:
 
 ## Advocate
 
-- A programmatic registry for the constants in `nemotron_cc/prompts.py`
-  (module-level constants today, no `__all__` / loader) so docs and
-  tutorials don't hand-enumerate.
-- A test that imports the package and asserts each prompt constant
-  loads — catches packaging regressions early.
-- Documentation of each prompt's intended use, expected output shape,
-  and known failure modes.
-- A consistent seed / determinism story across generators.
+- **A programmatic registry for prompt constants** in
+  `nemotron_cc/prompts.py` (module-level constants today, no
+  `__all__` / loader) so docs and tutorials don't hand-enumerate.
+- **A test that imports the package and asserts each prompt
+  constant loads** — catches packaging regressions early.
+- **Documentation of each prompt's intended use**, expected output
+  shape, and known failure modes.
+- **A consistent seed / determinism story** across generators.
 
 ## Own
 

--- a/nemo_curator/stages/text/AGENTS.md
+++ b/nemo_curator/stages/text/AGENTS.md
@@ -28,11 +28,12 @@ a `DocumentBatch`.
   `text/embedders/` lacks an equivalent registry today (see
   Advocate). Renames, removals, and default changes are
   user-visible.
-- **Filter and modifier semantics** (`text/modifiers/`,
-  `text/modules/`): keep/drop predicates and string transforms are
-  contract. Document edge cases (Unicode, whitespace, length
-  cutoffs). Note: there is no `text/filters/` directory —
-  filter-shaped stages live alongside modifiers and modules.
+- **Filter and modifier semantics** (`text/filters/`,
+  `text/modifiers/`, `text/modules/`): keep/drop predicates
+  (`text/filters/{doc_filter,score_filter}.py` and the `fasttext`,
+  `heuristic`, `histogram`, `token` subpackages under filters) and
+  string transforms are contract. Document edge cases (Unicode,
+  whitespace, length cutoffs).
 - **Download stages** (`text/download/`): respect upstream rate
   limits / robots / licensing; surface failures explicitly; retry-safe
   under preemption.
@@ -47,7 +48,7 @@ a `DocumentBatch`.
 
 When this domain changes:
 
-- `stages/text/{classifiers,embedders,modifiers,modules,io,download,utils,experimental,models,deduplication}/`
+- `stages/text/{classifiers,embedders,filters,modifiers,modules,io,download,utils,experimental,models,deduplication}/`
 - `tasks/document.py`
 - `tests/stages/text/`
 - `fern/` text curation pages — classifier names, filter params,
@@ -72,8 +73,9 @@ When this domain changes:
 ## Own
 
 **Code:** `nemo_curator/stages/text/` (subpackages: `classifiers`,
-`embedders`, `modifiers`, `modules`, `io`, `download`, `utils`,
-`experimental`, `models`, `deduplication`); `tasks/document.py`.
+`embedders`, `filters`, `modifiers`, `modules`, `io`, `download`,
+`utils`, `experimental`, `models`, `deduplication`);
+`tasks/document.py`.
 
 **Tests:** `tests/stages/text/`.
 

--- a/nemo_curator/stages/text/AGENTS.md
+++ b/nemo_curator/stages/text/AGENTS.md
@@ -1,0 +1,144 @@
+# Steward: Text Modality
+
+Text is the largest and most diverse modality surface in the repo:
+readers, writers, classifiers, embedders, filters, modifiers,
+modules, and downloader pipelines. This steward defends the text
+public API and routes deep changes in classifiers / embedders to
+their named human owners.
+
+Related docs:
+
+- root [AGENTS.md](../../../AGENTS.md)
+- parent [nemo_curator/AGENTS.md](../../AGENTS.md)
+- `.cursor/rules/modality-structure.mdc`
+- `fern/` text curation pages and tutorials
+
+## Point Of View
+
+The textual corpus. Owners of every transformation that produces or
+mutates a `DocumentBatch`. The most user-touched modality — most
+copy-paste from the docs lands here, so doc-snippet rot bites
+hardest.
+
+## Protect
+
+- **`DocumentBatch` contract** (defined in
+  `nemo_curator/tasks/document.py`): `pa.Table | pd.DataFrame` payload,
+  `num_items` semantics, `validate()` expectations.
+- **Reader/writer round-tripping** (`text/io/`): writing then
+  reading the same data must preserve schema, encoding, and metadata.
+  JSONL, Parquet, and any other supported formats stay symmetric.
+- **Classifier / embedder public surfaces**
+  (`text/classifiers/`, `text/embedders/`): named classifier and
+  embedder classes are part of the documented API.
+  `text/classifiers/__init__.py` exposes a canonical lazy registry
+  via `_LAZY` and `__all__`; renames, removals, and default-changes
+  are user-visible.
+- **Filter and modifier semantics** (`text/modifiers/`,
+  `text/modules/`): a filter's keep/drop predicate and a modifier's
+  string transformation are part of the contract; document
+  edge-case behavior (Unicode, whitespace, length cutoffs). Note:
+  there is no `text/filters/` directory — filter-shaped stages live
+  alongside modifiers and modules.
+- **Download stages** (`text/download/`): respect upstream
+  rate-limits, robots, and licensing; surface failures explicitly;
+  retry-safe under preemption.
+- **GPU vs CPU paths**: text classifiers and embedders often have
+  GPU implementations. Imports gated; resource declarations
+  honest; CPU fallback works.
+- **Tokenizer / model artifact handling**: paths to local caches,
+  HuggingFace identifiers, and any pinning must be stable and
+  documented.
+
+## Contract Checklist
+
+When this domain changes:
+
+- `nemo_curator/stages/text/{classifiers,embedders,modifiers,modules,io,download,utils,experimental,models,deduplication}/`
+- `nemo_curator/tasks/document.py`
+- `tests/stages/text/`
+- `fern/` text curation pages — classifier names, filter parameters,
+  example invocations
+- `tutorials/text/`, `tutorials/quickstart.py`
+- `.cursor/rules/modality-structure.mdc`
+- `CHANGELOG.md` for user-visible behavior changes
+
+## Advocate
+
+- A programmatic embedder registry mirroring
+  `classifiers/__init__.py:_LAZY` so docs do not need to be
+  hand-counted. Surface both registries in `fern/` reference pages
+  auto-generated from `__all__`.
+- Clearer separation between *experimental* (`text/experimental/`)
+  and stable surfaces in the docs.
+- Better diagnostics for misconfigured tokenizer paths and missing
+  model artifacts.
+- Reusable text-fixture data under `tests/data/` so filter and
+  modifier behavior tests stay diverse and current.
+- Improved download-stage resilience under Xenna preemption.
+
+## Serve Peers
+
+- **To pipeline-contract steward**: text exercises composite stages,
+  IO partitioning, and lazy-import patterns harder than other
+  modalities. Surface awkward spots in the base contract.
+- **To deduplication steward**: text dedup integrates exact / fuzzy /
+  semantic dedup; keep the integration documented and tested.
+- **To backends steward**: text classifiers / embedders are the
+  primary GPU stage class. Help validate resource declarations on
+  each backend.
+- **To docs steward**: keep classifier/embedder/filter names and
+  parameters in `fern/` aligned with source. This is the highest
+  Known Regression Pattern surface in the repo.
+- **To tutorials steward**: text tutorials are the most-used; treat
+  their snippets as canonical and audit them on every text-public
+  change.
+
+## Do Not
+
+- Import `cudf`, `cupy`, `torch.cuda`-only paths, `fasttext`,
+  `sentencepiece`, or other optional libs at module top level if
+  they are not in the base install. Lazy-import in the stage.
+- Rename a public classifier or embedder class without a deprecation
+  alias + changelog entry + Fern doc update + tutorial update in the
+  same PR.
+- Add a filter / modifier parameter without documenting it in
+  `fern/` and adding a test.
+- Use `print()`; use `loguru`.
+- Hardcode HuggingFace model IDs in docs that no longer exist on
+  the Hub — verify before merging.
+
+## Own
+
+**Code surfaces**:
+
+- `nemo_curator/stages/text/` (subpackages: `classifiers`,
+  `embedders`, `modifiers`, `modules`, `io`, `download`, `utils`,
+  `experimental`, `models`, `deduplication`)
+- `nemo_curator/tasks/document.py`
+
+**Tests**:
+
+- `tests/stages/text/`
+
+**Docs (autopilot audit surface)**:
+
+- `fern/` text curation concept pages, classifier reference,
+  embedder reference, filter reference, modifier reference, download
+  pipelines, tutorials (canonical paths to be pinned in the next docs
+  autopilot pass)
+- Text-related sections of `README.md`
+
+**Agent-facing artifacts**:
+
+- `.cursor/rules/modality-structure.mdc` (text portion)
+
+**CODEOWNERS routing**:
+
+- Default: `@NVIDIA-NeMo/curator_reviewers`
+- `nemo_curator/stages/text/classifiers/`:
+  `@sarahyurick @praateekmahajan @VibhuJawa`
+- `nemo_curator/stages/text/embedders/`:
+  `@sarahyurick @praateekmahajan @VibhuJawa`
+
+Any classifier / embedder PR must route to the named team.

--- a/nemo_curator/stages/text/AGENTS.md
+++ b/nemo_curator/stages/text/AGENTS.md
@@ -1,52 +1,45 @@
 # Steward: Text Modality
 
-Text is the largest and most diverse modality surface in the repo:
-readers, writers, classifiers, embedders, filters, modifiers,
-modules, and downloader pipelines. This steward defends the text
-public API and routes deep changes in classifiers / embedders to
-their named human owners.
+Text is the largest and most diverse modality: readers, writers,
+classifiers, embedders, modifiers, modules, and download pipelines.
+The most user-touched modality — most copy-paste from the docs lands
+here, so doc-snippet rot bites hardest.
 
-Related docs:
-
-- root [AGENTS.md](../../../AGENTS.md)
-- parent [nemo_curator/AGENTS.md](../../AGENTS.md)
-- `.cursor/rules/modality-structure.mdc`
-- `fern/` text curation pages and tutorials
+Related: root [AGENTS.md](../../../AGENTS.md), parent
+[nemo_curator/AGENTS.md](../../AGENTS.md),
+`.cursor/rules/modality-structure.mdc`.
 
 ## Point Of View
 
-The textual corpus. Owners of every transformation that produces or
-mutates a `DocumentBatch`. The most user-touched modality — most
-copy-paste from the docs lands here, so doc-snippet rot bites
-hardest.
+The textual corpus. Owns every transformation that produces or mutates
+a `DocumentBatch`.
 
 ## Protect
 
-- **`DocumentBatch` contract** (defined in
-  `nemo_curator/tasks/document.py`): `pa.Table | pd.DataFrame` payload,
-  `num_items` semantics, `validate()` expectations.
-- **Reader/writer round-tripping** (`text/io/`): writing then
-  reading the same data must preserve schema, encoding, and metadata.
-  JSONL, Parquet, and any other supported formats stay symmetric.
-- **Classifier / embedder public surfaces**
-  (`text/classifiers/`, `text/embedders/`): named classifier and
-  embedder classes are part of the documented API.
+- **`DocumentBatch` contract** (`nemo_curator/tasks/document.py`):
+  `pa.Table | pd.DataFrame` payload, `num_items` semantics,
+  `validate()` expectations.
+- **Reader/writer round-tripping** (`text/io/`): writing then reading
+  preserves schema, encoding, and metadata for every supported
+  format (JSONL, Parquet, others).
+- **Classifier and embedder public surfaces.**
   `text/classifiers/__init__.py` exposes a canonical lazy registry
-  via `_LAZY` and `__all__`; renames, removals, and default-changes
-  are user-visible.
+  via `_LAZY` and `__all__` — class names there are documented API.
+  `text/embedders/` lacks an equivalent registry today (see
+  Advocate). Renames, removals, and default changes are
+  user-visible.
 - **Filter and modifier semantics** (`text/modifiers/`,
-  `text/modules/`): a filter's keep/drop predicate and a modifier's
-  string transformation are part of the contract; document
-  edge-case behavior (Unicode, whitespace, length cutoffs). Note:
-  there is no `text/filters/` directory — filter-shaped stages live
-  alongside modifiers and modules.
-- **Download stages** (`text/download/`): respect upstream
-  rate-limits, robots, and licensing; surface failures explicitly;
-  retry-safe under preemption.
-- **GPU vs CPU paths**: text classifiers and embedders often have
-  GPU implementations. Imports gated; resource declarations
-  honest; CPU fallback works.
-- **Tokenizer / model artifact handling**: paths to local caches,
+  `text/modules/`): keep/drop predicates and string transforms are
+  contract. Document edge cases (Unicode, whitespace, length
+  cutoffs). Note: there is no `text/filters/` directory —
+  filter-shaped stages live alongside modifiers and modules.
+- **Download stages** (`text/download/`): respect upstream rate
+  limits / robots / licensing; surface failures explicitly; retry-safe
+  under preemption.
+- **GPU/CPU paths.** Text classifiers and embedders often have GPU
+  implementations. Lazy-import GPU libs; declare resources honestly;
+  ensure CPU fallback loads.
+- **Tokenizer / model artifact handling.** Local cache paths,
   HuggingFace identifiers, and any pinning must be stable and
   documented.
 
@@ -54,91 +47,45 @@ hardest.
 
 When this domain changes:
 
-- `nemo_curator/stages/text/{classifiers,embedders,modifiers,modules,io,download,utils,experimental,models,deduplication}/`
-- `nemo_curator/tasks/document.py`
+- `stages/text/{classifiers,embedders,modifiers,modules,io,download,utils,experimental,models,deduplication}/`
+- `tasks/document.py`
 - `tests/stages/text/`
-- `fern/` text curation pages — classifier names, filter parameters,
+- `fern/` text curation pages — classifier names, filter params,
   example invocations
 - `tutorials/text/`, `tutorials/quickstart.py`
 - `.cursor/rules/modality-structure.mdc`
-- `CHANGELOG.md` for user-visible behavior changes
+- `CHANGELOG.md`
 
 ## Advocate
 
-- A programmatic embedder registry mirroring
-  `classifiers/__init__.py:_LAZY` so docs do not need to be
-  hand-counted. Surface both registries in `fern/` reference pages
-  auto-generated from `__all__`.
-- Clearer separation between *experimental* (`text/experimental/`)
-  and stable surfaces in the docs.
+- **Programmatic embedder registry** mirroring
+  `classifiers/__init__.py:_LAZY`, so docs don't hand-count.
+  Auto-generate `fern/` reference pages from `__all__`.
+- Clearer separation between `text/experimental/` and stable
+  surfaces in the docs.
 - Better diagnostics for misconfigured tokenizer paths and missing
   model artifacts.
-- Reusable text-fixture data under `tests/data/` so filter and
-  modifier behavior tests stay diverse and current.
+- Reusable text fixtures under `tests/data/` so filter/modifier
+  tests stay diverse and current.
 - Improved download-stage resilience under Xenna preemption.
-
-## Serve Peers
-
-- **To pipeline-contract steward**: text exercises composite stages,
-  IO partitioning, and lazy-import patterns harder than other
-  modalities. Surface awkward spots in the base contract.
-- **To deduplication steward**: text dedup integrates exact / fuzzy /
-  semantic dedup; keep the integration documented and tested.
-- **To backends steward**: text classifiers / embedders are the
-  primary GPU stage class. Help validate resource declarations on
-  each backend.
-- **To docs steward**: keep classifier/embedder/filter names and
-  parameters in `fern/` aligned with source. This is the highest
-  Known Regression Pattern surface in the repo.
-- **To tutorials steward**: text tutorials are the most-used; treat
-  their snippets as canonical and audit them on every text-public
-  change.
-
-## Do Not
-
-- Import `cudf`, `cupy`, `torch.cuda`-only paths, `fasttext`,
-  `sentencepiece`, or other optional libs at module top level if
-  they are not in the base install. Lazy-import in the stage.
-- Rename a public classifier or embedder class without a deprecation
-  alias + changelog entry + Fern doc update + tutorial update in the
-  same PR.
-- Add a filter / modifier parameter without documenting it in
-  `fern/` and adding a test.
-- Use `print()`; use `loguru`.
-- Hardcode HuggingFace model IDs in docs that no longer exist on
-  the Hub — verify before merging.
 
 ## Own
 
-**Code surfaces**:
+**Code:** `nemo_curator/stages/text/` (subpackages: `classifiers`,
+`embedders`, `modifiers`, `modules`, `io`, `download`, `utils`,
+`experimental`, `models`, `deduplication`); `tasks/document.py`.
 
-- `nemo_curator/stages/text/` (subpackages: `classifiers`,
-  `embedders`, `modifiers`, `modules`, `io`, `download`, `utils`,
-  `experimental`, `models`, `deduplication`)
-- `nemo_curator/tasks/document.py`
+**Tests:** `tests/stages/text/`.
 
-**Tests**:
+**Docs (autopilot surface):** `fern/` text curation concepts,
+classifier reference, embedder reference, filter / modifier
+reference, download pipelines, tutorials; text-related sections of
+`README.md`.
 
-- `tests/stages/text/`
+**Agent artifacts:** the text portion of
+`.cursor/rules/modality-structure.mdc`.
 
-**Docs (autopilot audit surface)**:
-
-- `fern/` text curation concept pages, classifier reference,
-  embedder reference, filter reference, modifier reference, download
-  pipelines, tutorials (canonical paths to be pinned in the next docs
-  autopilot pass)
-- Text-related sections of `README.md`
-
-**Agent-facing artifacts**:
-
-- `.cursor/rules/modality-structure.mdc` (text portion)
-
-**CODEOWNERS routing**:
-
-- Default: `@NVIDIA-NeMo/curator_reviewers`
-- `nemo_curator/stages/text/classifiers/`:
-  `@sarahyurick @praateekmahajan @VibhuJawa`
-- `nemo_curator/stages/text/embedders/`:
-  `@sarahyurick @praateekmahajan @VibhuJawa`
-
-Any classifier / embedder PR must route to the named team.
+**CODEOWNERS:** default `@NVIDIA-NeMo/curator_reviewers`.
+`classifiers/` and `embedders/` route additionally to
+`@sarahyurick @praateekmahajan @VibhuJawa` — any classifier/embedder
+PR must route there.

--- a/nemo_curator/stages/text/AGENTS.md
+++ b/nemo_curator/stages/text/AGENTS.md
@@ -1,9 +1,10 @@
 # Steward: Text Modality
 
-Text is the largest and most diverse modality: readers, writers,
-classifiers, embedders, modifiers, modules, and download pipelines.
-The most user-touched modality — most copy-paste from the docs lands
-here, so doc-snippet rot bites hardest.
+This domain exists because text is the largest user-facing surface in
+the framework and the most copied-and-pasted. Most new users meet
+NeMo Curator through text — running a quality classifier, deduplicating
+a corpus, or extracting and filtering Common Crawl. Doc-snippet rot
+here breaks the first thing those users try.
 
 Related: root [AGENTS.md](../../../AGENTS.md), parent
 [nemo_curator/AGENTS.md](../../AGENTS.md),
@@ -12,7 +13,12 @@ Related: root [AGENTS.md](../../../AGENTS.md), parent
 ## Point Of View
 
 The textual corpus. Owns every transformation that produces or mutates
-a `DocumentBatch`.
+a `DocumentBatch`: download, extraction, filtering, classification,
+embedding, deduplication, modification, synthetic generation. Defends
+the published classifier surfaces (Domain, Quality, and others on
+HuggingFace) as public API — their class names, output schemas, and
+documented rubrics are downstream user contracts, not implementation
+details.
 
 ## Protect
 
@@ -22,12 +28,19 @@ a `DocumentBatch`.
 - **Reader/writer round-tripping** (`text/io/`): writing then reading
   preserves schema, encoding, and metadata for every supported
   format (JSONL, Parquet, others).
-- **Classifier and embedder public surfaces.**
-  `text/classifiers/__init__.py` exposes a canonical lazy registry
-  via `_LAZY` and `__all__` — class names there are documented API.
-  `text/embedders/` lacks an equivalent registry today (see
-  Advocate). Renames, removals, and default changes are
-  user-visible.
+- **Classifier public surface.** `text/classifiers/__init__.py`
+  exposes a canonical lazy registry via `_LAZY` and `__all__`. The
+  Domain Classifier (26 domain classes — Finance, Health, Business
+  and Industrial, Science, Law and Government, Internet and Telecom,
+  Jobs and Education, News, Computers and Electronics, Shopping, and
+  16 others) and the Quality Classifier (High / Medium / Low against
+  a rubric of content accuracy, clarity, coherence, grammar, depth of
+  information, and overall usefulness) are user-visible API published
+  on HuggingFace. Renames, removals, default changes, or rubric
+  changes are major-version events.
+- **Embedder public surface.** `text/embedders/` is inference-bearing
+  — coordinate with the Inference Acceleration Steward when changing
+  serving stacks or throughput characteristics.
 - **Filter and modifier semantics** (`text/filters/`,
   `text/modifiers/`, `text/modules/`): keep/drop predicates
   (`text/filters/{doc_filter,score_filter}.py` and the `fasttext`,
@@ -39,10 +52,11 @@ a `DocumentBatch`.
   under preemption.
 - **GPU/CPU paths.** Text classifiers and embedders often have GPU
   implementations. Lazy-import GPU libs; declare resources honestly;
-  ensure CPU fallback loads.
-- **Tokenizer / model artifact handling.** Local cache paths,
+  CPU fallback loads.
+- **Tokenizer and model artifact handling.** Local cache paths,
   HuggingFace identifiers, and any pinning must be stable and
-  documented.
+  documented. HuggingFace-pinned artifacts can vanish; this is an
+  operational risk to manage.
 
 ## Contract Checklist
 
@@ -51,7 +65,7 @@ When this domain changes:
 - `stages/text/{classifiers,embedders,filters,modifiers,modules,io,download,utils,experimental,models,deduplication}/`
 - `tasks/document.py`
 - `tests/stages/text/`
-- `fern/` text curation pages — classifier names, filter params,
+- `fern/` text curation pages — classifier names, filter parameters,
   example invocations
 - `tutorials/text/`, `tutorials/quickstart.py`
 - `.cursor/rules/modality-structure.mdc`
@@ -60,15 +74,18 @@ When this domain changes:
 ## Advocate
 
 - **Programmatic embedder registry** mirroring
-  `classifiers/__init__.py:_LAZY`, so docs don't hand-count.
-  Auto-generate `fern/` reference pages from `__all__`.
-- Clearer separation between `text/experimental/` and stable
-  surfaces in the docs.
-- Better diagnostics for misconfigured tokenizer paths and missing
-  model artifacts.
-- Reusable text fixtures under `tests/data/` so filter/modifier
+  `classifiers/__init__.py:_LAZY`, so docs don't hand-count. Surface
+  both registries in `fern/` reference pages auto-generated from
+  `__all__`.
+- **Clearer separation** between `text/experimental/` and stable
+  surfaces in the docs, plus a graduation path so experimental
+  doesn't become permanent.
+- **Better diagnostics** for misconfigured tokenizer paths and
+  missing model artifacts.
+- **Reusable text fixtures** under `tests/data/` so filter/modifier
   tests stay diverse and current.
-- Improved download-stage resilience under Xenna preemption.
+- **Improved download-stage resilience** under preemption — partial
+  downloads, retries, rate-limit handling.
 
 ## Own
 

--- a/nemo_curator/stages/video/AGENTS.md
+++ b/nemo_curator/stages/video/AGENTS.md
@@ -1,0 +1,119 @@
+# Steward: Video Modality
+
+Video curation with GPU-accelerated decode and processing via OpenCV,
+PyAV, CvCuda, and PyNvVideoCodec. The highest-resource and most
+hardware-sensitive modality.
+
+Related docs:
+
+- root [AGENTS.md](../../../AGENTS.md)
+- parent [nemo_curator/AGENTS.md](../../AGENTS.md)
+- `.cursor/rules/modality-structure.mdc`
+- `fern/` video curation pages
+
+## Point Of View
+
+Frames, clips, and the decode/encode pipeline that feeds them. The
+modality where a wrong codec path or a leaked file handle costs
+node-hours and where backend choice (Xenna autoscaling vs Ray Data
+streaming) is most consequential.
+
+## Protect
+
+- **`VideoTask` contract** (in `nemo_curator/tasks/video.py`):
+  `VideoTask` wraps a `Video` dataclass; clip identifiers, timestamps,
+  windows, and metadata live on nested `Clip`, `VideoMetadata`, and
+  `_Window` types (not directly on `VideoTask`). Adding or removing
+  fields on `Video` / `Clip` / `VideoMetadata` is user-visible.
+- **Decode path correctness**: PyNvVideoCodec, CvCuda, PyAV, and
+  OpenCV paths must produce equivalent frame outputs (modulo
+  documented color-space differences) for the same input.
+- **Resource declarations**: video stages reserve GPUs and significant
+  GPU memory; mis-declared resources break the scheduler and OOM
+  workers.
+- **File-handle and GPU-memory hygiene**: video stages are long-lived
+  and process many files; leaks compound. Use context managers.
+- **CUDA gating**: import `cv2.cuda`, `cvcuda`, `pynvvideocodec`, and
+  `PyAV` GPU paths lazily so CPU installs and non-video pipelines do
+  not break on import.
+- **Codec / container coverage claims**: any documented "supports X"
+  list (codecs, containers, resolutions) must match what the code
+  actually handles.
+
+## Contract Checklist
+
+When this domain changes:
+
+- `nemo_curator/stages/video/`
+- `nemo_curator/tasks/video.py`
+- `tests/stages/video/`
+- `pyproject.toml` `video_cpu` and `video_cuda12` extras groups
+- `fern/` video curation pages — codec/container coverage, GPU
+  prerequisites, configuration
+- `tutorials/video/`
+- `benchmarking/` — video benchmark configs and runners (ALM is the
+  audio-language benchmark and belongs to the audio domain, not video)
+- `docker/` for video-specific runtime dependencies
+- `CHANGELOG.md`
+
+## Advocate
+
+- A small CI-runnable video fixture (a few seconds, free-license)
+  that exercises decode, transform, and write paths.
+- Better diagnostics when a required codec library is missing.
+- Clearer guidance on choosing executor for video (Xenna for
+  autoscaling, Ray Data for streaming).
+- GPU-memory budgeting documentation per stage.
+- A canonical "minimum hardware to run the video tutorial" claim that
+  is verified against current code.
+
+## Serve Peers
+
+- **To pipeline-contract steward**: video pushes the resource model
+  (multi-GPU, GPU memory) harder than other modalities. Surface
+  awkward spots.
+- **To backends steward**: video stages exercise autoscaling and
+  large-resource scheduling. Help validate backend behavior.
+- **To benchmarking steward**: video is a primary perf gate; keep
+  benchmarks current.
+- **To docs steward**: GPU prereqs and codec support are the most
+  common video doc bugs.
+
+## Do Not
+
+- Import `cv2.cuda`, `cvcuda`, `pynvvideocodec`, or GPU-decoder paths
+  of PyAV at module top level. Plain `import cv2` and `import av` at
+  module top level are acceptable (the GPU symbols are the gated
+  ones).
+- Hold a video file handle across a Ray task boundary; release
+  before yielding.
+- Document a codec or container that the code does not actually
+  decode/encode.
+- Ship a video stage without a resource declaration (`gpus`,
+  `gpu_memory_gb`) that reflects real usage.
+- Pin a frame rate, resolution, or codec in tests that prevents the
+  test from running on small fixtures.
+
+## Own
+
+**Code surfaces**:
+
+- `nemo_curator/stages/video/`
+- `nemo_curator/tasks/video.py`
+
+**Tests**:
+
+- `tests/stages/video/`
+
+**Docs (autopilot audit surface)**:
+
+- `fern/` video curation concept pages, codec/container reference,
+  GPU prerequisites, tutorials (canonical paths to be pinned in the
+  next docs autopilot pass)
+
+**Agent-facing artifacts**:
+
+- `.cursor/rules/modality-structure.mdc` (video portion)
+
+**CODEOWNERS routing**: `@suiyoubi @abhinavg4`. Every video PR routes
+to this team.

--- a/nemo_curator/stages/video/AGENTS.md
+++ b/nemo_curator/stages/video/AGENTS.md
@@ -1,15 +1,12 @@
 # Steward: Video Modality
 
-Video curation with GPU-accelerated decode and processing via OpenCV,
-PyAV, CvCuda, and PyNvVideoCodec. The highest-resource and most
-hardware-sensitive modality.
+Video curation with GPU-accelerated decode via OpenCV, PyAV, CvCuda,
+and PyNvVideoCodec. The highest-resource and most hardware-sensitive
+modality.
 
-Related docs:
-
-- root [AGENTS.md](../../../AGENTS.md)
-- parent [nemo_curator/AGENTS.md](../../AGENTS.md)
-- `.cursor/rules/modality-structure.mdc`
-- `fern/` video curation pages
+Related: root [AGENTS.md](../../../AGENTS.md), parent
+[nemo_curator/AGENTS.md](../../AGENTS.md),
+`.cursor/rules/modality-structure.mdc`.
 
 ## Point Of View
 
@@ -20,23 +17,25 @@ streaming) is most consequential.
 
 ## Protect
 
-- **`VideoTask` contract** (in `nemo_curator/tasks/video.py`):
-  `VideoTask` wraps a `Video` dataclass; clip identifiers, timestamps,
-  windows, and metadata live on nested `Clip`, `VideoMetadata`, and
-  `_Window` types (not directly on `VideoTask`). Adding or removing
-  fields on `Video` / `Clip` / `VideoMetadata` is user-visible.
-- **Decode path correctness**: PyNvVideoCodec, CvCuda, PyAV, and
+- **`VideoTask` shape** (`tasks/video.py`): `VideoTask` wraps a
+  `Video` dataclass; clip identifiers, timestamps, windows, and
+  metadata live on nested `Clip`, `VideoMetadata`, and `_Window`
+  types — not directly on `VideoTask`. Adding/removing fields on
+  `Video` / `Clip` / `VideoMetadata` is user-visible.
+- **Decode-path equivalence.** PyNvVideoCodec, CvCuda, PyAV, and
   OpenCV paths must produce equivalent frame outputs (modulo
   documented color-space differences) for the same input.
-- **Resource declarations**: video stages reserve GPUs and significant
-  GPU memory; mis-declared resources break the scheduler and OOM
-  workers.
-- **File-handle and GPU-memory hygiene**: video stages are long-lived
-  and process many files; leaks compound. Use context managers.
-- **CUDA gating**: import `cv2.cuda`, `cvcuda`, `pynvvideocodec`, and
-  `PyAV` GPU paths lazily so CPU installs and non-video pipelines do
-  not break on import.
-- **Codec / container coverage claims**: any documented "supports X"
+- **Resource declarations.** Video stages reserve GPUs and
+  significant GPU memory; mis-declared resources break the scheduler
+  and OOM workers.
+- **File-handle and GPU-memory hygiene.** Video stages are long-lived
+  and process many files; leaks compound. Use context managers;
+  release handles before yielding across task boundaries.
+- **CUDA gating.** Lazy-import `cv2.cuda`, `cvcuda`, `pynvvideocodec`,
+  and GPU-decoder paths of PyAV. Plain `import cv2` and `import av`
+  at module top level are acceptable (only the GPU symbols are
+  gated).
+- **Codec / container coverage claims.** Any documented "supports X"
   list (codecs, containers, resolutions) must match what the code
   actually handles.
 
@@ -44,76 +43,38 @@ streaming) is most consequential.
 
 When this domain changes:
 
-- `nemo_curator/stages/video/`
-- `nemo_curator/tasks/video.py`
+- `nemo_curator/stages/video/`, `nemo_curator/tasks/video.py`
 - `tests/stages/video/`
 - `pyproject.toml` `video_cpu` and `video_cuda12` extras groups
-- `fern/` video curation pages — codec/container coverage, GPU
-  prerequisites, configuration
+- `fern/` video pages — codec/container coverage, GPU prereqs,
+  configuration
 - `tutorials/video/`
-- `benchmarking/` — video benchmark configs and runners (ALM is the
-  audio-language benchmark and belongs to the audio domain, not video)
+- `benchmarking/` — video benchmark configs and runners
+  (`ALM_BENCHMARK.md` is audio, not video)
 - `docker/` for video-specific runtime dependencies
 - `CHANGELOG.md`
 
 ## Advocate
 
 - A small CI-runnable video fixture (a few seconds, free-license)
-  that exercises decode, transform, and write paths.
-- Better diagnostics when a required codec library is missing.
-- Clearer guidance on choosing executor for video (Xenna for
-  autoscaling, Ray Data for streaming).
-- GPU-memory budgeting documentation per stage.
-- A canonical "minimum hardware to run the video tutorial" claim that
-  is verified against current code.
-
-## Serve Peers
-
-- **To pipeline-contract steward**: video pushes the resource model
-  (multi-GPU, GPU memory) harder than other modalities. Surface
-  awkward spots.
-- **To backends steward**: video stages exercise autoscaling and
-  large-resource scheduling. Help validate backend behavior.
-- **To benchmarking steward**: video is a primary perf gate; keep
-  benchmarks current.
-- **To docs steward**: GPU prereqs and codec support are the most
-  common video doc bugs.
-
-## Do Not
-
-- Import `cv2.cuda`, `cvcuda`, `pynvvideocodec`, or GPU-decoder paths
-  of PyAV at module top level. Plain `import cv2` and `import av` at
-  module top level are acceptable (the GPU symbols are the gated
-  ones).
-- Hold a video file handle across a Ray task boundary; release
-  before yielding.
-- Document a codec or container that the code does not actually
-  decode/encode.
-- Ship a video stage without a resource declaration (`gpus`,
-  `gpu_memory_gb`) that reflects real usage.
-- Pin a frame rate, resolution, or codec in tests that prevents the
-  test from running on small fixtures.
+  exercising decode, transform, and write paths.
+- Clear "missing codec library" diagnostics.
+- Executor-selection guidance for video (Xenna for autoscaling, Ray
+  Data for streaming).
+- GPU-memory budgeting docs per stage.
+- A "minimum hardware to run the video tutorial" claim verified
+  against current code.
 
 ## Own
 
-**Code surfaces**:
+**Code:** `nemo_curator/stages/video/`, `nemo_curator/tasks/video.py`.
 
-- `nemo_curator/stages/video/`
-- `nemo_curator/tasks/video.py`
+**Tests:** `tests/stages/video/`.
 
-**Tests**:
+**Docs (autopilot surface):** `fern/` video curation concepts,
+codec/container reference, GPU prerequisites, tutorials.
 
-- `tests/stages/video/`
+**Agent artifacts:** the video portion of
+`.cursor/rules/modality-structure.mdc`.
 
-**Docs (autopilot audit surface)**:
-
-- `fern/` video curation concept pages, codec/container reference,
-  GPU prerequisites, tutorials (canonical paths to be pinned in the
-  next docs autopilot pass)
-
-**Agent-facing artifacts**:
-
-- `.cursor/rules/modality-structure.mdc` (video portion)
-
-**CODEOWNERS routing**: `@suiyoubi @abhinavg4`. Every video PR routes
-to this team.
+**CODEOWNERS:** `@suiyoubi @abhinavg4`.

--- a/nemo_curator/stages/video/AGENTS.md
+++ b/nemo_curator/stages/video/AGENTS.md
@@ -1,8 +1,12 @@
 # Steward: Video Modality
 
-Video curation with GPU-accelerated decode via OpenCV, PyAV, CvCuda,
-and PyNvVideoCodec. The highest-resource and most hardware-sensitive
-modality.
+This domain exists because video curation at PB scale is impossible
+without end-to-end GPU acceleration. Every CPU-bound stage in a video
+pipeline is dead weight — decode, transcode, splitting, captioning,
+embedding all have GPU paths and must use them. The bet here is that
+GPU-accelerated decode (NVDEC), encode (NVENC), and inference
+(TensorRT-LLM, FP8 quantization) compress what would be years of CPU
+processing into days.
 
 Related: root [AGENTS.md](../../../AGENTS.md), parent
 [nemo_curator/AGENTS.md](../../AGENTS.md),
@@ -10,24 +14,42 @@ Related: root [AGENTS.md](../../../AGENTS.md), parent
 
 ## Point Of View
 
-Frames, clips, and the decode/encode pipeline that feeds them. The
-modality where a wrong codec path or a leaked file handle costs
-node-hours and where backend choice (Xenna autoscaling vs Ray Data
-streaming) is most consequential.
+Frames, clips, and the GPU-accelerated decode/encode pipeline that
+feeds them. Defends two convictions: **all stages must be
+GPU-accelerated** (CPU stages in a video pipeline are technical debt),
+and **each inference model in the pipeline must run at speed-of-light**
+for its hardware (TensorRT-LLM, memory optimization, FP8 quantization
+are the floor, not the ceiling). This modality is also where backend
+choice matters most — streaming with auto-balancing across
+heterogeneous compute stages is what keeps GPUs saturated.
 
 ## Protect
 
 - **`VideoTask` shape** (`tasks/video.py`): `VideoTask` wraps a
   `Video` dataclass; clip identifiers, timestamps, windows, and
   metadata live on nested `Clip`, `VideoMetadata`, and `_Window`
-  types — not directly on `VideoTask`. Adding/removing fields on
-  `Video` / `Clip` / `VideoMetadata` is user-visible.
+  types. Adding or removing fields on `Video` / `Clip` /
+  `VideoMetadata` is user-visible.
+- **Output format** is WebDataset: clip mp4 + text caption + text
+  embedding + video embedding. This is the contract with downstream
+  training pipelines; format changes are user-visible.
+- **All-GPU pipeline.** The defended invariant is end-to-end GPU
+  acceleration: NVDEC for decode, NVENC for encode, CV-CUDA for
+  image ops, TensorRT-LLM for VLM captioning, GPU embedding models.
+  Reintroducing CPU stages in the video pipeline is a regression
+  unless explicitly justified (e.g., S3 IO).
+- **Each inference model at speed-of-light.** Captioning, motion
+  filtering, aesthetic filtering, embedding — each model in the
+  pipeline must be benchmarked and accelerated (TensorRT-LLM,
+  memory optimization, quantization). Coordinate with the Inference
+  Acceleration Steward when adding or changing model-bearing stages.
 - **Decode-path equivalence.** PyNvVideoCodec, CvCuda, PyAV, and
   OpenCV paths must produce equivalent frame outputs (modulo
   documented color-space differences) for the same input.
 - **Resource declarations.** Video stages reserve GPUs and
   significant GPU memory; mis-declared resources break the scheduler
-  and OOM workers.
+  and OOM workers. GPU memory budgeting matters more than throughput
+  — OOM is the failure mode that ends runs.
 - **File-handle and GPU-memory hygiene.** Video stages are long-lived
   and process many files; leaks compound. Use context managers;
   release handles before yielding across task boundaries.
@@ -56,13 +78,14 @@ When this domain changes:
 
 ## Advocate
 
-- A small CI-runnable video fixture (a few seconds, free-license)
-  exercising decode, transform, and write paths.
-- Clear "missing codec library" diagnostics.
-- Executor-selection guidance for video (Xenna for autoscaling, Ray
-  Data for streaming).
-- GPU-memory budgeting docs per stage.
-- A "minimum hardware to run the video tutorial" claim verified
+- **A small CI-runnable video fixture** (a few seconds,
+  free-license) exercising decode, transform, captioning, embedding,
+  and write paths.
+- **Clear "missing codec library" diagnostics.**
+- **Executor-selection guidance for video** — when streaming with
+  auto-balancing matters most.
+- **GPU-memory budgeting docs** per stage.
+- **A "minimum hardware to run the video tutorial" claim** verified
   against current code.
 
 ## Own

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,135 @@
+# Steward: Tests
+
+The test suite. CPU-default with explicit GPU markers. The conftest
+sets up a smart Ray cluster that adapts to available GPUs. CI runs via
+`L0_Unit_Test_CPU.sh` and `L0_Unit_Test_GPU.sh`. Pre-commit checks
+plus 80% coverage on changes are gate conditions.
+
+Related docs:
+
+- root [AGENTS.md](../AGENTS.md)
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — unit test / coverage
+  policy
+- `.cursor/rules/coding-standards.mdc`
+
+## Point Of View
+
+The safety net. Defends the parity, fault-tolerance, and ABI claims
+the rest of the repo makes. Without consistent test conventions, every
+modality drifts independently and parity testing across backends
+collapses.
+
+## Protect
+
+- **`@pytest.mark.gpu`**: every test that requires CUDA carries this
+  marker. CPU-only runs (`pytest -m "not gpu"`) must pass on a clean
+  install without GPU libs.
+- **`conftest.py` cluster lifecycle**: tests share a single Ray
+  cluster configured by `tests/conftest.py` (session-scoped
+  `shared_ray_cluster` fixture). Do not start ad-hoc Ray clusters
+  inside tests.
+- **Modality selection rules**: `pytest_ignore_collect` in
+  `tests/conftest.py` enforces one modality per `-m` flag, forbids
+  negation, and rejects multi-modality selection. Don't try to work
+  around this; if you need cross-modality runs, do separate
+  invocations.
+- **GPU detection**: GPU presence is detected via pynvml /
+  `nvidia-smi`. Tests gracefully skip when no GPU; they must not
+  hard-fail.
+- **Test-source layout mirrors `nemo_curator/`**. New code under
+  `nemo_curator/<area>/` gets tests under `tests/<area>/`.
+- **CI scripts** (`L0_Unit_Test_CPU.sh`, `L0_Unit_Test_GPU.sh`) and
+  `gpu_test_groups.json` are the canonical CI entrypoints; keep
+  them in sync with the test tree.
+- **80% coverage on changed lines** (per `CONTRIBUTING.md`).
+  `codecov.yml` enforces this in CI.
+- **Determinism**: avoid wall-clock and randomness in tests unless
+  the random source is explicitly seeded.
+- **Fixtures and data** (`tests/fixtures/`, `tests/data/`): keep
+  small, license-clean, and committed (no large binaries).
+
+## Contract Checklist
+
+When this domain changes:
+
+- `tests/conftest.py` — Ray cluster lifecycle, GPU detection,
+  marker registration
+- `tests/L0_Unit_Test_CPU.sh`, `tests/L0_Unit_Test_GPU.sh`,
+  `tests/gpu_test_groups.json`
+- `tests/fixtures/`, `tests/data/`
+- `pyproject.toml` `[tool.pytest.ini_options]` — markers, addopts
+- `codecov.yml` — coverage thresholds
+- `.github/workflows/` — CI pipelines that invoke the L0 scripts
+- `CONTRIBUTING.md` — unit test / coverage policy
+- `.cursor/rules/coding-standards.mdc`
+- The "Testing Guidelines" section of
+  `.github/copilot-instructions.md`
+
+## Advocate
+
+- Backend-parity test fixtures so executor sweeps are first-class
+  instead of hand-coded per test.
+- A canonical set of small fixtures per modality so new tests do not
+  reinvent fixture loading.
+- Coverage reporting per-module so low-coverage hotspots are visible.
+- Faster CPU CI by selective test selection on changed-paths (CODEOWNERS
+  / pytest collect).
+- Snapshot or determinism tests for deduplication and synthetic-data
+  outputs.
+
+## Serve Peers
+
+- **To pipeline-contract steward**: provide minimal stage / task
+  fixtures so contract tests do not depend on real modality stages.
+- **To backends steward**: own the parity test harness so executor
+  sweeps are trivial to add.
+- **To modality stewards**: keep `tests/data/` and `tests/fixtures/`
+  organized so each modality can pull representative inputs.
+- **To docs steward**: tests are the verification surface for doc
+  claims. When a content audit lands a P0 about a flag/default,
+  there should be a test that pins it.
+
+## Do Not
+
+- Add a test that requires a GPU without `@pytest.mark.gpu`.
+- Start ad-hoc Ray clusters; reuse the conftest's cluster.
+- Commit large binaries or model artifacts.
+- Use real network calls (HuggingFace download, remote APIs) inside
+  CPU tests; mock or skip.
+- Disable coverage with `# pragma: no cover` for non-trivial logic.
+- Use `print()`; tests should be quiet on success.
+- Set `RAY_memory_usage_threshold` in test code; conftest already
+  sets a reasonable default.
+
+## Own
+
+**Code surfaces**:
+
+- `tests/` (entire tree)
+- `tests/conftest.py`, `tests/L0_Unit_Test_*.sh`,
+  `tests/gpu_test_groups.json`
+
+**Tests**: self.
+
+**Docs (autopilot audit surface)**:
+
+- The "Unit tests" and "Coverage" sections of `CONTRIBUTING.md`
+- The "Testing Guidelines" section of
+  `.github/copilot-instructions.md`
+- `fern/` developer / contributor pages about testing
+
+**Agent-facing artifacts**:
+
+- The "Testing" portion of `.cursor/rules/coding-standards.mdc`
+
+**CODEOWNERS routing**:
+
+- Default: `@NVIDIA-NeMo/curator_reviewers`
+- Per-domain subtrees route to their modality CODEOWNERS where
+  defined: `tests/stages/deduplication/`,
+  `tests/stages/text/embedders/`, `tests/stages/text/classifiers/`,
+  `tests/stages/synthetic/`, `tests/stages/video/`, `tests/backends/`.
+  Other subtrees (`tests/stages/{audio,image,interleaved,math_stages,common}/`,
+  `tests/{tasks,pipelines,core,metrics,models,config,utils}/`) fall
+  through to the default reviewers team today; add explicit
+  CODEOWNERS entries when those modalities grow dedicated owners.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,10 +1,11 @@
 # Steward: Tests
 
-The test suite. CPU-default with explicit GPU markers. `conftest.py`
-runs a shared session-scoped Ray cluster that adapts to available
-GPUs. CI runs via `L0_Unit_Test_CPU.sh` and `L0_Unit_Test_GPU.sh`.
-Pre-commit plus 80% coverage on changed lines (per `codecov.yml`) are
-gate conditions.
+This domain exists because the framework's parity, fault-tolerance,
+and ABI claims need defending. Without consistent test conventions,
+every modality drifts independently and the "same pipeline runs on
+any backend" guarantee silently rots. Parity across modalities and
+backends is the actual risk surface — more so than CPU-vs-GPU
+coverage.
 
 Related: root [AGENTS.md](../AGENTS.md),
 [CONTRIBUTING.md](../CONTRIBUTING.md),
@@ -12,9 +13,11 @@ Related: root [AGENTS.md](../AGENTS.md),
 
 ## Point Of View
 
-The safety net. Defends the parity, fault-tolerance, and ABI claims
-the rest of the repo makes. Without consistent conventions, every
-modality drifts independently and parity testing collapses.
+The safety net. Defends the framework's portability and contract
+claims through fixtures, markers, and CI scripts that mirror how
+users actually run pipelines. Tests are also the documentation of
+*intended* behavior — when source and tests disagree, the discussion
+is "which one matches what we promised users?"
 
 ## Protect
 
@@ -56,15 +59,15 @@ When this domain changes:
 
 ## Advocate
 
-- Backend-parity test fixtures so executor sweeps are first-class
+- **Backend-parity test fixtures** so executor sweeps are first-class
   instead of hand-coded per test.
-- Canonical small fixtures per modality so new tests don't reinvent
-  fixture loading. Today `tests/fixtures/` and `tests/data/` only
-  cover audio.
-- Per-module coverage reporting so low-coverage hotspots are
+- **Canonical small fixtures per modality** so new tests don't
+  reinvent fixture loading. Today `tests/fixtures/` and
+  `tests/data/` only cover audio.
+- **Per-module coverage reporting** so low-coverage hotspots are
   visible.
-- Faster CPU CI via path-based test selection on changed files.
-- Snapshot or determinism tests for dedup and synthetic-data
+- **Faster CPU CI** via path-based test selection on changed files.
+- **Snapshot or determinism tests** for dedup and synthetic-data
   outputs.
 
 ## Do Not
@@ -88,12 +91,10 @@ testing pages.
 **Agent artifacts:** the "Testing" portion of
 `.cursor/rules/coding-standards.mdc`.
 
-**CODEOWNERS:** default `@NVIDIA-NeMo/curator_reviewers`. Per-modality
-subtrees route to their modality CODEOWNERS when defined:
-`tests/stages/deduplication/`, `tests/stages/text/embedders/`,
-`tests/stages/text/classifiers/`, `tests/stages/synthetic/`,
-`tests/stages/video/`, `tests/backends/`. Other subtrees
-(`tests/stages/{audio,image,interleaved,math_stages,common}/`,
-`tests/{tasks,pipelines,core,metrics,models,config,utils}/`) fall
-through to the default team — add explicit CODEOWNERS entries when
-those modalities grow dedicated owners.
+**CODEOWNERS:** default `@NVIDIA-NeMo/curator_reviewers`.
+Per-modality subtrees route to their modality CODEOWNERS when
+defined: `tests/stages/deduplication/`,
+`tests/stages/text/embedders/`, `tests/stages/text/classifiers/`,
+`tests/stages/synthetic/`, `tests/stages/video/`, `tests/backends/`.
+Other subtrees fall through to the default team — add explicit
+CODEOWNERS entries when those modalities grow dedicated owners.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,135 +1,99 @@
 # Steward: Tests
 
-The test suite. CPU-default with explicit GPU markers. The conftest
-sets up a smart Ray cluster that adapts to available GPUs. CI runs via
-`L0_Unit_Test_CPU.sh` and `L0_Unit_Test_GPU.sh`. Pre-commit checks
-plus 80% coverage on changes are gate conditions.
+The test suite. CPU-default with explicit GPU markers. `conftest.py`
+runs a shared session-scoped Ray cluster that adapts to available
+GPUs. CI runs via `L0_Unit_Test_CPU.sh` and `L0_Unit_Test_GPU.sh`.
+Pre-commit plus 80% coverage on changed lines (per `codecov.yml`) are
+gate conditions.
 
-Related docs:
-
-- root [AGENTS.md](../AGENTS.md)
-- [CONTRIBUTING.md](../CONTRIBUTING.md) — unit test / coverage
-  policy
-- `.cursor/rules/coding-standards.mdc`
+Related: root [AGENTS.md](../AGENTS.md),
+[CONTRIBUTING.md](../CONTRIBUTING.md),
+`.cursor/rules/coding-standards.mdc`.
 
 ## Point Of View
 
 The safety net. Defends the parity, fault-tolerance, and ABI claims
-the rest of the repo makes. Without consistent test conventions, every
-modality drifts independently and parity testing across backends
-collapses.
+the rest of the repo makes. Without consistent conventions, every
+modality drifts independently and parity testing collapses.
 
 ## Protect
 
-- **`@pytest.mark.gpu`**: every test that requires CUDA carries this
-  marker. CPU-only runs (`pytest -m "not gpu"`) must pass on a clean
-  install without GPU libs.
-- **`conftest.py` cluster lifecycle**: tests share a single Ray
-  cluster configured by `tests/conftest.py` (session-scoped
-  `shared_ray_cluster` fixture). Do not start ad-hoc Ray clusters
-  inside tests.
-- **Modality selection rules**: `pytest_ignore_collect` in
-  `tests/conftest.py` enforces one modality per `-m` flag, forbids
-  negation, and rejects multi-modality selection. Don't try to work
-  around this; if you need cross-modality runs, do separate
-  invocations.
-- **GPU detection**: GPU presence is detected via pynvml /
-  `nvidia-smi`. Tests gracefully skip when no GPU; they must not
-  hard-fail.
-- **Test-source layout mirrors `nemo_curator/`**. New code under
+- **`@pytest.mark.gpu`** registered in `pyproject.toml`
+  `[tool.pytest.ini_options]`. Every test that needs CUDA carries
+  this marker. CPU-only runs (`pytest -m "not gpu"`) pass on a clean
+  install.
+- **Shared Ray cluster.** Tests reuse the session-scoped
+  `shared_ray_cluster` fixture in `conftest.py`. No ad-hoc Ray
+  clusters in tests.
+- **Modality selection rules.** `pytest_ignore_collect` in
+  `conftest.py` enforces one modality per `-m` flag, forbids
+  negation, and rejects multi-modality selection. Don't work around
+  this — do separate invocations.
+- **GPU detection** via pynvml → `nvidia-smi -L` → `nvidia-smi
+  --query-gpu=count`. Tests gracefully skip when no GPU; they must
+  not hard-fail.
+- **Test-source layout mirrors `nemo_curator/`.** New code under
   `nemo_curator/<area>/` gets tests under `tests/<area>/`.
-- **CI scripts** (`L0_Unit_Test_CPU.sh`, `L0_Unit_Test_GPU.sh`) and
-  `gpu_test_groups.json` are the canonical CI entrypoints; keep
-  them in sync with the test tree.
-- **80% coverage on changed lines** (per `CONTRIBUTING.md`).
-  `codecov.yml` enforces this in CI.
-- **Determinism**: avoid wall-clock and randomness in tests unless
-  the random source is explicitly seeded.
-- **Fixtures and data** (`tests/fixtures/`, `tests/data/`): keep
+- **CI entrypoints.** `L0_Unit_Test_CPU.sh`, `L0_Unit_Test_GPU.sh`,
+  and `gpu_test_groups.json` stay in sync with the test tree.
+- **80% coverage on changed lines** (`codecov.yml`).
+- **Determinism.** Avoid wall-clock and unseeded randomness.
+- **Fixtures and data.** `tests/fixtures/` and `tests/data/` stay
   small, license-clean, and committed (no large binaries).
 
 ## Contract Checklist
 
 When this domain changes:
 
-- `tests/conftest.py` — Ray cluster lifecycle, GPU detection,
-  marker registration
-- `tests/L0_Unit_Test_CPU.sh`, `tests/L0_Unit_Test_GPU.sh`,
-  `tests/gpu_test_groups.json`
-- `tests/fixtures/`, `tests/data/`
-- `pyproject.toml` `[tool.pytest.ini_options]` — markers, addopts
-- `codecov.yml` — coverage thresholds
+- `tests/conftest.py`, `L0_Unit_Test_{CPU,GPU}.sh`,
+  `gpu_test_groups.json`, `fixtures/`, `data/`
+- `pyproject.toml` `[tool.pytest.ini_options]` (markers, addopts)
+- `codecov.yml`
 - `.github/workflows/` — CI pipelines that invoke the L0 scripts
-- `CONTRIBUTING.md` — unit test / coverage policy
-- `.cursor/rules/coding-standards.mdc`
-- The "Testing Guidelines" section of
+- `CONTRIBUTING.md` "Unit tests" / "Coverage" sections
+- `.cursor/rules/coding-standards.mdc`; "Testing Guidelines" in
   `.github/copilot-instructions.md`
 
 ## Advocate
 
 - Backend-parity test fixtures so executor sweeps are first-class
   instead of hand-coded per test.
-- A canonical set of small fixtures per modality so new tests do not
-  reinvent fixture loading.
-- Coverage reporting per-module so low-coverage hotspots are visible.
-- Faster CPU CI by selective test selection on changed-paths (CODEOWNERS
-  / pytest collect).
-- Snapshot or determinism tests for deduplication and synthetic-data
+- Canonical small fixtures per modality so new tests don't reinvent
+  fixture loading. Today `tests/fixtures/` and `tests/data/` only
+  cover audio.
+- Per-module coverage reporting so low-coverage hotspots are
+  visible.
+- Faster CPU CI via path-based test selection on changed files.
+- Snapshot or determinism tests for dedup and synthetic-data
   outputs.
-
-## Serve Peers
-
-- **To pipeline-contract steward**: provide minimal stage / task
-  fixtures so contract tests do not depend on real modality stages.
-- **To backends steward**: own the parity test harness so executor
-  sweeps are trivial to add.
-- **To modality stewards**: keep `tests/data/` and `tests/fixtures/`
-  organized so each modality can pull representative inputs.
-- **To docs steward**: tests are the verification surface for doc
-  claims. When a content audit lands a P0 about a flag/default,
-  there should be a test that pins it.
 
 ## Do Not
 
-- Add a test that requires a GPU without `@pytest.mark.gpu`.
-- Start ad-hoc Ray clusters; reuse the conftest's cluster.
-- Commit large binaries or model artifacts.
-- Use real network calls (HuggingFace download, remote APIs) inside
-  CPU tests; mock or skip.
-- Disable coverage with `# pragma: no cover` for non-trivial logic.
-- Use `print()`; tests should be quiet on success.
-- Set `RAY_memory_usage_threshold` in test code; conftest already
-  sets a reasonable default.
+- Use real network calls (HuggingFace download, remote APIs) in CPU
+  tests; mock or skip.
+- Set `RAY_memory_usage_threshold` in test code — `conftest.py`
+  already sets a reasonable default.
+- Suppress coverage with `# pragma: no cover` for non-trivial
+  logic.
 
 ## Own
 
-**Code surfaces**:
+**Code:** `tests/` (entire tree).
 
-- `tests/` (entire tree)
-- `tests/conftest.py`, `tests/L0_Unit_Test_*.sh`,
-  `tests/gpu_test_groups.json`
+**Docs (autopilot surface):** "Unit tests" / "Coverage" sections of
+`CONTRIBUTING.md`; "Testing Guidelines" in
+`.github/copilot-instructions.md`; `fern/` contributor / developer
+testing pages.
 
-**Tests**: self.
+**Agent artifacts:** the "Testing" portion of
+`.cursor/rules/coding-standards.mdc`.
 
-**Docs (autopilot audit surface)**:
-
-- The "Unit tests" and "Coverage" sections of `CONTRIBUTING.md`
-- The "Testing Guidelines" section of
-  `.github/copilot-instructions.md`
-- `fern/` developer / contributor pages about testing
-
-**Agent-facing artifacts**:
-
-- The "Testing" portion of `.cursor/rules/coding-standards.mdc`
-
-**CODEOWNERS routing**:
-
-- Default: `@NVIDIA-NeMo/curator_reviewers`
-- Per-domain subtrees route to their modality CODEOWNERS where
-  defined: `tests/stages/deduplication/`,
-  `tests/stages/text/embedders/`, `tests/stages/text/classifiers/`,
-  `tests/stages/synthetic/`, `tests/stages/video/`, `tests/backends/`.
-  Other subtrees (`tests/stages/{audio,image,interleaved,math_stages,common}/`,
-  `tests/{tasks,pipelines,core,metrics,models,config,utils}/`) fall
-  through to the default reviewers team today; add explicit
-  CODEOWNERS entries when those modalities grow dedicated owners.
+**CODEOWNERS:** default `@NVIDIA-NeMo/curator_reviewers`. Per-modality
+subtrees route to their modality CODEOWNERS when defined:
+`tests/stages/deduplication/`, `tests/stages/text/embedders/`,
+`tests/stages/text/classifiers/`, `tests/stages/synthetic/`,
+`tests/stages/video/`, `tests/backends/`. Other subtrees
+(`tests/stages/{audio,image,interleaved,math_stages,common}/`,
+`tests/{tasks,pipelines,core,metrics,models,config,utils}/`) fall
+through to the default team — add explicit CODEOWNERS entries when
+those modalities grow dedicated owners.

--- a/tutorials/AGENTS.md
+++ b/tutorials/AGENTS.md
@@ -1,47 +1,43 @@
 # Steward: Tutorials & Examples
 
-End-to-end runnable examples per modality. The single biggest source
-of "copy this, it should work" trust — and the single biggest doc-rot
+End-to-end runnable examples per modality. The single biggest "copy
+this, it should work" trust surface — and the single biggest doc-rot
 surface when public APIs evolve.
 
-Related docs:
-
-- root [AGENTS.md](../AGENTS.md)
-- [tutorials/README.md](README.md)
-- `tutorials/quickstart.py`
+Related: root [AGENTS.md](../AGENTS.md),
+[tutorials/README.md](README.md), `tutorials/quickstart.py`.
 
 ## Point Of View
 
 The user's "does this actually work?" test. Every tutorial is a
-contract with users that the imports, configs, CLI invocations, and
-pipeline composition shown here resolve against the current
-`nemo_curator/` public API.
+contract that the imports, configs, CLI invocations, and pipeline
+composition shown here resolve against the current `nemo_curator/`
+public API.
 
 ## Protect
 
-- **Imports resolve**: every `from nemo_curator…` line in a tutorial
-  must resolve against the current installed package.
-- **Pipeline composition type-checks**: `pipeline.add_stage(...)`
-  examples must produce a runnable pipeline against current
+- **Imports resolve.** Every `from nemo_curator…` line in a tutorial
+  resolves against the current installed package.
+- **Pipeline composition type-checks.** `pipeline.add_stage(...)`
+  examples produce a runnable pipeline against current
   `ProcessingStage` and `Task` types.
-- **CLI invocations**: any shell or notebook line invoking a Curator
-  CLI / script must match the current argparse / entry-point
-  definition.
-- **Install steps**: extras must match the current `pyproject.toml`
-  extras groups. Curator splits each modality into `_cpu` and
-  `_cuda12` variants — the real names are `text_cpu` / `text_cuda12`,
-  `video_cpu` / `video_cuda12`, `audio_cpu` / `audio_cuda12`,
-  `image_cpu` / `image_cuda12`, `math_cpu` / `math_cuda12`,
-  `interleaved_cpu` / `interleaved_cuda12`, `sdg_cpu` / `sdg_cuda12`,
-  plus `deduplication_cuda12` and the aggregate `all`. Bare `text` /
+- **CLI invocations** match current argparse / entry-point
+  definitions.
+- **Install extras** must match `pyproject.toml`. Curator splits
+  each modality into `_cpu` and `_cuda12` variants — real names are
+  `text_cpu` / `text_cuda12`, `video_cpu` / `video_cuda12`,
+  `audio_cpu` / `audio_cuda12`, `image_cpu` / `image_cuda12`,
+  `math_cpu` / `math_cuda12`, `interleaved_cpu` /
+  `interleaved_cuda12`, `sdg_cpu` / `sdg_cuda12`, plus
+  `deduplication_cuda12` and the aggregate `all`. Bare `text` /
   `video` / etc. do **not** exist.
-- **Resource and hardware claims**: a "needs N GPUs of M GB" claim
-  must reflect actual stage resource declarations.
-- **Modality coverage**: `audio/`, `image/`, `interleaved/`, `math/`,
-  `slurm/`, `synthetic/`, `text/`, `video/` — each modality folder
-  should have at least one currently-runnable tutorial.
-- **Slurm / cluster examples** (`tutorials/slurm/`): keep
-  cluster-launch scripts aligned with current `RayClient` lifecycle.
+- **Resource and hardware claims** reflect actual stage resource
+  declarations.
+- **Modality coverage.** `audio/`, `image/`, `interleaved/`, `math/`,
+  `slurm/`, `synthetic/`, `text/`, `video/` — each should have at
+  least one currently-runnable tutorial.
+- **Slurm / cluster examples** (`tutorials/slurm/`) stay aligned
+  with current `RayClient` lifecycle.
 
 ## Contract Checklist
 
@@ -49,72 +45,42 @@ When this domain changes:
 
 - `tutorials/` (entire tree)
 - `tutorials/quickstart.py`
-- `pyproject.toml` extras (mentions must match — `<modality>_cpu` /
-  `<modality>_cuda12` naming, see Protect)
+- `pyproject.toml` extras (mentions must match `<modality>_cpu` /
+  `<modality>_cuda12` naming)
 - `fern/` tutorial / how-to pages that reference these tutorials
-- `README.md` — its quickstart must align with `tutorials/quickstart.py`
+- `README.md` — its quickstart aligns with `tutorials/quickstart.py`
 - `CHANGELOG.md` if tutorial changes reflect user-visible API moves
 
 ## Advocate
 
-- A CI smoke job that imports and parses every tutorial Python file
-  (catches `ImportError` early). Notebooks can be exported to .py
-  for static checks even if full execution is impractical.
-- A "tutorial freshness" report that flags tutorials touching public
-  APIs that changed since the tutorial was last edited.
-- Tiny, license-clean fixtures so tutorials can run end-to-end on a
+- CI smoke job that imports/parses every tutorial Python file
+  (catches `ImportError` early). Export notebooks to `.py` for
+  static checks even if full execution is impractical.
+- A "tutorial freshness" report flagging tutorials touching public
+  APIs that changed since their last edit.
+- Tiny, license-clean fixtures so tutorials run end-to-end on a
   laptop where the modality permits.
-- A canonical structure across modality folders so users moving
-  between modalities find the same shape.
-
-## Serve Peers
-
-- **To pipeline-contract steward**: tutorials exercise the public
-  API harder than tests. Surface awkwardness early.
-- **To modality stewards**: own the tutorial(s) for your modality.
-  Tutorials touching your modality must round-trip against your
-  current public API.
-- **To docs steward**: tutorials are linked from `fern/` and embedded
-  as snippets — keep them in sync.
-
-## Do Not
-
-- Ship a tutorial that imports a private (`_`-prefixed) module.
-- Pin to a version of a model artifact that has been removed.
-- Use real network calls without a `# requires network` note and a
-  graceful failure path.
-- Document install extras that do not exist in `pyproject.toml`.
-- Hardcode absolute paths or contributor-specific environment
-  assumptions.
+- Canonical structure across modality folders.
 
 ## Own
 
-**Code surfaces**:
+**Code:** `tutorials/` (entire tree); `tutorials/quickstart.py`
+(cross-owned with the pipeline-contract steward — it is the canonical
+runnable example).
 
-- `tutorials/` (entire tree)
-- `tutorials/quickstart.py` (cross-owned with the pipeline-contract
-  steward — it is the canonical runnable example)
+**Tests:** static-import / parse checks for every tutorial Python
+file (add a CI gate if not present); notebook execution where
+practical.
 
-**Tests**:
+**Docs (autopilot surface):** `tutorials/README.md`, per-modality
+README files, `fern/` how-to and tutorial pages that reference these
+tutorials.
 
-- Static-import / parse checks for every tutorial Python file (add
-  a CI gate if not present)
-- Notebook execution where practical
+**Agent artifacts:** `.claude/skills/getting-started/` — this steward
+keeps the skill aligned with current tutorials. Apply the Docs-First
+evaluation gate before expanding.
 
-**Docs (autopilot audit surface)**:
-
-- `tutorials/README.md`
-- Per-modality tutorial README files
-- `fern/` how-to and tutorial pages that reference these tutorials
-  (to be pinned in the next docs autopilot pass)
-
-**Agent-facing artifacts**:
-
-- `.claude/skills/getting-started/` — this skill points at tutorials;
-  keep aligned. Apply the Docs-First Agent Artifact Evaluation gate
-  (root AGENTS.md) before expanding.
-
-**CODEOWNERS routing**: default `@NVIDIA-NeMo/curator_reviewers`.
-Tutorials touching a modality with named CODEOWNERS (deduplication,
-classifiers, embedders, video, synthetic) route additionally to
-those teams.
+**CODEOWNERS:** default `@NVIDIA-NeMo/curator_reviewers`. Tutorials
+touching a modality with named CODEOWNERS (deduplication,
+classifiers, embedders, video, synthetic) route additionally to those
+teams.

--- a/tutorials/AGENTS.md
+++ b/tutorials/AGENTS.md
@@ -80,7 +80,8 @@ tutorials.
 keeps the skill aligned with current tutorials. Apply the Docs-First
 evaluation gate before expanding.
 
-**CODEOWNERS:** default `@NVIDIA-NeMo/curator_reviewers`. Tutorials
-touching a modality with named CODEOWNERS (deduplication,
-classifiers, embedders, video, synthetic) route additionally to those
-teams.
+**CODEOWNERS:** default `@NVIDIA-NeMo/curator_reviewers`.
+`.github/CODEOWNERS` has no `tutorials/` entries today, so no
+per-modality routing fires for tutorial changes — adding explicit
+routes for tutorials touching dedup / classifiers / embedders /
+video / synthetic is open advocacy.

--- a/tutorials/AGENTS.md
+++ b/tutorials/AGENTS.md
@@ -1,18 +1,24 @@
 # Steward: Tutorials & Examples
 
-End-to-end runnable examples per modality. The single biggest "copy
-this, it should work" trust surface — and the single biggest doc-rot
-surface when public APIs evolve.
+This domain exists because tutorials are how users first decide
+whether NeMo Curator works for them. A tutorial that runs cleanly on
+first try recruits the user; one that fails on imports or wrong
+extras loses them. Tutorials are also the single biggest doc-rot
+surface — they reach into the public API and break whenever that API
+changes without a corresponding tutorial update.
 
 Related: root [AGENTS.md](../AGENTS.md),
 [tutorials/README.md](README.md), `tutorials/quickstart.py`.
 
 ## Point Of View
 
-The user's "does this actually work?" test. Every tutorial is a
-contract that the imports, configs, CLI invocations, and pipeline
-composition shown here resolve against the current `nemo_curator/`
-public API.
+The user's "does this actually work?" test. The user this domain
+serves runs on cluster-scheduled GPU infrastructure (Slurm,
+Kubernetes, multi-node Ray) as often as on a single machine — but
+the first impression usually happens on a laptop or single GPU, so
+both have to work. Every tutorial is a contract that imports,
+configs, CLI invocations, and pipeline composition shown here
+resolve against the current `nemo_curator/` public API.
 
 ## Protect
 
@@ -33,11 +39,12 @@ public API.
   `video` / etc. do **not** exist.
 - **Resource and hardware claims** reflect actual stage resource
   declarations.
-- **Modality coverage.** `audio/`, `image/`, `interleaved/`, `math/`,
-  `slurm/`, `synthetic/`, `text/`, `video/` — each should have at
-  least one currently-runnable tutorial.
-- **Slurm / cluster examples** (`tutorials/slurm/`) stay aligned
-  with current `RayClient` lifecycle.
+- **Modality coverage.** `audio/`, `image/`, `interleaved/`,
+  `math/`, `slurm/`, `synthetic/`, `text/`, `video/` — each should
+  have at least one currently-runnable tutorial.
+- **Cluster-scheduled examples** (`tutorials/slurm/`) stay aligned
+  with current `RayClient` lifecycle. Slurm and other
+  cluster-orchestration patterns are first-class, not afterthoughts.
 
 ## Contract Checklist
 
@@ -53,14 +60,17 @@ When this domain changes:
 
 ## Advocate
 
-- CI smoke job that imports/parses every tutorial Python file
+- **CI smoke job** that imports/parses every tutorial Python file
   (catches `ImportError` early). Export notebooks to `.py` for
   static checks even if full execution is impractical.
-- A "tutorial freshness" report flagging tutorials touching public
-  APIs that changed since their last edit.
-- Tiny, license-clean fixtures so tutorials run end-to-end on a
-  laptop where the modality permits.
-- Canonical structure across modality folders.
+- **"Tutorial freshness" report** flagging tutorials touching
+  public APIs that changed since their last edit.
+- **Tiny, license-clean fixtures** so tutorials run end-to-end on a
+  single GPU/laptop where the modality permits.
+- **Canonical structure across modality folders.**
+- **End-to-end "I curated this corpus from scratch" path.** The
+  Nemotron-CC recipe is the reference pattern; tutorials should
+  point at it.
 
 ## Own
 
@@ -76,9 +86,9 @@ practical.
 README files, `fern/` how-to and tutorial pages that reference these
 tutorials.
 
-**Agent artifacts:** `.claude/skills/getting-started/` — this steward
-keeps the skill aligned with current tutorials. Apply the Docs-First
-evaluation gate before expanding.
+**Agent artifacts:** `.claude/skills/getting-started/` — this
+steward keeps the skill aligned with current tutorials. Apply the
+Docs-First evaluation gate before expanding.
 
 **CODEOWNERS:** default `@NVIDIA-NeMo/curator_reviewers`.
 `.github/CODEOWNERS` has no `tutorials/` entries today, so no

--- a/tutorials/AGENTS.md
+++ b/tutorials/AGENTS.md
@@ -1,0 +1,120 @@
+# Steward: Tutorials & Examples
+
+End-to-end runnable examples per modality. The single biggest source
+of "copy this, it should work" trust — and the single biggest doc-rot
+surface when public APIs evolve.
+
+Related docs:
+
+- root [AGENTS.md](../AGENTS.md)
+- [tutorials/README.md](README.md)
+- `tutorials/quickstart.py`
+
+## Point Of View
+
+The user's "does this actually work?" test. Every tutorial is a
+contract with users that the imports, configs, CLI invocations, and
+pipeline composition shown here resolve against the current
+`nemo_curator/` public API.
+
+## Protect
+
+- **Imports resolve**: every `from nemo_curator…` line in a tutorial
+  must resolve against the current installed package.
+- **Pipeline composition type-checks**: `pipeline.add_stage(...)`
+  examples must produce a runnable pipeline against current
+  `ProcessingStage` and `Task` types.
+- **CLI invocations**: any shell or notebook line invoking a Curator
+  CLI / script must match the current argparse / entry-point
+  definition.
+- **Install steps**: extras must match the current `pyproject.toml`
+  extras groups. Curator splits each modality into `_cpu` and
+  `_cuda12` variants — the real names are `text_cpu` / `text_cuda12`,
+  `video_cpu` / `video_cuda12`, `audio_cpu` / `audio_cuda12`,
+  `image_cpu` / `image_cuda12`, `math_cpu` / `math_cuda12`,
+  `interleaved_cpu` / `interleaved_cuda12`, `sdg_cpu` / `sdg_cuda12`,
+  plus `deduplication_cuda12` and the aggregate `all`. Bare `text` /
+  `video` / etc. do **not** exist.
+- **Resource and hardware claims**: a "needs N GPUs of M GB" claim
+  must reflect actual stage resource declarations.
+- **Modality coverage**: `audio/`, `image/`, `interleaved/`, `math/`,
+  `slurm/`, `synthetic/`, `text/`, `video/` — each modality folder
+  should have at least one currently-runnable tutorial.
+- **Slurm / cluster examples** (`tutorials/slurm/`): keep
+  cluster-launch scripts aligned with current `RayClient` lifecycle.
+
+## Contract Checklist
+
+When this domain changes:
+
+- `tutorials/` (entire tree)
+- `tutorials/quickstart.py`
+- `pyproject.toml` extras (mentions must match — `<modality>_cpu` /
+  `<modality>_cuda12` naming, see Protect)
+- `fern/` tutorial / how-to pages that reference these tutorials
+- `README.md` — its quickstart must align with `tutorials/quickstart.py`
+- `CHANGELOG.md` if tutorial changes reflect user-visible API moves
+
+## Advocate
+
+- A CI smoke job that imports and parses every tutorial Python file
+  (catches `ImportError` early). Notebooks can be exported to .py
+  for static checks even if full execution is impractical.
+- A "tutorial freshness" report that flags tutorials touching public
+  APIs that changed since the tutorial was last edited.
+- Tiny, license-clean fixtures so tutorials can run end-to-end on a
+  laptop where the modality permits.
+- A canonical structure across modality folders so users moving
+  between modalities find the same shape.
+
+## Serve Peers
+
+- **To pipeline-contract steward**: tutorials exercise the public
+  API harder than tests. Surface awkwardness early.
+- **To modality stewards**: own the tutorial(s) for your modality.
+  Tutorials touching your modality must round-trip against your
+  current public API.
+- **To docs steward**: tutorials are linked from `fern/` and embedded
+  as snippets — keep them in sync.
+
+## Do Not
+
+- Ship a tutorial that imports a private (`_`-prefixed) module.
+- Pin to a version of a model artifact that has been removed.
+- Use real network calls without a `# requires network` note and a
+  graceful failure path.
+- Document install extras that do not exist in `pyproject.toml`.
+- Hardcode absolute paths or contributor-specific environment
+  assumptions.
+
+## Own
+
+**Code surfaces**:
+
+- `tutorials/` (entire tree)
+- `tutorials/quickstart.py` (cross-owned with the pipeline-contract
+  steward — it is the canonical runnable example)
+
+**Tests**:
+
+- Static-import / parse checks for every tutorial Python file (add
+  a CI gate if not present)
+- Notebook execution where practical
+
+**Docs (autopilot audit surface)**:
+
+- `tutorials/README.md`
+- Per-modality tutorial README files
+- `fern/` how-to and tutorial pages that reference these tutorials
+  (to be pinned in the next docs autopilot pass)
+
+**Agent-facing artifacts**:
+
+- `.claude/skills/getting-started/` — this skill points at tutorials;
+  keep aligned. Apply the Docs-First Agent Artifact Evaluation gate
+  (root AGENTS.md) before expanding.
+
+**CODEOWNERS routing**: default `@NVIDIA-NeMo/curator_reviewers`.
+Tutorials touching a modality with named CODEOWNERS (deduplication,
+classifiers, embedders, video, synthetic) route additionally to
+those teams.


### PR DESCRIPTION
## Summary

Introduces an `AGENTS.md` steward network for NeMo Curator: a compact root constitution plus ten scoped stewards aligned to `.github/CODEOWNERS` and real ownership boundaries. Each steward follows the same operating model — *Point of View / Protect / Contract Checklist / Advocate / Serve Peers / Do Not / Own* — and routes review to the relevant CODEOWNERS team rather than replacing it.

The root file encodes the swarm, Content Audit, Convergence, Global Sweep, Doc Autopilot, Docs-First Agent Artifact Evaluation, signal/false-positive budgets, and Known Regression Patterns seeded from this repo's recurring failure modes.

**Scoped stewards** (with CODEOWNERS routing):

- `nemo_curator/` — Pipeline / Stage / Task ABI (default reviewers)
- `nemo_curator/backends/` — Executor parity across Xenna / Ray Data / Ray Actor Pool (`@oyilmaz-nvidia @praateekmahajan @abhinavg4 @ayushdg`)
- `nemo_curator/stages/deduplication/` — exact / fuzzy / semantic + CUDA gating (`@ayushdg @praateekmahajan`)
- `nemo_curator/stages/text/` — text modality; classifiers/embedders sub-ownership (`@sarahyurick @praateekmahajan @VibhuJawa`)
- `nemo_curator/stages/video/` — video + codecs (`@suiyoubi @abhinavg4`)
- `nemo_curator/stages/synthetic/` — SDG + prompt-template packaging (`@huvunvidia`)
- `tests/` — GPU markers, conftest cluster, L0 scripts, 80% coverage
- `fern/` — **Docs Steward**, owns the Doc Autopilot ritual
- `benchmarking/` — perf gates (split CODEOWNERS preserved)
- `tutorials/` — runnable examples, snippet-rot defense

## Bootstrap fixes (validated by the inaugural steward swarm audit before commit)

The new files went through a parallel steward swarm self-audit. Findings that produced corrections in this PR:

- **`fern/` was uncovered by `docs_team` review.** `.github/CODEOWNERS` only listed `docs/ @NVIDIA-NeMo/docs_team`; the canonical Fern site fell through to the default reviewers team. Added `fern/ @NVIDIA-NeMo/docs_team`.
- **Stray `AGENTS.md` line in `.gitignore`.** Sat inside the macOS Files block, no policy reason; removed.
- **Convergent P0 — phantom path `nemo_curator/examples/quickstart.py`.** Caught by Pipeline + Tutorials stewards independently. Global swept across `api-design.md` and `.github/copilot-instructions.md`; real path is `tutorials/quickstart.py`.
- **Convergent P0 — wrong pyproject extras names** (`text` / `video` / `video_cuda`). Real names are `text_cpu` / `text_cuda12` / `video_cpu` / `video_cuda12` etc.
- Modality task class names corrected (`AudioBatch` → `AudioTask`, `InterleavedTask` → `InterleavedBatch`).
- `decompose_to_ipc_stages` references replaced with the real hooks (`xenna_stage_spec`, `ray_stage_spec`).
- `Resources` claim about NVLink/network fields removed — real fields are only `cpus`, `gpu_memory_gb`, `gpus`.
- `text/filters/` references removed — directory doesn't exist; filter-shaped stages live in `text/modules/` and `text/modifiers/`.
- Synthetic Protect rewritten to describe reality (prompts are Python constants in `nemotron_cc/prompts.py`, not file-based templates).
- Deduplication CUDA-gating mandate rewritten to describe current top-level RAPIDS imports honestly, with lazy-import work tracked as open advocacy.
- Video `VideoTask` field description corrected (fields live on nested `Video` / `Clip`).
- Backend parity mandate softened where the parity test surface is still aspirational.

## Policy decisions encoded

- **`docs/` write-freeze effective 2026-05-20.** New product-facing changes land in `fern/` only; historical release notes under `docs/about/release-notes/` are scheduled for removal as part of the decommission.
- **`process()` `None` returns** are treated as adapter-tolerated, not declared on the ABI, until the abstract signature in `stages/base.py` is widened.

## Test plan

- [x] `markdownlint-cli2` on all 11 `AGENTS.md` files — clean
- [x] Pre-existing `api-design.md` lint warnings confirmed pre-existing (single-line edit didn't introduce them)
- [x] Steward swarm self-audit complete, P0 corrections applied, global sweep done
- [x] CODEOWNERS gap for `fern/` closed
- [x] All factual claims grep-verified against source

🤖 Generated with [Claude Code](https://claude.com/claude-code)