### PR TITLE
Fix get_free_port checking port 65535

### DIFF
--- a/nemo_curator/core/utils.py
+++ b/nemo_curator/core/utils.py
@@ -100,7 +100,7 @@ def get_free_port(start_port: int, get_next_free_port: bool = True) -> int:
     If not, it will get the next free port starting from start_port if get_next_free_port is True.
     Else, it will raise an error if the free port is not equal to start_port.
     """
-    for port in range(start_port, 65535):
+    for port in range(start_port, 65536):
         if port >= DEFAULT_RAY_MIN_WORKER_PORT and port <= DEFAULT_RAY_MAX_WORKER_PORT:
             continue
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Self
+
 import pytest
 
-from nemo_curator.core.utils import ignore_ray_head_node
+from nemo_curator.core.utils import get_free_port, ignore_ray_head_node
 
 
 @pytest.mark.parametrize(
@@ -34,3 +36,23 @@ def test_ignore_ray_head_node_env_parsing(monkeypatch: pytest.MonkeyPatch, value
     else:
         monkeypatch.setenv("CURATOR_IGNORE_RAY_HEAD_NODE", value)
     assert ignore_ray_head_node() is expected
+
+
+def test_get_free_port_checks_port_65535(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeSocket:
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def setsockopt(self, *_args: object) -> None:
+            return None
+
+        def bind(self, address: tuple[str, int]) -> None:
+            if address[1] != 65535:
+                raise OSError
+
+    monkeypatch.setattr("nemo_curator.core.utils.socket.socket", lambda *_args: FakeSocket())
+
+    assert get_free_port(65534) == 65535


### PR DESCRIPTION
## Description
Fixes the inclusive upper bound in `get_free_port()` so port 65535 is actually checked before raising.

Closes #2023.

## Usage
```python
from nemo_curator.core.utils import get_free_port

port = get_free_port(65534)
```

## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.

Tests:
- `uv run ruff check nemo_curator/core/utils.py tests/core/test_utils.py`
- `uv run python - <<'PY' ...` custom focused `get_free_port(65534) == 65535` harness

Note: `uv run pytest tests/core/test_utils.py -q` could not run on this macOS host because NeMo-Curator raises on non-Linux systems during import.
