### PR TITLE
fix: expose inference server kwargs

### DIFF
--- a/nemo_curator/core/serve/ray_serve/backend.py
+++ b/nemo_curator/core/serve/ray_serve/backend.py
@@ -101,6 +101,10 @@ class RayServeBackend(InferenceBackend):
         quiet_runtime_env: dict[str, Any] | None,
     ) -> dict[str, Any]:
         """Build arguments for Ray Serve's OpenAI app factory."""
+        if "llm_configs" in self._server.server_kwargs:
+            msg = "server_kwargs must not include 'llm_configs'; it is generated from the server models"
+            raise ValueError(msg)
+
         build_args = deepcopy(self._server.server_kwargs)
         build_args["llm_configs"] = llm_configs
 

--- a/nemo_curator/core/serve/ray_serve/backend.py
+++ b/nemo_curator/core/serve/ray_serve/backend.py
@@ -110,8 +110,8 @@ class RayServeBackend(InferenceBackend):
 
         if quiet_runtime_env:
             # Suppress access logs on the OpenAI ingress deployment too.
-            ingress_config = deepcopy(build_args.get("ingress_deployment_config", {}))
-            actor_options = deepcopy(ingress_config.get("ray_actor_options", {}))
+            ingress_config = build_args.get("ingress_deployment_config", {})
+            actor_options = ingress_config.get("ray_actor_options", {})
             actor_options["runtime_env"] = BaseModelConfig.merge_runtime_envs(
                 actor_options.get("runtime_env", {}),
                 quiet_runtime_env,

--- a/nemo_curator/core/serve/ray_serve/backend.py
+++ b/nemo_curator/core/serve/ray_serve/backend.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 from loguru import logger
@@ -69,12 +70,7 @@ class RayServeBackend(InferenceBackend):
         quiet_env = self._quiet_runtime_env() if not server.verbose else None
         llm_configs = [self._to_llm_config(model, quiet_runtime_env=quiet_env) for model in server.models]
 
-        build_args: dict[str, Any] = {"llm_configs": llm_configs}
-        if quiet_env:
-            # Suppress access logs on the OpenAI ingress deployment too.
-            build_args["ingress_deployment_config"] = {
-                "ray_actor_options": {"runtime_env": quiet_env},
-            }
+        build_args = self._build_openai_app_args(llm_configs, quiet_env)
 
         from ray import serve
         from ray.serve.llm import build_openai_app
@@ -98,6 +94,28 @@ class RayServeBackend(InferenceBackend):
         except Exception:
             self._cleanup_failed_deploy()
             raise
+
+    def _build_openai_app_args(
+        self,
+        llm_configs: list["LLMConfig"],
+        quiet_runtime_env: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Build arguments for Ray Serve's OpenAI app factory."""
+        build_args = deepcopy(self._server.server_kwargs)
+        build_args["llm_configs"] = llm_configs
+
+        if quiet_runtime_env:
+            # Suppress access logs on the OpenAI ingress deployment too.
+            ingress_config = deepcopy(build_args.get("ingress_deployment_config", {}))
+            actor_options = deepcopy(ingress_config.get("ray_actor_options", {}))
+            actor_options["runtime_env"] = BaseModelConfig.merge_runtime_envs(
+                actor_options.get("runtime_env", {}),
+                quiet_runtime_env,
+            )
+            ingress_config["ray_actor_options"] = actor_options
+            build_args["ingress_deployment_config"] = ingress_config
+
+        return build_args
 
     @staticmethod
     def _reset_serve_client_cache() -> None:

--- a/nemo_curator/core/serve/server.py
+++ b/nemo_curator/core/serve/server.py
@@ -19,6 +19,7 @@ import logging
 import time
 import urllib.request
 from dataclasses import dataclass, field
+from typing import Any
 
 from loguru import logger
 
@@ -47,6 +48,7 @@ class InferenceServer:
     port: int = DEFAULT_SERVE_PORT
     health_check_timeout_s: int = DEFAULT_SERVE_HEALTH_TIMEOUT_S
     verbose: bool = False
+    server_kwargs: dict[str, Any] = field(default_factory=dict)
 
     _started: bool = field(init=False, default=False, repr=False)
     _backend_impl: InferenceBackend | None = field(init=False, default=None, repr=False)

--- a/tests/core/serve/ray_serve/test_backend.py
+++ b/tests/core/serve/ray_serve/test_backend.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from nemo_curator.core.serve import RayServeModelConfig
+from nemo_curator.core.serve import InferenceServer, RayServeModelConfig
 from nemo_curator.core.serve.ray_serve.backend import RayServeBackend
 
 LLMConfig = pytest.importorskip("ray.serve.llm", reason="ray[serve] not installed").LLMConfig
@@ -45,3 +45,25 @@ class TestRayServeBackend:
         assert result.runtime_env["env_vars"]["MY_VAR"] == "1"
         assert result.runtime_env["env_vars"]["VLLM_LOGGING_LEVEL"] == "WARNING"
         assert result.runtime_env["env_vars"]["RAY_SERVE_LOG_TO_STDERR"] == "0"
+
+    def test_build_openai_app_args_forwards_server_kwargs(self) -> None:
+        server = InferenceServer(
+            models=[RayServeModelConfig(model_identifier="some-model")],
+            server_kwargs={
+                "ingress_deployment_config": {
+                    "autoscaling_config": {"min_replicas": 4, "max_replicas": 4},
+                    "ray_actor_options": {"runtime_env": {"env_vars": {"USER_VAR": "1"}}},
+                },
+            },
+        )
+
+        result = RayServeBackend(server)._build_openai_app_args([], RayServeBackend._quiet_runtime_env())
+
+        ingress_config = result["ingress_deployment_config"]
+        assert result["llm_configs"] == []
+        assert ingress_config["autoscaling_config"] == {"min_replicas": 4, "max_replicas": 4}
+        assert ingress_config["ray_actor_options"]["runtime_env"]["env_vars"] == {
+            "USER_VAR": "1",
+            "VLLM_LOGGING_LEVEL": "WARNING",
+            "RAY_SERVE_LOG_TO_STDERR": "0",
+        }

--- a/tests/core/serve/ray_serve/test_backend.py
+++ b/tests/core/serve/ray_serve/test_backend.py
@@ -67,3 +67,12 @@ class TestRayServeBackend:
             "VLLM_LOGGING_LEVEL": "WARNING",
             "RAY_SERVE_LOG_TO_STDERR": "0",
         }
+
+    def test_build_openai_app_args_rejects_llm_configs_server_kwarg(self) -> None:
+        server = InferenceServer(
+            models=[RayServeModelConfig(model_identifier="some-model")],
+            server_kwargs={"llm_configs": []},
+        )
+
+        with pytest.raises(ValueError, match="server_kwargs must not include 'llm_configs'"):
+            RayServeBackend(server)._build_openai_app_args([], None)


### PR DESCRIPTION
## Description
Expose a generic `server_kwargs` parameter on `InferenceServer` and forward it to Ray Serve's `build_openai_app`, allowing users to pass options such as `ingress_deployment_config` for tuning ingress replicas.

Closes #1621

## Usage
```python
from nemo_curator.core.serve import InferenceServer, RayServeModelConfig

server = InferenceServer(
    models=[RayServeModelConfig(model_identifier="my-model")],
    server_kwargs={
        "ingress_deployment_config": {
            "autoscaling_config": {"min_replicas": 4, "max_replicas": 4},
        },
    },
)
```
## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Testing
- `uv run ruff check nemo_curator/core/serve/server.py nemo_curator/core/serve/ray_serve/backend.py tests/core/serve/ray_serve/test_backend.py`
- `uv run python -m py_compile nemo_curator/core/serve/server.py nemo_curator/core/serve/ray_serve/backend.py tests/core/serve/ray_serve/test_backend.py`
- `uv run pytest tests/core/serve/ray_serve/test_backend.py tests/core/serve/test_server.py` (blocked locally: package intentionally raises on Darwin; NeMo-Curator currently only supports Linux)
