### PR TITLE
Strip user-set task_id from tutorials & getting-started script

### DIFF
--- a/.claude/skills/getting-started/scripts/verify_pipeline_cpu.py
+++ b/.claude/skills/getting-started/scripts/verify_pipeline_cpu.py
@@ -38,7 +38,6 @@ class TaskCreationStage(ProcessingStage[_EmptyTask, SampleTask]):
         return [
             SampleTask(
                 data=pd.DataFrame({"text": ["Hello world", "Test sentence"]}),
-                task_id="1",
                 dataset_name="test",
             )
         ]

--- a/tutorials/audio/callhome_diar/run.py
+++ b/tutorials/audio/callhome_diar/run.py
@@ -89,7 +89,6 @@ def _load_task(path: Path) -> AudioTask:
     """Reconstruct a single AudioTask from a checkpoint file."""
     payload = json.loads(path.read_text())
     return AudioTask(
-        task_id=payload["task_id"],
         dataset_name=payload["dataset_name"],
         data=payload["data"],
         _metadata=payload.get("_metadata", {}),
@@ -159,7 +158,6 @@ class CallHomeReaderStage(ProcessingStage[_EmptyTask, AudioTask]):
             tasks.append(
                 AudioTask(
                     data={self.filepath_key: str(wav), "session_name": fid},
-                    task_id=f"callhome_{fid}",
                     dataset_name="callhome_eng0",
                 )
             )
@@ -196,7 +194,6 @@ class EnsureMonoStage(ProcessingStage[AudioTask, AudioTask]):
         output_data = dict(task.data)
         output_data[self.filepath_key] = self._ensure_mono(task.data[self.filepath_key])
         return AudioTask(
-            task_id=task.task_id,
             dataset_name=task.dataset_name,
             data=output_data,
             _metadata=task._metadata,
@@ -237,7 +234,6 @@ class DERComputationStage(ProcessingStage[AudioTask, AudioTask]):
                 metrics = self._compute_der(gt, output_data[self.diar_segments_key], uem_start, uem_end)
         output_data[self.der_metrics_key] = metrics
         return AudioTask(
-            task_id=task.task_id,
             dataset_name=task.dataset_name,
             data=output_data,
             _metadata=task._metadata,

--- a/tutorials/audio/single_speaker_filter/run.py
+++ b/tutorials/audio/single_speaker_filter/run.py
@@ -93,14 +93,12 @@ def _load_task(path: Path) -> AudioTask | FileGroupTask:
     payload = json.loads(path.read_text())
     if payload.get("_task_type") == "FileGroupTask":
         return FileGroupTask(
-            task_id=payload["task_id"],
             dataset_name=payload["dataset_name"],
             data=payload["data"],
             _metadata=payload.get("_metadata", {}),
             reader_config=payload.get("reader_config", {}),
         )
     return AudioTask(
-        task_id=payload["task_id"],
         dataset_name=payload["dataset_name"],
         data=payload["data"],
         _metadata=payload.get("_metadata", {}),
@@ -153,7 +151,6 @@ class SingleSpeakerFilterStage(ProcessingStage[AudioTask, AudioTask]):
                 output_data["num_speakers"] = 1
                 results.append(
                     AudioTask(
-                        task_id=task.task_id,
                         dataset_name=task.dataset_name,
                         data=output_data,
                         _metadata=task._metadata,

--- a/tutorials/math/1_cc_index_lookup.py
+++ b/tutorials/math/1_cc_index_lookup.py
@@ -121,7 +121,6 @@ class CCIndexLookupStage(ProcessingStage[FileGroupTask, FileGroupTask]):
         logger.debug(f"Processed {len(task.data)} files: {total_input:,} -> {total_matched:,} rows")
 
         return FileGroupTask(
-            task_id=task.task_id,
             dataset_name=task.dataset_name,
             data=output_files,
             _metadata={

--- a/tutorials/quickstart.py
+++ b/tutorials/quickstart.py
@@ -84,7 +84,6 @@ class TaskCreationStage(ProcessingStage[_EmptyTask, SampleTask]):
             tasks.append(
                 SampleTask(
                     data=pd.DataFrame({"sentence": sampled_sentences}),
-                    task_id=random.randint(0, 1000000),  # noqa: S311
                     dataset_name="SampleDataset",
                 )
             )
@@ -203,7 +202,7 @@ class SentimentStage(ProcessingStage[SampleTask, SampleTask]):
             new_data = task.data.copy()
             new_data["sentiment"] = task_sentiments
 
-            result_task = SampleTask(data=new_data, task_id=task.task_id, dataset_name=task.dataset_name)
+            result_task = SampleTask(data=new_data, dataset_name=task.dataset_name)
             result_tasks.append(result_task)
 
             sentence_idx += num_sentences

--- a/tutorials/slurm/pipeline.py
+++ b/tutorials/slurm/pipeline.py
@@ -114,12 +114,11 @@ class TaskCreationStage(ProcessingStage[_EmptyTask, SampleTask]):
 
     def process(self, _: _EmptyTask) -> list[SampleTask]:
         tasks = []
-        for i in range(self.num_tasks):
+        for _ in range(self.num_tasks):
             sentences = random.choices(SAMPLE_SENTENCES, k=self.sentences_per_task)  # noqa: S311
             tasks.append(
                 SampleTask(
                     data=pd.DataFrame({"sentence": sentences}),
-                    task_id=f"task_{i:04d}",
                     dataset_name="slurm_demo",
                 )
             )

--- a/tutorials/synthetic/nemotron_cc/nemo_data_designer/nemotron_cc_sdg_high_quality_example_pipeline.py
+++ b/tutorials/synthetic/nemotron_cc/nemo_data_designer/nemotron_cc_sdg_high_quality_example_pipeline.py
@@ -371,14 +371,13 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
         input_batches = [input_data[i : i + batch_size] for i in range(0, len(input_data), batch_size)]
         input_tasks = []
         id_counter = 0
-        for i in range(num_input_tasks // len(input_batches)):
-            for j, batch in enumerate(input_batches):
+        for _ in range(num_input_tasks // len(input_batches)):
+            for batch in input_batches:
                 df = pd.DataFrame(batch)
                 df["id"] = [id_counter + k for k in range(len(df))]
                 id_counter += len(df)
                 input_task = DocumentBatch(
                     data=df,
-                    task_id=f"input_batch_{i * batch_size + j}",
                     dataset_name="data_for_sdg",
                 )
                 input_tasks.append(input_task)

--- a/tutorials/synthetic/nemotron_cc/nemo_data_designer/nemotron_cc_sdg_low_quality_example_pipeline.py
+++ b/tutorials/synthetic/nemotron_cc/nemo_data_designer/nemotron_cc_sdg_low_quality_example_pipeline.py
@@ -292,11 +292,10 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
         batch_size = 5
         input_batches = [input_data[i : i + batch_size] for i in range(0, len(input_data), batch_size)]
         input_tasks = []
-        for i, batch in enumerate(input_batches):
+        for batch in input_batches:
             df = pd.DataFrame(batch)
             input_task = DocumentBatch(
                 data=df,
-                task_id=f"input_batch_{i}",
                 dataset_name="data_for_sdg",
             )
             input_tasks.append(input_task)

--- a/tutorials/synthetic/nemotron_cc/nemotron_cc_sdg_high_quality_example_pipeline.py
+++ b/tutorials/synthetic/nemotron_cc/nemotron_cc_sdg_high_quality_example_pipeline.py
@@ -349,15 +349,14 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
         input_batches = [input_data[i : i + batch_size] for i in range(0, len(input_data), batch_size)]
         input_tasks = []
         id_counter = 0
-        for i in range(num_input_tasks // len(input_batches)):
-            for j, batch in enumerate(input_batches):
+        for _ in range(num_input_tasks // len(input_batches)):
+            for batch in input_batches:
                 df = pd.DataFrame(batch)
                 # Ensure a stable document identifier required by DocumentJoiner
                 df["id"] = [id_counter + j for j in range(len(df))]
                 id_counter += len(df)
                 input_task = DocumentBatch(
                     data=df,
-                    task_id=f"input_batch_{i * batch_size + j}",
                     dataset_name="data_for_sdg",
                 )
                 input_tasks.append(input_task)

--- a/tutorials/synthetic/nemotron_cc/nemotron_cc_sdg_low_quality_example_pipeline.py
+++ b/tutorials/synthetic/nemotron_cc/nemotron_cc_sdg_low_quality_example_pipeline.py
@@ -272,11 +272,10 @@ def main() -> None:  # noqa: C901, PLR0912, PLR0915
         batch_size = 5
         input_batches = [input_data[i : i + batch_size] for i in range(0, len(input_data), batch_size)]
         input_tasks = []
-        for i, batch in enumerate(input_batches):
+        for batch in input_batches:
             df = pd.DataFrame(batch)
             input_task = DocumentBatch(
                 data=df,
-                task_id=f"input_batch_{i}",
                 dataset_name="data_for_sdg",
             )
             input_tasks.append(input_task)

--- a/tutorials/text/gliner-pii-redaction/gliner_pii_redactor.py
+++ b/tutorials/text/gliner-pii-redaction/gliner_pii_redactor.py
@@ -178,7 +178,6 @@ class GlinerPiiRedactor(ProcessingStage[DocumentBatch, DocumentBatch]):
 
         # Create output batch
         return DocumentBatch(
-            task_id=f"{batch.task_id}_{self.name}",
             dataset_name=batch.dataset_name,
             data=df,
             _metadata=batch._metadata,

--- a/tutorials/text/llama-nemotron-data-curation/filters/model_filters.py
+++ b/tutorials/text/llama-nemotron-data-curation/filters/model_filters.py
@@ -97,7 +97,6 @@ class NonEnglishFilter(ProcessingStage[DocumentBatch, DocumentBatch]):
         df_filtered = df[mask]
 
         return DocumentBatch(
-            task_id=batch.task_id,
             dataset_name=batch.dataset_name,
             data=df_filtered,
             _metadata=batch._metadata,
@@ -179,7 +178,6 @@ class TokenCountFilter(ProcessingStage[DocumentBatch, DocumentBatch]):
         df_filtered = df[mask]
 
         return DocumentBatch(
-            task_id=batch.task_id,
             dataset_name=batch.dataset_name,
             data=df_filtered,
             _metadata=batch._metadata,
@@ -256,7 +254,6 @@ class CompletionTokenCountFilter(ProcessingStage[DocumentBatch, DocumentBatch]):
         df_filtered = df[mask]
 
         return DocumentBatch(
-            task_id=batch.task_id,
             dataset_name=batch.dataset_name,
             data=df_filtered,
             _metadata=batch._metadata,
@@ -350,7 +347,6 @@ class ApplyChatTemplate(ProcessingStage[DocumentBatch, DocumentBatch]):
         )
 
         return DocumentBatch(
-            task_id=batch.task_id,
             dataset_name=batch.dataset_name,
             data=df,
             _metadata=batch._metadata,

--- a/tutorials/text/nemotron-climb-data-curation/3_prune.py
+++ b/tutorials/text/nemotron-climb-data-curation/3_prune.py
@@ -126,7 +126,6 @@ class JsonlClusterWriter(JsonlWriter):
 
         # Create FileGroupTask with written files using the full protocol-prefixed path
         return FileGroupTask(
-            task_id=task.task_id,
             dataset_name=task.dataset_name,
             data=[file_path_with_protocol],
             _metadata={


### PR DESCRIPTION
## What

PR #2036 made `Task.task_id` `init=False` (framework-owned — assigned by the executor adapter at each stage boundary). The `tutorials/` examples and the getting-started verify script were not swept and still pass `task_id=` to `Task` constructors, so they now crash:

```
TypeError: FileGroupTask.__init__() got an unexpected keyword argument 'task_id'
```

This was reported for the math `cc_index_lookup` pipeline; the same break exists across audio / text / synthetic / slurm / quickstart tutorials and the getting-started CPU verify script.

## Change

Remove the `task_id=` kwarg at every construction site (`FileGroupTask`, `DocumentBatch`, `AudioTask`, `SampleTask`) — the framework assigns the id. Where a loop index existed only to build the removed `task_id`, drop the index (`for _ ...` / `for batch in ...`). Read-only uses of `task_id` (logging, a hash seed, the audio checkpoint payload dict) are left unchanged.

13 files, 8 insertions / 29 deletions — no behavior change beyond ids now being framework-assigned.

Labeled `docs-only` (tutorials/examples) so it skips CI, per @praateekmahajan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
