### PR TITLE
[benchmarking] Add ping_users_on_failure toggle, disable in nightly config

### DIFF
--- a/benchmarking/nightly-benchmark.yaml
+++ b/benchmarking/nightly-benchmark.yaml
@@ -120,6 +120,9 @@ sinks:
     live_updates: true
     channel_id: ${SLACK_CHANNEL_ID}
     default_metrics: ["exec_time_s"]
+    # Temporarily disable @-mentions on failure while the test suite is being
+    # stabilized. Flip back to true (or remove this line) once runs are clean.
+    ping_users_on_failure: false
 #  - name: gdrive
 #    enabled: false
 #    drive_folder_id: ${GDRIVE_FOLDER_ID}

--- a/benchmarking/runner/sinks/slack_sink.py
+++ b/benchmarking/runner/sinks/slack_sink.py
@@ -466,6 +466,11 @@ class SlackSink(Sink):
 
         self.live_updates: bool = sink_config.get("live_updates", False)
 
+        # Whether per-entry `ping_on_failure` user lists are honored. Set to False at
+        # sink config level to globally suppress @-mentions on failure without having
+        # to remove the per-entry lists. Default True preserves existing behavior.
+        self.ping_users_on_failure: bool = sink_config.get("ping_users_on_failure", True)
+
         self.default_metrics: list[str] = sink_config.get("default_metrics", [])
         if not self.default_metrics:
             msg = "SlackSink: No default metrics configured"
@@ -572,7 +577,12 @@ class SlackSink(Sink):
         # such as additional metrics to include in the report, pings, etc.
         sink_data = benchmark_entry.get_sink_data(self.name)
         additional_metrics = sink_data.get("additional_metrics", [])
-        pings = [] if result_dict["success"] else sink_data.get("ping_on_failure", [])
+        # Per-entry ping_on_failure lists are consulted on failure unless the sink
+        # globally disables pings via `ping_users_on_failure: false` in sink config.
+        if result_dict["success"] or not self.ping_users_on_failure:
+            pings = []
+        else:
+            pings = sink_data.get("ping_on_failure", [])
         status_text = "✅ success" if result_dict["success"] else "❌ FAILED"
 
         warnings = result_dict.get("warnings", [])


### PR DESCRIPTION
## Summary

Adds a sink-level boolean `ping_users_on_failure` (default `true`) to the
Slack sink, and disables it in the nightly benchmark config to silence
`@`-mentions while the test suite is being stabilized.

## Why

When a benchmark entry fails, the Slack sink currently `@`-mentions every
user in the entry's per-entry `ping_on_failure` list — even when failures
are caused by known transient infrastructure or work-in-progress issues
rather than ownership-relevant regressions. The author of each affected
entry has agreed to temporarily silence pings until the suite is back to a
clean state.

The straightforward but disruptive way to do this would be to edit every
entry's `sink_data.ping_on_failure` list. Instead, this PR adds a
sink-level toggle so the per-entry lists are preserved and can be honored
again by flipping a single line (or removing it).

## Changes

### 1. `[benchmarking] Add ping_users_on_failure toggle to SlackSink` (c210f051)

* `benchmarking/runner/sinks/slack_sink.py`:
  * `SlackSink.__init__` reads `sink_config.get("ping_users_on_failure", True)`.
  * `register_benchmark_entry_finished` gates the existing per-entry `ping_on_failure` lookup on the new flag.
* Default `True` so existing pipelines see no behavior change.

The new key is named `ping_users_on_failure` rather than overloading the
existing per-entry `ping_on_failure` — the latter is a list of Slack user
IDs, while this is a boolean. Same name with different types in different
config scopes would invite confusion and silent misconfiguration.

### 2. `[benchmarking] Disable Slack @-mentions on failure in nightly config` (da80d7a5)

* `benchmarking/nightly-benchmark.yaml`: sets `ping_users_on_failure: false`
  on the slack sink block, with an inline comment explaining how to revert.

## Config example

```yaml
sinks:
  - name: slack
    enabled: true
    ping_users_on_failure: false   # ← new, default true
    ...

entries:
  - name: my_benchmark
    sink_data:
      - name: slack
        ping_on_failure:             # existing per-entry list, unchanged
          - U022P8CDX40
```

## Reverting

To restore @-mentions, change `ping_users_on_failure: false` back to
`true` (or remove the line) in `nightly-benchmark.yaml`. No other edits
are needed — the per-entry `ping_on_failure` lists were not touched.

## Test plan

- [x] Pre-commit (ruff, ruff-format, signoff) clean
- [ ] Trigger a curator nightly run with at least one entry expected to
      fail (e.g. against a known-failing test from
      [Curator PR #2035](https://github.com/NVIDIA-NeMo/Curator/pull/2035)
      remaining failures) and confirm no `@`-mention appears in the
      Slack thread for the failed entry
- [ ] Flip `ping_users_on_failure: true` locally, re-run, confirm pings
      reappear (verifies default-true path)
- [ ] Run an unmodified config without the new key; confirm behavior
      matches current production (verifies the default-True read path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
