### PR TITLE
Refactor empty/sentinel tasks: EmptyTask class + SentinelTask base

### DIFF
--- a/nemo_curator/backends/ray_actor_pool/executor.py
+++ b/nemo_curator/backends/ray_actor_pool/executor.py
@@ -104,7 +104,7 @@ class RayActorPoolExecutor(BaseExecutor):
                 f"Setup on node complete for all stages. Starting Ray Actor Pool pipeline with {len(stages)} stages"
             )
             # Initialize with initial tasks
-            current_tasks = initial_tasks or [EmptyTask]
+            current_tasks = initial_tasks or [EmptyTask()]
             # Process through each stage with ActorPool
             for i, stage in enumerate(stages):
                 logger.info(f"\nProcessing stage {i + 1}/{len(stages)}: {stage}")

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -58,7 +58,7 @@ class RayDataExecutor(BaseExecutor):
         # This prevents verbose logging from Ray Data about serialization of the dataclass
         DataContext.get_current().enable_fallback_to_arrow_object_ext_type = True
         # Initialize with initial tasks if provided, otherwise start with EmptyTask
-        tasks: list[Task] = initial_tasks or [EmptyTask]
+        tasks: list[Task] = initial_tasks or [EmptyTask()]
         output_tasks: list[Task] = []
         # When runtime_env with pip is used, Ray's pip plugin sets up per-stage virtualenvs
         # lazily on first task dispatch by cloning the current virtualenv. The NeMo Curator

--- a/nemo_curator/backends/xenna/executor.py
+++ b/nemo_curator/backends/xenna/executor.py
@@ -73,7 +73,7 @@ class XennaExecutor(BaseExecutor):
         stage_specs = []
 
         # Initialize with initial tasks if provided, otherwise start with EmptyTask
-        initial_tasks = initial_tasks if initial_tasks else [EmptyTask]
+        initial_tasks = initial_tasks if initial_tasks else [EmptyTask()]
 
         for stage in stages:
             # Get stage configuration

--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -18,16 +18,15 @@ from loguru import logger
 
 from nemo_curator.backends.base import BaseExecutor
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
-from nemo_curator.tasks import Task
-from nemo_curator.tasks.tasks import _EmptyTask
+from nemo_curator.tasks import EmptyTask, Task
 
 
 def assign_root_task_ids(initial_tasks: list[Task]) -> list[Task]:
     """Assign root ``task_id``s to user-provided initial tasks.
 
     Every task in a run descends from the implicit root ``"0"`` (the id of
-    :class:`_EmptyTask`). User-provided initial tasks are its direct
-    children, so they get ``"0_0"``, ``"0_1"``, … ``_EmptyTask`` instances
+    :class:`EmptyTask`). User-provided initial tasks are its direct
+    children, so they get ``"0_0"``, ``"0_1"``, … ``EmptyTask`` instances
     are skipped (already ``"0"``). All downstream ``task_id`` assignment
     happens in ``BaseStageAdapter``.
 
@@ -40,7 +39,7 @@ def assign_root_task_ids(initial_tasks: list[Task]) -> list[Task]:
     source ids, let a source stage emit them.
     """
     for i, task in enumerate(initial_tasks):
-        if isinstance(task, _EmptyTask):
+        if isinstance(task, EmptyTask):
             continue
         task._set_task_id("0", i)
     return initial_tasks

--- a/nemo_curator/stages/audio/alm/pretrain/io.py
+++ b/nemo_curator/stages/audio/alm/pretrain/io.py
@@ -46,7 +46,7 @@ from nemo_curator.stages.audio.alm.pretrain.utils import (
 )
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
-from nemo_curator.tasks import AudioTask, _EmptyTask
+from nemo_curator.tasks import AudioTask, EmptyTask
 
 if TYPE_CHECKING:
     from nemo_curator.backends.base import NodeInfo, WorkerMetadata
@@ -100,7 +100,7 @@ def _check_duplicate_audio_basename(
 
 
 @dataclass
-class ReadLongFormManifestStage(ProcessingStage[_EmptyTask, AudioTask]):
+class ReadLongFormManifestStage(ProcessingStage[EmptyTask, AudioTask]):
     """Read a JSONL manifest of long-form audios; emit one AudioTask per row.
 
     Each line in ``input_manifest`` is parsed as JSON and re-emitted as
@@ -116,7 +116,7 @@ class ReadLongFormManifestStage(ProcessingStage[_EmptyTask, AudioTask]):
     fallback collapsed per-source metrics and could collide tar member
     names when source times matched).
 
-    This is the entry-point ``_EmptyTask -> list[AudioTask]`` fan-out
+    This is the entry-point ``EmptyTask -> list[AudioTask]`` fan-out
     stage following the same pattern as
     ``CreateInitialManifestReadSpeechStage``.
 
@@ -161,7 +161,7 @@ class ReadLongFormManifestStage(ProcessingStage[_EmptyTask, AudioTask]):
     def xenna_stage_spec(self) -> dict[str, Any]:
         return {"num_workers": 1}
 
-    def process(self, _: _EmptyTask) -> list[AudioTask]:
+    def process(self, _: EmptyTask) -> list[AudioTask]:
         t0 = time.perf_counter()
         if self.audio_path_resolution not in _AUDIO_PATH_RESOLUTION_MODES:
             msg = (

--- a/nemo_curator/stages/audio/common.py
+++ b/nemo_curator/stages/audio/common.py
@@ -27,7 +27,7 @@ from loguru import logger
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
-from nemo_curator.tasks import AudioTask, FileGroupTask, _EmptyTask
+from nemo_curator.tasks import AudioTask, EmptyTask, FileGroupTask
 
 
 def get_audio_duration(audio_filepath: str) -> float:
@@ -179,7 +179,7 @@ class ManifestReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
 
 
 @dataclass
-class ManifestReader(CompositeStage[_EmptyTask, AudioTask]):
+class ManifestReader(CompositeStage[EmptyTask, AudioTask]):
     """Composite stage for reading JSONL manifests.
 
     Decomposes into:

--- a/nemo_curator/stages/audio/datasets/fleurs/create_initial_manifest.py
+++ b/nemo_curator/stages/audio/datasets/fleurs/create_initial_manifest.py
@@ -19,7 +19,7 @@ from typing import Any
 from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio.datasets.file_utils import download_file, extract_archive
 from nemo_curator.stages.base import ProcessingStage
-from nemo_curator.tasks import AudioTask, _EmptyTask
+from nemo_curator.tasks import AudioTask, EmptyTask
 
 
 def get_fleurs_url_list(lang: str, split: str) -> list[str]:
@@ -44,7 +44,7 @@ def get_fleurs_url_list(lang: str, split: str) -> list[str]:
 
 
 @dataclass
-class CreateInitialManifestFleursStage(ProcessingStage[_EmptyTask, AudioTask]):
+class CreateInitialManifestFleursStage(ProcessingStage[EmptyTask, AudioTask]):
     """Create initial manifest for the FLEURS dataset.
 
     Dataset link: https://huggingface.co/datasets/google/fleurs
@@ -114,6 +114,6 @@ class CreateInitialManifestFleursStage(ProcessingStage[_EmptyTask, AudioTask]):
     def ray_stage_spec(self) -> dict[str, Any]:
         return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
 
-    def process(self, _: _EmptyTask) -> list[AudioTask]:
+    def process(self, _: EmptyTask) -> list[AudioTask]:
         self.download_extract_files(self.raw_data_dir)
         return self.process_transcript(os.path.join(self.raw_data_dir, self.split + ".tsv"))

--- a/nemo_curator/stages/audio/datasets/readspeech/create_initial_manifest.py
+++ b/nemo_curator/stages/audio/datasets/readspeech/create_initial_manifest.py
@@ -23,7 +23,7 @@ from loguru import logger
 from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio.datasets.file_utils import download_file
 from nemo_curator.stages.base import ProcessingStage
-from nemo_curator.tasks import AudioTask, _EmptyTask
+from nemo_curator.tasks import AudioTask, EmptyTask
 
 SAMPLE_RATE_48KHZ = 48000
 _MIN_FILENAME_PARTS = 6
@@ -35,7 +35,7 @@ DNS_READSPEECH_URL = (
 
 
 @dataclass
-class CreateInitialManifestReadSpeechStage(ProcessingStage[_EmptyTask, AudioTask]):
+class CreateInitialManifestReadSpeechStage(ProcessingStage[EmptyTask, AudioTask]):
     """
     Stage to create initial manifest for the DNS Challenge Read Speech dataset.
 
@@ -316,7 +316,7 @@ class CreateInitialManifestReadSpeechStage(ProcessingStage[_EmptyTask, AudioTask
 
         logger.info("=" * 60)
 
-    def process(self, _: _EmptyTask) -> list[AudioTask]:
+    def process(self, _: EmptyTask) -> list[AudioTask]:
         """
         Main processing method. Returns list[AudioTask] with one AudioTask per file.
         """

--- a/nemo_curator/stages/client_partitioning.py
+++ b/nemo_curator/stages/client_partitioning.py
@@ -22,7 +22,7 @@ from fsspec.core import url_to_fs
 
 from nemo_curator.backends.base import WorkerMetadata
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 from nemo_curator.utils.client_utils import FSPath
 
 
@@ -43,7 +43,7 @@ class ClientPartitioningStage(FilePartitioningStage):
     def setup(self, worker_metadata: WorkerMetadata | None = None) -> None:  # noqa: ARG002
         self._fs, self._root = url_to_fs(self.file_paths, **self.storage_options or {})
 
-    def process(self, _: _EmptyTask) -> list[FileGroupTask]:
+    def process(self, _: EmptyTask) -> list[FileGroupTask]:
         if not self._fs or not self._root:
             msg = "Stage not initialized. Call setup() before process()."
             raise RuntimeError(msg)

--- a/nemo_curator/stages/deduplication/semantic/kmeans.py
+++ b/nemo_curator/stages/deduplication/semantic/kmeans.py
@@ -24,7 +24,7 @@ from nemo_curator.stages.deduplication.io_utils import DeduplicationIO
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.stages.text.embedders.utils import create_list_series_from_1d_or_2d_ar
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 from nemo_curator.utils.file_utils import FILETYPE_TO_DEFAULT_EXTENSIONS, check_disallowed_kwargs
 
 from .utils import break_parquet_partition_into_groups, get_array_from_df
@@ -45,7 +45,7 @@ L2_DIST_TO_CENT_COL = "l2_dist_to_cent"
 COSINE_DIST_TO_CENT_COL = "cosine_dist_to_cent"
 
 
-class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], DeduplicationIO):
+class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], DeduplicationIO):
     """KMeans clustering stage that requires RAFT for distributed processing."""
 
     def __init__(  # noqa: PLR0913
@@ -127,11 +127,11 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], Dedupl
         self.name = "KMeansStage"
         self.resources = Resources(cpus=1.0, gpus=1.0)
 
-    def process(self, task: FileGroupTask) -> _EmptyTask:
+    def process(self, task: FileGroupTask) -> EmptyTask:
         msg = "KMeansReadFitWriteStage does not support single-task processing"
         raise NotImplementedError(msg)
 
-    def process_batch(self, tasks: list[FileGroupTask]) -> list[_EmptyTask]:
+    def process_batch(self, tasks: list[FileGroupTask]) -> list[EmptyTask]:
         """Process a batch of FileGroupTasks using distributed RAFT KMeans.
 
         In RAFT mode, each actor processes its assigned tasks, but the KMeans model
@@ -184,7 +184,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], Dedupl
         msg = f"Unsupported data type: {self.filetype}"
         raise ValueError(msg)
 
-    def _process_batch_single_pass(self, tasks: list[FileGroupTask], groups: list[list[str]]) -> list["_EmptyTask"]:
+    def _process_batch_single_pass(self, tasks: list[FileGroupTask], groups: list[list[str]]) -> list["EmptyTask"]:
         """Single-pass approach: loads all groups simultaneously.
 
         Requires peak GPU memory = sum(all groups' data). Only suitable when the
@@ -246,7 +246,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], Dedupl
 
             # Create result task for this subgroup
             results.append(
-                _EmptyTask(
+                EmptyTask(
                     dataset_name=f"kmeans_group_{i}",
                     _metadata=None,
                     _stage_perf=[],
@@ -260,7 +260,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], Dedupl
 
         return results
 
-    def _process_batch_two_pass(self, tasks: list[FileGroupTask], groups: list[list[str]]) -> list["_EmptyTask"]:
+    def _process_batch_two_pass(self, tasks: list[FileGroupTask], groups: list[list[str]]) -> list["EmptyTask"]:
         """Memory-efficient two-pass approach for large datasets.
 
         Pass 1 (_fit_pass): samples fit_data_fraction of the actor's files (across
@@ -368,7 +368,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], Dedupl
 
     def _predict_write_pass(
         self, tasks: list[FileGroupTask], groups: list[list[str]]
-    ) -> tuple[list["_EmptyTask"], float, int]:
+    ) -> tuple[list["EmptyTask"], float, int]:
         """Pass 2: load each full group, predict labels, write results.
 
         Returns:
@@ -377,7 +377,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], Dedupl
             reports total_rows as num_rows.
         """
         t_start = time.perf_counter()
-        results: list[_EmptyTask] = []
+        results: list[EmptyTask] = []
         pass2_read_time = 0.0
         total_rows = 0
 
@@ -404,7 +404,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], Dedupl
                 **self.write_kwargs,
             )
             results.append(
-                _EmptyTask(
+                EmptyTask(
                     dataset_name=f"kmeans_group_{i}",
                     _metadata=None,
                     _stage_perf=[],
@@ -480,7 +480,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, _EmptyTask], Dedupl
 
 
 @dataclass
-class KMeansStage(CompositeStage[_EmptyTask, _EmptyTask]):
+class KMeansStage(CompositeStage[EmptyTask, EmptyTask]):
     """KMeans clustering stage that requires RAFT for distributed processing."""
 
     n_clusters: int

--- a/nemo_curator/stages/deduplication/semantic/pairwise.py
+++ b/nemo_curator/stages/deduplication/semantic/pairwise.py
@@ -26,7 +26,7 @@ from loguru import logger
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.deduplication.io_utils import DeduplicationIO
 from nemo_curator.stages.resources import Resources
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 from nemo_curator.utils.file_utils import check_disallowed_kwargs
 
 from .pairwise_io import ClusterWiseFilePartitioningStage
@@ -251,7 +251,7 @@ class PairwiseCosineSimilarityStage(ProcessingStage[FileGroupTask, FileGroupTask
 
 
 @dataclass
-class PairwiseStage(CompositeStage[_EmptyTask, FileGroupTask]):
+class PairwiseStage(CompositeStage[EmptyTask, FileGroupTask]):
     """Pairwise similarity stage for semantic deduplication."""
 
     # Required parameters

--- a/nemo_curator/stages/deduplication/semantic/pairwise_io.py
+++ b/nemo_curator/stages/deduplication/semantic/pairwise_io.py
@@ -20,7 +20,7 @@ from nemo_curator.backends.base import WorkerMetadata
 from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 from nemo_curator.utils.client_utils import is_remote_url
 from nemo_curator.utils.file_utils import get_all_file_paths_under, get_fs, infer_dataset_name_from_path
 
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from fsspec import AbstractFileSystem
 
 
-class ClusterWiseFilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
+class ClusterWiseFilePartitioningStage(ProcessingStage[EmptyTask, FileGroupTask]):
     """Stage that partitions input files into PairwiseFileGroupTasks for deduplication.
 
     This stage takes an EmptyTask as input and outputs partition-aware file groups.
@@ -76,7 +76,7 @@ class ClusterWiseFilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask
             "num_workers_per_node": 1,
         }
 
-    def process(self, _: _EmptyTask) -> list[FileGroupTask]:
+    def process(self, _: EmptyTask) -> list[FileGroupTask]:
         """Process the EmptyTask to create PairwiseFileGroupTasks.
 
         Args:

--- a/nemo_curator/stages/file_partitioning.py
+++ b/nemo_curator/stages/file_partitioning.py
@@ -20,7 +20,7 @@ from loguru import logger
 from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 from nemo_curator.utils.file_utils import (
     _split_files_as_per_blocksize,
     get_all_file_paths_and_size_under,
@@ -30,7 +30,7 @@ from nemo_curator.utils.file_utils import (
 
 
 @dataclass
-class FilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
+class FilePartitioningStage(ProcessingStage[EmptyTask, FileGroupTask]):
     """Stage that partitions input file paths into FileGroupTasks.
 
     This stage runs as a dedicated processing stage (not on the driver)
@@ -106,7 +106,7 @@ class FilePartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
     def xenna_stage_spec(self) -> dict[str, Any]:
         return {"num_workers_per_node": 1}
 
-    def process(self, _: _EmptyTask) -> list[FileGroupTask]:
+    def process(self, _: EmptyTask) -> list[FileGroupTask]:
         """Process the initial task to create file group tasks.
 
         This stage expects a simple Task with file paths information

--- a/nemo_curator/stages/interleaved/io/reader.py
+++ b/nemo_curator/stages/interleaved/io/reader.py
@@ -31,11 +31,11 @@ from nemo_curator.stages.interleaved.utils import (
     DEFAULT_WEBDATASET_EXTENSIONS,
     resolve_storage_options,
 )
-from nemo_curator.tasks import InterleavedBatch, _EmptyTask
+from nemo_curator.tasks import EmptyTask, InterleavedBatch
 
 
 @dataclass
-class InterleavedWebdatasetReader(CompositeStage[_EmptyTask, InterleavedBatch]):
+class InterleavedWebdatasetReader(CompositeStage[EmptyTask, InterleavedBatch]):
     """Composite stage for reading WebDataset shards."""
 
     file_paths: str | list[str]
@@ -87,7 +87,7 @@ class InterleavedWebdatasetReader(CompositeStage[_EmptyTask, InterleavedBatch]):
 
 
 @dataclass
-class InterleavedParquetReader(CompositeStage[_EmptyTask, InterleavedBatch]):
+class InterleavedParquetReader(CompositeStage[EmptyTask, InterleavedBatch]):
     """Composite stage for reading interleaved Parquet files."""
 
     file_paths: str | list[str]

--- a/nemo_curator/stages/interleaved/pdf/nemotron_parse/composite.py
+++ b/nemo_curator/stages/interleaved/pdf/nemotron_parse/composite.py
@@ -26,11 +26,11 @@ from nemo_curator.stages.interleaved.pdf.nemotron_parse.inference import (
 from nemo_curator.stages.interleaved.pdf.nemotron_parse.partitioning import PDFPartitioningStage
 from nemo_curator.stages.interleaved.pdf.nemotron_parse.postprocess import NemotronParsePostprocessStage
 from nemo_curator.stages.interleaved.pdf.nemotron_parse.preprocess import PDFPreprocessStage
-from nemo_curator.tasks import InterleavedBatch, _EmptyTask
+from nemo_curator.tasks import EmptyTask, InterleavedBatch
 
 
 @dataclass
-class NemotronParsePDFReader(CompositeStage[_EmptyTask, InterleavedBatch]):
+class NemotronParsePDFReader(CompositeStage[EmptyTask, InterleavedBatch]):
     """Composite reader: partition -> preprocess -> infer -> postprocess.
 
     Decomposes into four execution stages:

--- a/nemo_curator/stages/interleaved/pdf/nemotron_parse/partitioning.py
+++ b/nemo_curator/stages/interleaved/pdf/nemotron_parse/partitioning.py
@@ -24,11 +24,11 @@ from loguru import logger
 
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 
 
 @dataclass
-class PDFPartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
+class PDFPartitioningStage(ProcessingStage[EmptyTask, FileGroupTask]):
     """Read a JSONL manifest and produce FileGroupTasks for downstream processing.
 
     Each line in the JSONL file must contain at least a ``file_name`` field.
@@ -122,7 +122,7 @@ class PDFPartitioningStage(ProcessingStage[_EmptyTask, FileGroupTask]):
 
         return entries
 
-    def process(self, _: _EmptyTask) -> list[FileGroupTask]:
+    def process(self, _: EmptyTask) -> list[FileGroupTask]:
         entries = self._parse_manifest()
 
         tasks: list[FileGroupTask] = []

--- a/nemo_curator/stages/synthetic/qa_multilingual_synthetic.py
+++ b/nemo_curator/stages/synthetic/qa_multilingual_synthetic.py
@@ -26,11 +26,11 @@ from loguru import logger
 from nemo_curator.backends.base import WorkerMetadata
 from nemo_curator.models.client.llm_client import AsyncLLMClient, GenerationConfig, LLMClient
 from nemo_curator.stages.base import ProcessingStage
-from nemo_curator.tasks import DocumentBatch, _EmptyTask
+from nemo_curator.tasks import DocumentBatch, EmptyTask
 
 
 @dataclass
-class QAMultilingualSyntheticStage(ProcessingStage[_EmptyTask, DocumentBatch]):
+class QAMultilingualSyntheticStage(ProcessingStage[EmptyTask, DocumentBatch]):
     """
     A simple stage for generating synthetic data. It takes in Empty task and a prompt and produces the output in form of a DocumentBatch.
     """
@@ -55,7 +55,7 @@ class QAMultilingualSyntheticStage(ProcessingStage[_EmptyTask, DocumentBatch]):
     def setup(self, _: WorkerMetadata | None = None) -> None:
         self.client.setup()
 
-    def process(self, _: _EmptyTask) -> DocumentBatch:
+    def process(self, _: EmptyTask) -> DocumentBatch:
         responses = self._process_async() if self.is_async_client else self._process_sync()
 
         return DocumentBatch(data=pd.DataFrame({"text": responses}), dataset_name="simple_synthetic_data")

--- a/nemo_curator/stages/text/download/base/stage.py
+++ b/nemo_curator/stages/text/download/base/stage.py
@@ -15,7 +15,7 @@
 from dataclasses import dataclass
 
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
-from nemo_curator.tasks import DocumentBatch, _EmptyTask
+from nemo_curator.tasks import DocumentBatch, EmptyTask
 
 from .download import DocumentDownloader, DocumentDownloadStage
 from .extract import DocumentExtractor
@@ -24,7 +24,7 @@ from .url_generation import URLGenerationStage, URLGenerator
 
 
 @dataclass
-class DocumentDownloadExtractStage(CompositeStage[_EmptyTask, DocumentBatch]):
+class DocumentDownloadExtractStage(CompositeStage[EmptyTask, DocumentBatch]):
     """Composite stage that combines URL generation, download, and iterate-extract stages.
 
     This supports the full 3-step pipeline pattern like Common Crawl:

--- a/nemo_curator/stages/text/download/base/url_generation.py
+++ b/nemo_curator/stages/text/download/base/url_generation.py
@@ -18,7 +18,7 @@ from typing import Any
 
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 
 
 class URLGenerator(ABC):
@@ -31,7 +31,7 @@ class URLGenerator(ABC):
 
 
 @dataclass
-class URLGenerationStage(ProcessingStage[_EmptyTask, FileGroupTask]):
+class URLGenerationStage(ProcessingStage[EmptyTask, FileGroupTask]):
     """Stage that generates URLs from minimal input parameters.
 
     This allows pipelines to start with URL generation (like Common Crawl).
@@ -52,11 +52,11 @@ class URLGenerationStage(ProcessingStage[_EmptyTask, FileGroupTask]):
         """Define output - produces FileGroupTask with URLs."""
         return (["data"], [])
 
-    def process(self, task: _EmptyTask) -> list[FileGroupTask]:
+    def process(self, task: EmptyTask) -> list[FileGroupTask]:
         """Generate URLs and create FileGroupTasks.
 
         Args:
-            task (_EmptyTask): Empty input task
+            task (EmptyTask): Empty input task
 
         Returns:
             list[FileGroupTask]: List of tasks containing URLs

--- a/nemo_curator/stages/text/io/reader/jsonl.py
+++ b/nemo_curator/stages/text/io/reader/jsonl.py
@@ -20,7 +20,7 @@ from loguru import logger
 
 from nemo_curator.stages.base import CompositeStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
-from nemo_curator.tasks import DocumentBatch, _EmptyTask
+from nemo_curator.tasks import DocumentBatch, EmptyTask
 from nemo_curator.utils.file_utils import FILETYPE_TO_DEFAULT_EXTENSIONS, pandas_select_columns
 
 from .base import BaseReader
@@ -81,7 +81,7 @@ class JsonlReaderStage(BaseReader):
 
 
 @dataclass
-class JsonlReader(CompositeStage[_EmptyTask, DocumentBatch]):
+class JsonlReader(CompositeStage[EmptyTask, DocumentBatch]):
     """Composite stage for reading JSONL files.
 
     This high-level stage decomposes into:

--- a/nemo_curator/stages/text/io/reader/parquet.py
+++ b/nemo_curator/stages/text/io/reader/parquet.py
@@ -19,7 +19,7 @@ import pandas as pd
 
 from nemo_curator.stages.base import CompositeStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
-from nemo_curator.tasks import DocumentBatch, _EmptyTask
+from nemo_curator.tasks import DocumentBatch, EmptyTask
 from nemo_curator.utils.file_utils import FILETYPE_TO_DEFAULT_EXTENSIONS
 
 from .base import BaseReader
@@ -66,7 +66,7 @@ class ParquetReaderStage(BaseReader):
 
 
 @dataclass
-class ParquetReader(CompositeStage[_EmptyTask, DocumentBatch]):
+class ParquetReader(CompositeStage[EmptyTask, DocumentBatch]):
     """Composite stage for reading Parquet files.
 
     This high-level stage decomposes into:

--- a/nemo_curator/stages/video/io/video_reader.py
+++ b/nemo_curator/stages/video/io/video_reader.py
@@ -21,7 +21,7 @@ from loguru import logger
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.client_partitioning import ClientPartitioningStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
-from nemo_curator.tasks import _EmptyTask
+from nemo_curator.tasks import EmptyTask
 from nemo_curator.tasks.file_group import FileGroupTask
 from nemo_curator.tasks.video import Video, VideoTask
 from nemo_curator.utils.client_utils import FSPath, is_remote_url
@@ -233,7 +233,7 @@ class VideoReaderStage(ProcessingStage[FileGroupTask, VideoTask]):
 
 
 @dataclass
-class VideoReader(CompositeStage[_EmptyTask, VideoTask]):
+class VideoReader(CompositeStage[EmptyTask, VideoTask]):
     """Composite stage that reads video files from storage and downloads/processes them.
 
     This stage combines FilePartitioningStage and VideoReaderStage into a single

--- a/nemo_curator/tasks/__init__.py
+++ b/nemo_curator/tasks/__init__.py
@@ -17,7 +17,8 @@ from .document import DocumentBatch
 from .file_group import FileGroupTask
 from .image import ImageBatch, ImageObject
 from .interleaved import InterleavedBatch
-from .tasks import EmptyTask, Task, _EmptyTask
+from .sentinels import EmptyTask, SentinelTask
+from .tasks import Task
 
 __all__ = [
     "AudioTask",
@@ -27,6 +28,6 @@ __all__ = [
     "ImageBatch",
     "ImageObject",
     "InterleavedBatch",
+    "SentinelTask",
     "Task",
-    "_EmptyTask",
 ]

--- a/nemo_curator/tasks/sentinels.py
+++ b/nemo_curator/tasks/sentinels.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Payload-less marker tasks.
+
+``EmptyTask`` seeds a pipeline (the implicit root id ``"0"``). All markers
+share the :class:`SentinelTask` base and carry no payload (``data is None``).
+Construct one with ``EmptyTask()``.
+"""
+
+from dataclasses import dataclass, field
+
+from nemo_curator.tasks.tasks import Task
+
+
+@dataclass
+class SentinelTask(Task[None]):
+    """Base for payload-less marker tasks. Always carries no data; ``task_id``
+    is framework-assigned like any other task."""
+
+    data: None = None
+
+    def __post_init__(self) -> None:
+        assert self.data is None, "SentinelTask carries no data"  # noqa: S101
+        super().__post_init__()
+
+    @property
+    def num_items(self) -> int:
+        return 0
+
+    def validate(self) -> bool:
+        return True
+
+
+@dataclass
+class EmptyTask(SentinelTask):
+    """Payload-less task that seeds a pipeline. Its ``task_id`` is fixed to
+    ``"0"`` — the implicit root every task in a run descends from, so all
+    ``task_id``s share the ``"0"`` prefix (source partitions become
+    ``"0_<id>"``, user-provided initial tasks become ``"0_0"``, ``"0_1"``, …).
+    """
+
+    dataset_name: str = "empty"
+    task_id: str = field(init=False, default="0")

--- a/nemo_curator/tasks/tasks.py
+++ b/nemo_curator/tasks/tasks.py
@@ -120,28 +120,3 @@ class Task(ABC, Generic[T]):
     @abstractmethod
     def validate(self) -> bool:
         """Validate the task data."""
-
-
-@dataclass
-class _EmptyTask(Task[None]):
-    """Placeholder input that seeds a pipeline (e.g. for ``ls``/source stages).
-
-    Its ``task_id`` is fixed to ``"0"`` — the implicit root that every task
-    in a run descends from, so all ``task_id``s
-    share the ``"0"`` prefix (source partitions become ``"0_<id>"``,
-    user-provided initial tasks become ``"0_0"``, ``"0_1"``, …).
-    """
-
-    task_id: str = field(init=False, default="0")
-
-    @property
-    def num_items(self) -> int:
-        return 0
-
-    def validate(self) -> bool:
-        """Validate the task data."""
-        return True
-
-
-# Empty tasks are just used for `ls` stages
-EmptyTask = _EmptyTask(dataset_name="empty", data=None)

--- a/tests/backends/ray_data/test_max_calls_pid.py
+++ b/tests/backends/ray_data/test_max_calls_pid.py
@@ -129,7 +129,7 @@ class PassthroughTaskStage(ProcessingStage[DocumentBatch, DocumentBatch]):
 @pytest.mark.parametrize("max_calls_per_worker", [2, None])
 @pytest.mark.usefixtures("single_cpu_ray_client")
 def test_pid_recycling(max_calls_per_worker: int | None):
-    tasks = [EmptyTask] * 8
+    tasks = [EmptyTask()] * 8
 
     stage = PidRecorderStage(max_calls_per_worker=max_calls_per_worker)
     executor = RayDataExecutor()
@@ -159,7 +159,7 @@ def test_max_calls_not_fused_with_actor_stage(max_calls_per_worker: int | None):
     the execution plan directly to ensure no fusion occurred.
     """
     num_tasks = 4
-    tasks = [EmptyTask] * num_tasks
+    tasks = [EmptyTask()] * num_tasks
 
     pid_stage = PidRecorderStage(max_calls_per_worker=max_calls_per_worker).with_(resources=Resources(cpus=0.5))
     actor_stage = PassthroughActorStage().with_(resources=Resources(cpus=0.5))
@@ -220,7 +220,7 @@ def test_max_calls_not_fused_with_task_stage(max_calls_per_worker: int | None):
     We also verify the execution plan directly to ensure no fusion occurred.
     """
     num_tasks = 4
-    tasks = [EmptyTask] * num_tasks
+    tasks = [EmptyTask()] * num_tasks
 
     pid_stage = PidRecorderStage(max_calls_per_worker=max_calls_per_worker).with_(resources=Resources(cpus=0.5))
     task_stage = PassthroughTaskStage().with_(resources=Resources(cpus=0.5))

--- a/tests/backends/test_task_id_postprocess.py
+++ b/tests/backends/test_task_id_postprocess.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 
 from nemo_curator.backends.base import BaseStageAdapter
 from nemo_curator.stages.base import ProcessingStage
-from nemo_curator.tasks import FileGroupTask, Task, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask, Task
 
 
 @dataclass
@@ -102,7 +102,7 @@ class TestSourceStage:
     def test_uses_content_id_rooted_at_input(self) -> None:
         # FileGroupTask.get_deterministic_id() hashes its files; the source
         # output is rooted at the EmptyTask input id "0" → "0_<content_id>".
-        empty = _EmptyTask(dataset_name="empty", data=None)
+        empty = EmptyTask(dataset_name="empty", data=None)
         a = FileGroupTask(dataset_name="d", data=["a.parquet"])
         b = FileGroupTask(dataset_name="d", data=["b.parquet"])
         _assign([empty], [a, b], is_source=True)

--- a/tests/pipelines/test_pipelines.py
+++ b/tests/pipelines/test_pipelines.py
@@ -20,7 +20,7 @@ import pytest
 from nemo_curator.pipeline.pipeline import Pipeline, assign_root_task_ids
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
-from nemo_curator.tasks import EmptyTask, Task, _EmptyTask
+from nemo_curator.tasks import EmptyTask, Task
 
 
 @dataclass
@@ -138,11 +138,11 @@ class TestPipelineBuild:
 
 class TestRootTaskIds:
     """``assign_root_task_ids`` roots user-provided initial tasks under the
-    implicit ``_EmptyTask`` root id ``"0"``."""
+    implicit ``EmptyTask`` root id ``"0"``."""
 
     def test_empty_task_id_is_zero(self) -> None:
-        assert EmptyTask.task_id == "0"
-        assert _EmptyTask(dataset_name="d", data=None).task_id == "0"
+        assert EmptyTask().task_id == "0"
+        assert EmptyTask(dataset_name="d", data=None).task_id == "0"
 
     def test_roots_user_tasks_at_zero(self) -> None:
         tasks = [_SimpleTask(dataset_name="d", data=[1]) for _ in range(3)]
@@ -151,7 +151,7 @@ class TestRootTaskIds:
         assert [t.task_id for t in tasks] == ["0_0", "0_1", "0_2"]
 
     def test_skips_empty_tasks(self) -> None:
-        et = _EmptyTask(dataset_name="d", data=None)
+        et = EmptyTask(dataset_name="d", data=None)
         real = _SimpleTask(dataset_name="d", data=[1])
         assign_root_task_ids([et, real])
         # EmptyTask stays "0"; the real task is rooted by its position.

--- a/tests/stages/audio/alm/pretrain/test_io.py
+++ b/tests/stages/audio/alm/pretrain/test_io.py
@@ -31,7 +31,7 @@ from nemo_curator.stages.audio.alm.pretrain import (
     SnippetManifestWriterStage,
 )
 from nemo_curator.stages.audio.alm.pretrain.utils import _PRETRAIN_META_KEY
-from nemo_curator.tasks import AudioTask, _EmptyTask
+from nemo_curator.tasks import AudioTask, EmptyTask
 
 
 def _make_audio_task(data: dict | None = None) -> AudioTask:
@@ -71,19 +71,19 @@ def manifest_path(tmp_path: Path) -> Path:
 class TestReadLongFormManifestStage:
     def test_emits_one_task_per_valid_row(self, tmp_path: Path, manifest_path: Path) -> None:
         stage = ReadLongFormManifestStage(input_manifest=str(manifest_path), audio_dir=str(tmp_path))
-        out = stage.process(_EmptyTask(dataset_name="empty", data=None))
+        out = stage.process(EmptyTask(dataset_name="empty", data=None))
         assert len(out) == 1
         assert out[0].data["id"] == "A"
 
     def test_resolves_audio_path_against_audio_dir(self, tmp_path: Path, manifest_path: Path) -> None:
         stage = ReadLongFormManifestStage(input_manifest=str(manifest_path), audio_dir="/data")
-        out = stage.process(_EmptyTask(dataset_name="empty", data=None))
+        out = stage.process(EmptyTask(dataset_name="empty", data=None))
         assert out[0].data["audio_filepath"] == "/data/a.wav"
 
     def test_missing_manifest_raises(self, tmp_path: Path) -> None:
         stage = ReadLongFormManifestStage(input_manifest=str(tmp_path / "nope.jsonl"), audio_dir=str(tmp_path))
         with pytest.raises(FileNotFoundError):
-            stage.process(_EmptyTask(dataset_name="empty", data=None))
+            stage.process(EmptyTask(dataset_name="empty", data=None))
 
     def test_skips_rows_missing_id(self, tmp_path: Path) -> None:
         # `id` is required: the metrics aggregator keys per-source records on
@@ -100,7 +100,7 @@ class TestReadLongFormManifestStage:
             for r in rows:
                 f.write(json.dumps(r) + "\n")
         stage = ReadLongFormManifestStage(input_manifest=str(p), audio_dir="/data")
-        out = stage.process(_EmptyTask(dataset_name="empty", data=None))
+        out = stage.process(EmptyTask(dataset_name="empty", data=None))
         assert [t.data["id"] for t in out] == ["OK"]
 
     def test_skips_duplicate_ids(self, tmp_path: Path) -> None:
@@ -117,7 +117,7 @@ class TestReadLongFormManifestStage:
             for r in rows:
                 f.write(json.dumps(r) + "\n")
         stage = ReadLongFormManifestStage(input_manifest=str(p), audio_dir="/data")
-        out = stage.process(_EmptyTask(dataset_name="empty", data=None))
+        out = stage.process(EmptyTask(dataset_name="empty", data=None))
         assert [t.data["id"] for t in out] == ["A", "B"]
         # The kept "A" row is the first one, not the duplicate.
         assert out[0].data["audio_filepath"] == "/data/a.wav"
@@ -136,7 +136,7 @@ class TestReadLongFormManifestStage:
                 f.write(json.dumps(r) + "\n")
         stage = ReadLongFormManifestStage(input_manifest=str(p), audio_dir="/data")
         with pytest.raises(ValueError, match="duplicate audio basename"):
-            stage.process(_EmptyTask(dataset_name="empty", data=None))
+            stage.process(EmptyTask(dataset_name="empty", data=None))
 
     def test_relative_mode_preserves_subdirectories(self, tmp_path: Path) -> None:
         # 'relative' joins audio_dir / audio_filepath verbatim and so does
@@ -150,7 +150,7 @@ class TestReadLongFormManifestStage:
             for r in rows:
                 f.write(json.dumps(r) + "\n")
         stage = ReadLongFormManifestStage(input_manifest=str(p), audio_dir="/data", audio_path_resolution="relative")
-        out = stage.process(_EmptyTask(dataset_name="empty", data=None))
+        out = stage.process(EmptyTask(dataset_name="empty", data=None))
         assert [t.data["audio_filepath"] for t in out] == [
             "/data/shard1/foo.wav",
             "/data/shard2/foo.wav",
@@ -166,7 +166,7 @@ class TestReadLongFormManifestStage:
             for r in rows:
                 f.write(json.dumps(r) + "\n")
         stage = ReadLongFormManifestStage(input_manifest=str(p), audio_dir="/ignored", audio_path_resolution="as_is")
-        out = stage.process(_EmptyTask(dataset_name="empty", data=None))
+        out = stage.process(EmptyTask(dataset_name="empty", data=None))
         assert [t.data["audio_filepath"] for t in out] == [
             "/absolute/a.wav",
             "relative/b.wav",
@@ -178,7 +178,7 @@ class TestReadLongFormManifestStage:
             f.write(json.dumps({"id": "A", "audio_filepath": "./a.wav", "segments": []}) + "\n")
         stage = ReadLongFormManifestStage(input_manifest=str(p), audio_dir="/data", audio_path_resolution="not_a_mode")
         with pytest.raises(ValueError, match="unknown audio_path_resolution"):
-            stage.process(_EmptyTask(dataset_name="empty", data=None))
+            stage.process(EmptyTask(dataset_name="empty", data=None))
 
 
 # ----------------------------------------------------------------------

--- a/tests/stages/audio/alm/pretrain/test_pipeline.py
+++ b/tests/stages/audio/alm/pretrain/test_pipeline.py
@@ -57,7 +57,7 @@ from nemo_curator.stages.audio.alm.pretrain import (
     finalize_audio_pretrain_outputs,
     prepare_audio_pretrain_outputs,
 )
-from nemo_curator.tasks import _EmptyTask
+from nemo_curator.tasks import EmptyTask
 
 _LOCAL_MANIFEST = Path(__file__).resolve().parent / "sample_long_form_manifest.jsonl"
 _NUM_ROWS = 10
@@ -163,7 +163,7 @@ def _run_pipeline_inline(  # noqa: PLR0913
     aggregator.setup_on_node()
     aggregator.setup()
 
-    for input_task in reader.process(_EmptyTask(dataset_name="e", data=None)):
+    for input_task in reader.process(EmptyTask(dataset_name="e", data=None)):
         filtered = overlap.process(input_task)
         planned = planner.process(filtered)
         rep_filtered = rep_filter.process(planned)

--- a/tests/stages/audio/datasets/test_fleurs_create_initial_manifest.py
+++ b/tests/stages/audio/datasets/test_fleurs_create_initial_manifest.py
@@ -103,13 +103,13 @@ def test_process_end_to_end(tmp_path: Path) -> None:
     (audio_dir / "file2.wav").write_bytes(b"")
 
     stage = stage_cls(lang="en_us", split="dev", raw_data_dir=str(raw_dir))
-    from nemo_curator.tasks import _EmptyTask
+    from nemo_curator.tasks import EmptyTask
 
     with (
         patch("nemo_curator.stages.audio.datasets.fleurs.create_initial_manifest.download_file"),
         patch("nemo_curator.stages.audio.datasets.fleurs.create_initial_manifest.extract_archive"),
     ):
-        results = stage.process(_EmptyTask(dataset_name="test", data=None))
+        results = stage.process(EmptyTask(dataset_name="test", data=None))
     assert len(results) == 2
     assert results[0].data["text"] == "hello"
     assert results[1].data["text"] == "world"

--- a/tests/stages/audio/datasets/test_readspeech_create_initial_manifest.py
+++ b/tests/stages/audio/datasets/test_readspeech_create_initial_manifest.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 from nemo_curator.stages.audio.datasets.readspeech.create_initial_manifest import (
     CreateInitialManifestReadSpeechStage,
 )
-from nemo_curator.tasks import AudioTask, _EmptyTask
+from nemo_curator.tasks import AudioTask, EmptyTask
 
 
 def test_ray_stage_spec(tmp_path: Path) -> None:
@@ -84,7 +84,7 @@ def test_process_end_to_end(tmp_path: Path) -> None:
         max_samples=-1,
         auto_download=False,
     )
-    results = stage.process(_EmptyTask(dataset_name="test", data=None))
+    results = stage.process(EmptyTask(dataset_name="test", data=None))
     assert len(results) == 2
     assert all(isinstance(r, AudioTask) for r in results)
     assert results[0].dataset_name == "DNS-ReadSpeech"
@@ -94,7 +94,7 @@ def test_process_empty_dir(tmp_path: Path) -> None:
     empty_dir = tmp_path / "empty"
     empty_dir.mkdir()
     stage = CreateInitialManifestReadSpeechStage(raw_data_dir=str(empty_dir), auto_download=False)
-    results = stage.process(_EmptyTask(dataset_name="t", data=None))
+    results = stage.process(EmptyTask(dataset_name="t", data=None))
     assert results == []
 
 
@@ -105,6 +105,6 @@ def test_auto_download_calls_download(tmp_path: Path) -> None:
     (wav_dir / "book_00000_chp_0001_reader_00100_0_seg_1_seg1.wav").write_bytes(b"\x00")
 
     with patch.object(stage, "download_and_extract", return_value=str(wav_dir)) as mock_dl:
-        results = stage.process(_EmptyTask(dataset_name="t", data=None))
+        results = stage.process(EmptyTask(dataset_name="t", data=None))
         mock_dl.assert_called_once()
         assert len(results) == 1

--- a/tests/stages/common/test_client_partitioning.py
+++ b/tests/stages/common/test_client_partitioning.py
@@ -18,16 +18,16 @@ import pytest
 
 from nemo_curator.backends.base import WorkerMetadata
 from nemo_curator.stages.client_partitioning import ClientPartitioningStage, _read_list_json_rel
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 
 
 class TestClientPartitioningStage:
     """Test suite for ClientPartitioningStage."""
 
     @pytest.fixture
-    def empty_task(self) -> _EmptyTask:
+    def empty_task(self) -> EmptyTask:
         """Create an empty task for testing."""
-        return _EmptyTask(
+        return EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={"source": "test"},
@@ -90,7 +90,7 @@ class TestClientPartitioningStage:
     @patch("nemo_curator.stages.client_partitioning.ClientPartitioningStage._list_relative")
     @patch("nemo_curator.stages.client_partitioning.url_to_fs")
     def test_process_basic_functionality(
-        self, mock_url_to_fs: Mock, mock_list_relative: Mock, empty_task: _EmptyTask
+        self, mock_url_to_fs: Mock, mock_list_relative: Mock, empty_task: EmptyTask
     ) -> None:
         """Test basic process functionality including file filtering."""
         mock_fs = Mock()
@@ -125,7 +125,7 @@ class TestClientPartitioningStage:
     @patch("nemo_curator.stages.client_partitioning.ClientPartitioningStage._list_relative")
     @patch("nemo_curator.stages.client_partitioning.url_to_fs")
     def test_process_partitioning_and_limits(
-        self, mock_url_to_fs: Mock, mock_list_relative: Mock, empty_task: _EmptyTask
+        self, mock_url_to_fs: Mock, mock_list_relative: Mock, empty_task: EmptyTask
     ) -> None:
         """Test files_per_partition and limit functionality."""
         mock_fs = Mock()
@@ -157,7 +157,7 @@ class TestClientPartitioningStage:
 
     @patch("nemo_curator.stages.client_partitioning.ClientPartitioningStage._list_relative")
     @patch("nemo_curator.stages.client_partitioning.url_to_fs")
-    def test_process_edge_cases(self, mock_url_to_fs: Mock, mock_list_relative: Mock, empty_task: _EmptyTask) -> None:
+    def test_process_edge_cases(self, mock_url_to_fs: Mock, mock_list_relative: Mock, empty_task: EmptyTask) -> None:
         """Test edge cases like empty file list and combined filters."""
         mock_fs = Mock()
         mock_root = "/test/path"
@@ -183,7 +183,7 @@ class TestClientPartitioningStage:
         assert len(result[0].data) == 2
         assert len(result[1].data) == 1
 
-    def test_process_without_setup(self, empty_task: _EmptyTask) -> None:
+    def test_process_without_setup(self, empty_task: EmptyTask) -> None:
         """Test process method when setup() hasn't been called."""
         stage = ClientPartitioningStage(file_paths=None)
         with pytest.raises(RuntimeError, match="Stage not initialized"):

--- a/tests/stages/common/test_file_partitioning.py
+++ b/tests/stages/common/test_file_partitioning.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import pytest
 
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 
 
 def _create_test_jsonl_files(base_dir: Path | str, num_files: int, subdir: str | None = None) -> list[str]:
@@ -48,9 +48,9 @@ class TestFilePartitioningStage:
         return files
 
     @pytest.fixture
-    def empty_task(self) -> _EmptyTask:
+    def empty_task(self) -> EmptyTask:
         """Create an empty task for testing."""
-        return _EmptyTask(
+        return EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={"source": "test"},
@@ -122,7 +122,7 @@ class TestFilePartitioningStage:
         spec = stage.ray_stage_spec()
         assert spec["is_fanout_stage"] is True
 
-    def test_process_with_file_list(self, empty_task: _EmptyTask, tmp_path: Path):
+    def test_process_with_file_list(self, empty_task: EmptyTask, tmp_path: Path):
         """Test processing with a list of files."""
         # Create these files in the tmp_path:
         test_files = _create_test_jsonl_files(tmp_path, num_files=3, subdir="path")
@@ -135,7 +135,7 @@ class TestFilePartitioningStage:
         assert result[0].data == [test_files[0]]
         assert result[0].dataset_name == "path"
 
-    def test_process_with_files_per_partition(self, empty_task: _EmptyTask, tmp_path: Path):
+    def test_process_with_files_per_partition(self, empty_task: EmptyTask, tmp_path: Path):
         """Test processing with files_per_partition setting."""
         test_files = _create_test_jsonl_files(tmp_path, num_files=4, subdir="path")
         stage = FilePartitioningStage(file_paths=test_files, files_per_partition=2)
@@ -146,7 +146,7 @@ class TestFilePartitioningStage:
         assert result[0].data == test_files[:2]
         assert result[1].data == test_files[2:]
 
-    def test_process_with_limit(self, empty_task: _EmptyTask, tmp_path: Path):
+    def test_process_with_limit(self, empty_task: EmptyTask, tmp_path: Path):
         """Test processing with limit parameter - this is the main test for the limit functionality."""
         test_files = _create_test_jsonl_files(tmp_path, num_files=10, subdir="path")
         stage = FilePartitioningStage(
@@ -168,7 +168,7 @@ class TestFilePartitioningStage:
             assert task._metadata["partition_index"] == i
             assert task._metadata["total_partitions"] == 5  # Total partitions before limit
 
-    def test_process_with_limit_single_partition(self, empty_task: _EmptyTask, tmp_path: Path):
+    def test_process_with_limit_single_partition(self, empty_task: EmptyTask, tmp_path: Path):
         """Test limit when all files would be in a single partition."""
         test_files = _create_test_jsonl_files(tmp_path, num_files=5, subdir="path")
         stage = FilePartitioningStage(
@@ -180,7 +180,7 @@ class TestFilePartitioningStage:
         assert len(result) == 1
         assert result[0].data == [test_files[0]]
 
-    def test_process_with_limit_zero(self, empty_task: _EmptyTask, tmp_path: Path):
+    def test_process_with_limit_zero(self, empty_task: EmptyTask, tmp_path: Path):
         """Test processing with limit set to 0."""
         test_files = _create_test_jsonl_files(tmp_path, num_files=5, subdir="path")
         stage = FilePartitioningStage(
@@ -193,7 +193,7 @@ class TestFilePartitioningStage:
 
         assert len(result) == 0
 
-    def test_process_with_blocksize(self, empty_task: _EmptyTask, tmp_path: Path):
+    def test_process_with_blocksize(self, empty_task: EmptyTask, tmp_path: Path):
         """Test processing with blocksize setting."""
         test_files = _create_test_jsonl_files(tmp_path, num_files=6)
         # Test files are 3 bytes each, so blocksize of 3B should create 6 partitions
@@ -223,7 +223,7 @@ class TestFilePartitioningStage:
                 blocksize="128MB",
             )
 
-    def test_process_empty_file_list(self, empty_task: _EmptyTask):
+    def test_process_empty_file_list(self, empty_task: EmptyTask):
         """Test processing with empty file list."""
         stage = FilePartitioningStage(file_paths=[])
 
@@ -256,7 +256,7 @@ class TestFilePartitioningStage:
         assert partitions[1] == ["file3", "file4"]
         assert partitions[2] == ["file5"]
 
-    def test_task_metadata(self, empty_task: _EmptyTask, tmp_path: Path):
+    def test_task_metadata(self, empty_task: EmptyTask, tmp_path: Path):
         """Test that created tasks have proper metadata."""
         test_files = _create_test_jsonl_files(tmp_path, num_files=2, subdir="path")
         storage_options = {"option1": "value1"}

--- a/tests/stages/deduplication/semantic/test_kmeans.py
+++ b/tests/stages/deduplication/semantic/test_kmeans.py
@@ -250,7 +250,7 @@ class TestKMeansStageIntegration:
         We assert the names match that deterministic pattern (never a random
         ``r<uuid>`` fallback) and that the centroid partitioning is correct.
 
-        Note: the pipeline's result tasks are terminal ``_EmptyTask`` signals
+        Note: the pipeline's result tasks are terminal ``EmptyTask`` signals
         whose ids are framework-assigned (and, for this aggregating stage, the
         non-deterministic ``r<uuid>`` fallback) — they are intentionally NOT
         tied to the output filenames, which are derived from the input ids.

--- a/tests/stages/deduplication/semantic/test_pairwise_io.py
+++ b/tests/stages/deduplication/semantic/test_pairwise_io.py
@@ -23,7 +23,7 @@ import pytest
 # Suppress GPU-related import errors when running pytest -m "not gpu"
 with suppress(ImportError):
     from nemo_curator.stages.deduplication.semantic.pairwise_io import ClusterWiseFilePartitioningStage
-    from nemo_curator.tasks import FileGroupTask, _EmptyTask
+    from nemo_curator.tasks import EmptyTask, FileGroupTask
 
 
 @pytest.mark.gpu  # TODO : Remove this once we figure out how to import semantic on CPU
@@ -80,7 +80,7 @@ class TestClusterWiseFilePartitioningStage:
         mock_path_normalizer = Mock(side_effect=lambda x: x)
         stage.path_normalizer = mock_path_normalizer
 
-        empty_task = _EmptyTask(dataset_name="test", data=None)
+        empty_task = EmptyTask(dataset_name="test", data=None)
         result = stage.process(empty_task)
 
         # Verify path_normalizer was called exactly 3 times (once per centroid directory)

--- a/tests/stages/interleaved/pdf/nemotron_parse/test_stages.py
+++ b/tests/stages/interleaved/pdf/nemotron_parse/test_stages.py
@@ -31,11 +31,11 @@ from PIL import Image
 from nemo_curator.stages.interleaved.pdf.nemotron_parse.partitioning import PDFPartitioningStage
 from nemo_curator.stages.interleaved.pdf.nemotron_parse.postprocess import NemotronParsePostprocessStage
 from nemo_curator.stages.interleaved.pdf.nemotron_parse.preprocess import PDFPreprocessStage
-from nemo_curator.tasks import _EmptyTask
+from nemo_curator.tasks import EmptyTask
 
 
-def _empty_task() -> _EmptyTask:
-    return _EmptyTask(dataset_name="test", data=None)
+def _empty_task() -> EmptyTask:
+    return EmptyTask(dataset_name="test", data=None)
 
 
 class TestPDFPartitioningStage:

--- a/tests/stages/synthetic/test_qa_multilingual_synthetic.py
+++ b/tests/stages/synthetic/test_qa_multilingual_synthetic.py
@@ -24,7 +24,7 @@ import pandas as pd
 
 from nemo_curator.models.client.llm_client import AsyncLLMClient, GenerationConfig, LLMClient
 from nemo_curator.stages.synthetic.qa_multilingual_synthetic import QAMultilingualSyntheticStage
-from nemo_curator.tasks import DocumentBatch, _EmptyTask
+from nemo_curator.tasks import DocumentBatch, EmptyTask
 
 
 class MockSyncLLMClient(LLMClient):
@@ -126,7 +126,7 @@ class TestQAMultilingualSyntheticStage:
             num_samples=1,
         )
 
-        task = _EmptyTask(dataset_name="test", data=None)
+        task = EmptyTask(dataset_name="test", data=None)
         result = stage.process(task)
 
         assert isinstance(result, DocumentBatch)
@@ -149,7 +149,7 @@ class TestQAMultilingualSyntheticStage:
             num_samples=3,
         )
 
-        task = _EmptyTask(dataset_name="test", data=None)
+        task = EmptyTask(dataset_name="test", data=None)
         with patch("nemo_curator.models.client.llm_client.logger"):  # Suppress log statements
             result = stage.process(task)
 
@@ -169,7 +169,7 @@ class TestQAMultilingualSyntheticStage:
             num_samples=1,
         )
 
-        task = _EmptyTask(dataset_name="test", data=None)
+        task = EmptyTask(dataset_name="test", data=None)
         result = stage.process(task)
 
         assert isinstance(result, DocumentBatch)
@@ -189,7 +189,7 @@ class TestQAMultilingualSyntheticStage:
             num_samples=5,
         )
 
-        task = _EmptyTask(dataset_name="test", data=None)
+        task = EmptyTask(dataset_name="test", data=None)
         result = stage.process(task)
 
         assert isinstance(result, DocumentBatch)
@@ -211,7 +211,7 @@ class TestQAMultilingualSyntheticStage:
             generation_config=config,
         )
 
-        task = _EmptyTask(dataset_name="test", data=None)
+        task = EmptyTask(dataset_name="test", data=None)
         with patch("nemo_curator.models.client.llm_client.logger"):
             result = stage.process(task)
 
@@ -240,7 +240,7 @@ class TestQAMultilingualSyntheticStage:
         )
 
         with patch("nemo_curator.models.client.llm_client.logger"), patch("secrets.choice", return_value="Japanese"):
-            task = _EmptyTask(dataset_name="test", data=None)
+            task = EmptyTask(dataset_name="test", data=None)
             stage.process(task)
 
         assert len(captured_prompts) == 2
@@ -253,7 +253,7 @@ class TestQAMultilingualSyntheticStage:
             prompt="Test {language}", languages=["English"], client=client, model_name="test-model", num_samples=1
         )
 
-        task = _EmptyTask(dataset_name="test", data=None)
+        task = EmptyTask(dataset_name="test", data=None)
         with patch("nemo_curator.models.client.llm_client.logger"):
             result = stage.process(task)
 
@@ -266,7 +266,7 @@ class TestQAMultilingualSyntheticStage:
             prompt="Test {language}", languages=["English"], client=client, model_name="test-model", num_samples=1
         )
 
-        task = _EmptyTask(dataset_name="test", data=None)
+        task = EmptyTask(dataset_name="test", data=None)
         result = stage.process(task)
 
         assert result.data["text"].iloc[0] == "Another styled response"
@@ -297,7 +297,7 @@ class TestQAMultilingualSyntheticStage:
         )
 
         with patch("nemo_curator.models.client.llm_client.logger"):
-            task = _EmptyTask(dataset_name="test", data=None)
+            task = EmptyTask(dataset_name="test", data=None)
             stage.process(task)
 
         # Should have captured 10 languages

--- a/tests/stages/text/download/base/test_url_generation.py
+++ b/tests/stages/text/download/base/test_url_generation.py
@@ -18,7 +18,7 @@ import pytest
 
 from nemo_curator.stages.resources import Resources
 from nemo_curator.stages.text.download.base.url_generation import URLGenerationStage, URLGenerator
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 
 
 class MockURLGenerator(URLGenerator):
@@ -116,7 +116,7 @@ class TestURLGenerationStage:
         stage = URLGenerationStage(url_generator=generator)
 
         # Create input task
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={"source": "test"},
@@ -147,7 +147,7 @@ class TestURLGenerationStage:
         generator = MockURLGenerator(urls=urls)
         stage = URLGenerationStage(url_generator=generator, limit=3)
 
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={},
@@ -167,7 +167,7 @@ class TestURLGenerationStage:
         generator = MockURLGenerator(urls=[])
         stage = URLGenerationStage(url_generator=generator)
 
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={},
@@ -184,7 +184,7 @@ class TestURLGenerationStage:
         generator = MockURLGenerator(urls=urls)
         stage = URLGenerationStage(url_generator=generator, limit=10)
 
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={},
@@ -200,7 +200,7 @@ class TestURLGenerationStage:
         generator = MockURLGenerator()
         stage = URLGenerationStage(url_generator=generator, limit=0)
 
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={},
@@ -219,7 +219,7 @@ class TestURLGenerationStage:
         generator = MockURLGenerator()
         stage = URLGenerationStage(url_generator=generator)
 
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={},
@@ -235,7 +235,7 @@ class TestURLGenerationStage:
         generator = MockURLGenerator(urls=urls)
         stage = URLGenerationStage(url_generator=generator)
 
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={"original": "metadata"},
@@ -254,7 +254,7 @@ class TestURLGenerationStage:
         generator = MockURLGenerator(urls=urls)
         stage = URLGenerationStage(url_generator=generator)
 
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={},
@@ -277,7 +277,7 @@ class TestURLGenerationStage:
         generator = MockURLGenerator(urls=urls)
         stage = URLGenerationStage(url_generator=generator)
 
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={},
@@ -293,7 +293,7 @@ class TestURLGenerationStage:
         generator = MockURLGenerator(urls=urls)
         stage = URLGenerationStage(url_generator=generator)
 
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={},
@@ -311,7 +311,7 @@ class TestURLGenerationStage:
         generator = MockURLGenerator()
         stage = URLGenerationStage(url_generator=generator)
 
-        input_task = _EmptyTask(
+        input_task = EmptyTask(
             dataset_name="test_dataset",
             data=None,
             _metadata={},

--- a/tests/stages/text/io/reader/test_jsonl.py
+++ b/tests/stages/text/io/reader/test_jsonl.py
@@ -21,7 +21,7 @@ from nemo_curator.stages.deduplication.id_generator import (
     CURATOR_DEDUP_ID_STR,
 )
 from nemo_curator.stages.text.io.reader.jsonl import JsonlReader, JsonlReaderStage
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 
 
 @pytest.fixture
@@ -191,5 +191,5 @@ def test_jsonl_reader_with_blocksize_limit(tmp_path: Path, caplog: pytest.LogCap
     # Since the storage size is larger than 10 million bytes, the FilePartitioningStage should warn
     file_partitioning_stage = stage.decompose()[0]
     with caplog.at_level("WARNING"):
-        file_partitioning_stage.process(_EmptyTask)
+        file_partitioning_stage.process(EmptyTask)
     assert "File group task has exceeded the storage limit per partition" in caplog.text

--- a/tests/stages/text/io/reader/test_parquet.py
+++ b/tests/stages/text/io/reader/test_parquet.py
@@ -20,7 +20,7 @@ import pyarrow as pa
 import pytest
 
 from nemo_curator.stages.text.io.reader.parquet import ParquetReader, ParquetReaderStage
-from nemo_curator.tasks import FileGroupTask, _EmptyTask
+from nemo_curator.tasks import EmptyTask, FileGroupTask
 from nemo_curator.tasks.document import DocumentBatch
 
 
@@ -290,5 +290,5 @@ def test_parquet_reader_with_blocksize_limit(tmp_path: Path, caplog: pytest.LogC
     # Since the storage size is larger than 10_000 bytes, the FilePartitioningStage should warn
     file_partitioning_stage = stage.decompose()[0]
     with caplog.at_level("WARNING"):
-        file_partitioning_stage.process(_EmptyTask)
+        file_partitioning_stage.process(EmptyTask)
     assert "File group task has exceeded the storage limit per partition" in caplog.text

--- a/tests/stages/video/io/test_video_reader.py
+++ b/tests/stages/video/io/test_video_reader.py
@@ -607,9 +607,9 @@ class TestVideoReader:
         assert stage.name == "video_reader"
 
         # Test that it's a composite stage (should raise error when trying to process)
-        from nemo_curator.tasks import _EmptyTask
+        from nemo_curator.tasks import EmptyTask
 
-        empty_task = _EmptyTask(dataset_name="test", data=None)
+        empty_task = EmptyTask(dataset_name="test", data=None)
         with pytest.raises(RuntimeError, match="Composite stage 'video_reader' should not be executed directly"):
             stage.process(empty_task)
 

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -15,14 +15,14 @@
 import numpy as np
 
 from nemo_curator.pipeline.workflow import WorkflowRunResult
-from nemo_curator.tasks import _EmptyTask
+from nemo_curator.tasks import EmptyTask
 from nemo_curator.tasks.utils import TaskPerfUtils
 from nemo_curator.utils.performance_utils import StagePerfStats
 
 
-def make_dummy_task(stage_name: str, process_time: float, custom: float = 0.0) -> _EmptyTask:
+def make_dummy_task(stage_name: str, process_time: float, custom: float = 0.0) -> EmptyTask:
     perf = StagePerfStats(stage_name=stage_name, process_time=process_time, custom_metrics={"io": custom})
-    return _EmptyTask(dataset_name="test", data=None, _stage_perf=[perf])
+    return EmptyTask(dataset_name="test", data=None, _stage_perf=[perf])
 
 
 class TestTaskPerfUtils:


### PR DESCRIPTION
## What

Restructure the payload-less task hierarchy into a new `nemo_curator/tasks/sentinels.py`:

- **`SentinelTask(Task[None])`** — base for payload-less marker tasks; `__post_init__` asserts `data is None`.
- **`EmptyTask(SentinelTask)`** — the pipeline seed; `task_id` fixed to `"0"`.

Previously `_EmptyTask` was the class and `EmptyTask` a module-level **singleton instance**. This flips it: **`EmptyTask` is now the class** and `_EmptyTask` is removed entirely. Construct `EmptyTask()` where a seed instance is needed (also gives each run a fresh seed instead of a shared mutable singleton).

## Changes
- `_EmptyTask` → `EmptyTask` across ~35 stage/test files (type annotations, `isinstance`, instantiation, imports).
- Executors and the max-calls test seed with `EmptyTask()`.
- `pipeline.assign_root_task_ids` uses `isinstance(task, EmptyTask)`.
- `tasks/__init__` re-exports `EmptyTask`/`SentinelTask` from `.sentinels`.

## Notes
- **Pure refactor — no behavior change.**
- `SentinelTask` is the shared base the upcoming **resumability** PR builds on (its `NoneTask`/`FailedTask` will subclass it). That PR will be stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
