### PR TITLE
fix: include port 65535 in free port search

### DIFF
--- a/nemo_curator/core/utils.py
+++ b/nemo_curator/core/utils.py
@@ -100,7 +100,7 @@ def get_free_port(start_port: int, get_next_free_port: bool = True) -> int:
     If not, it will get the next free port starting from start_port if get_next_free_port is True.
     Else, it will raise an error if the free port is not equal to start_port.
     """
-    for port in range(start_port, 65535):
+    for port in range(start_port, 65536):
         if port >= DEFAULT_RAY_MIN_WORKER_PORT and port <= DEFAULT_RAY_MAX_WORKER_PORT:
             continue
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import socket
+
 import pytest
 
-from nemo_curator.core.utils import ignore_ray_head_node
+from nemo_curator.core.utils import get_free_port, ignore_ray_head_node
 
 
 @pytest.mark.parametrize(
@@ -34,3 +36,28 @@ def test_ignore_ray_head_node_env_parsing(monkeypatch: pytest.MonkeyPatch, value
     else:
         monkeypatch.setenv("CURATOR_IGNORE_RAY_HEAD_NODE", value)
     assert ignore_ray_head_node() is expected
+
+
+def test_get_free_port_checks_highest_valid_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeSocket:
+        def __enter__(self) -> "FakeSocket":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def setsockopt(self, *args: object) -> None:
+            return None
+
+        def bind(self, address: tuple[str, int]) -> None:
+            _, port = address
+            if port != 65535:
+                raise OSError
+
+    def fake_socket(*args: object, **kwargs: object) -> FakeSocket:
+        _ = args, kwargs
+        return FakeSocket()
+
+    monkeypatch.setattr(socket, "socket", fake_socket)
+
+    assert get_free_port(65535) == 65535


### PR DESCRIPTION
## Description

Closes #2023.

Updates `get_free_port()` to include port 65535 in the search range, matching the valid TCP port range and the existing error message. Adds a focused regression test for starting the search at 65535.

## Usage

```python
from nemo_curator.core.utils import get_free_port

port = get_free_port(65535)
```

## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Testing

- `uv run --python 3.12 --group linting ruff check nemo_curator/core/utils.py tests/core/test_utils.py` — passed
- `uv run --python 3.12 --group test python -m pytest tests/core/test_utils.py` — blocked on macOS because `nemo_curator` raises `ValueError` on non-Linux systems during import
- Direct boundary check with `get_free_port(65535)` and a fake socket — passed
