### PR TITLE
test: cover remote pairwise file paths

### DIFF
--- a/tests/stages/deduplication/semantic/test_pairwise_io.py
+++ b/tests/stages/deduplication/semantic/test_pairwise_io.py
@@ -110,3 +110,32 @@ class TestClusterWiseFilePartitioningStage:
         assert result[2].task_id == "pairwise_centroid_2"
         assert result[2]._metadata == {"centroid_id": 2, "filetype": "parquet"}
         assert result[2].data == [str(centroid_2_dir / "file4.parquet"), str(centroid_2_dir / "file5.parquet")]
+
+    def test_process_restores_protocol_for_remote_listings(self):
+        """Remote fsspec listings may strip protocols; tasks should keep full URLs."""
+
+        class FakeRemoteFs:
+            def unstrip_protocol(self, path: str) -> str:
+                return path if path.startswith("gs://") else f"gs://{path}"
+
+            def ls(self, _path: str) -> list[str]:
+                return ["bucket/kmeans/centroid=7"]
+
+            def expand_path(self, path: str, _recursive: bool = False) -> list[str]:
+                return [path]
+
+            def isdir(self, _path: str) -> bool:
+                return True
+
+            def find(self, _path: str, _maxdepth: int | None, _withdirs: bool, _detail: bool) -> list[str]:
+                return ["bucket/kmeans/centroid=7/part.0.parquet"]
+
+        stage = ClusterWiseFilePartitioningStage("gs://bucket/kmeans")
+        stage.fs = FakeRemoteFs()
+        stage.path_normalizer = stage.fs.unstrip_protocol
+
+        empty_task = _EmptyTask(task_id="test", dataset_name="test", data=None)
+        result = stage.process(empty_task)
+
+        assert len(result) == 1
+        assert result[0].data == ["gs://bucket/kmeans/centroid=7/part.0.parquet"]

--- a/tests/stages/deduplication/semantic/test_pairwise_io.py
+++ b/tests/stages/deduplication/semantic/test_pairwise_io.py
@@ -121,13 +121,18 @@ class TestClusterWiseFilePartitioningStage:
             def ls(self, _path: str) -> list[str]:
                 return ["bucket/kmeans/centroid=7"]
 
-            def expand_path(self, path: str, _recursive: bool = False) -> list[str]:
+            def expand_path(self, path: str, recursive: bool = False) -> list[str]:
+                assert recursive is False
                 return [path]
 
             def isdir(self, _path: str) -> bool:
                 return True
 
-            def find(self, _path: str, _maxdepth: int | None, _withdirs: bool, _detail: bool) -> list[str]:
+            def find(self, path: str, maxdepth: int | None, withdirs: bool, detail: bool) -> list[str]:
+                assert path == "gs://bucket/kmeans/centroid=7"
+                assert maxdepth == 1
+                assert withdirs is False
+                assert detail is False
                 return ["bucket/kmeans/centroid=7/part.0.parquet"]
 
         stage = ClusterWiseFilePartitioningStage("gs://bucket/kmeans")


### PR DESCRIPTION
## Description
Adds regression coverage for remote semantic dedup pairwise input listings where fsspec returns paths without the storage protocol. The test verifies that generated `FileGroupTask` parquet paths retain the full remote URL.

Closes #1213.

## Usage
N/A — test-only regression coverage.

## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.

Validation:
- `uv run ruff check tests/stages/deduplication/semantic/test_pairwise_io.py`
- `uv run ruff format --check tests/stages/deduplication/semantic/test_pairwise_io.py`
- `git diff --check`

Note: I attempted to run `uv run pytest tests/stages/deduplication/semantic/test_pairwise_io.py -q`, but local execution is blocked because NeMo Curator raises on unsupported Darwin/macOS hosts before tests load.
