### PR TITLE
ci: disable uv cache for cpu tests

### DIFF
--- a/tests/L0_Unit_Test_CPU.sh
+++ b/tests/L0_Unit_Test_CPU.sh
@@ -19,6 +19,8 @@ PY_VERSION="${2:?Usage: $0 <folder> <python-version>}"
 
 FOLDER="${FOLDER/stages-/stages/}"
 
+export UV_NO_CACHE=1
+
 rm -rf .venv
 uv venv --seed --python "${PY_VERSION}"
 uv sync --no-progress --link-mode copy --locked --extra audio_cpu --extra sdg_cpu --extra text_cpu --extra video_cpu --group test


### PR DESCRIPTION
## Description

- disable uv cache for cpu tests, currently failing due to out of storage

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
