### PR TITLE
feat(benchmarking): config-driven CI timeouts (default/cleanup/min)

### DIFF
--- a/benchmarking/nightly-benchmark.yaml
+++ b/benchmarking/nightly-benchmark.yaml
@@ -125,7 +125,13 @@ datasets:
     formats:
     - type: "files"
       path: "{datasets_path}/fleurs/hy_am"
+# Timeout knobs consumed by tools/generate_ci_tests.py to compute each SLURM job's wall-clock:
+#   max(entry.timeout_s (or default_timeout_s) + cleanup_timeout_s, min_timeout_s)
+# default_timeout_s: per-entry default; cleanup_timeout_s: post-run cleanup buffer; min_timeout_s:
+# floor covering container setup. (default_timeout_s is also the runner's per-entry default.)
 default_timeout_s: 7200
+cleanup_timeout_s: 60
+min_timeout_s: 600
 
 # Optional sinks
 sinks:

--- a/benchmarking/tools/generate_ci_tests.py
+++ b/benchmarking/tools/generate_ci_tests.py
@@ -22,7 +22,11 @@ yaml = YAML()
 yaml.default_flow_style = False
 yaml.preserve_quotes = True
 
-MIN_TIME_S = 600
+# Fallbacks used only when nightly-benchmark.yaml omits the corresponding key; the YAML config
+# is the source of truth for these timeout knobs.
+DEFAULT_TIMEOUT_S = 7200  # mirrors Session.default_timeout_s in runner/session.py
+DEFAULT_CLEANUP_TIMEOUT_S = 60
+DEFAULT_MIN_TIMEOUT_S = 600
 
 
 def seconds_to_time(seconds: int) -> str:
@@ -41,20 +45,26 @@ def seconds_to_time(seconds: int) -> str:
 
 
 
-def generate_job(entry: dict, scope: str) -> dict:
+def generate_job(
+    entry: dict, scope: str, default_timeout_s: int, cleanup_timeout_s: int, min_timeout_s: int
+) -> dict:
     """
     Generate a GitLab CI job for a single benchmark entry.
 
     Args:
         entry: Dictionary from nightly-benchmark.yaml entries list
         scope: CI scope (e.g. "nightly")
+        default_timeout_s: Timeout used for entries that omit "timeout_s"
+        cleanup_timeout_s: Buffer added on top of every entry's timeout for post-run cleanup
+        min_timeout_s: Floor on the generated job time to cover container setup overhead
 
     Returns:
         job: Dictionary defining the GitLab CI job
     """
     ray = entry.get("ray", {})
-    # Enforce a minimum of 10 minutes to allow for setup overhead
-    timeout_s = max(entry.get("timeout_s", MIN_TIME_S), MIN_TIME_S)
+    # SLURM wall-clock = entry's effective timeout + a fixed cleanup buffer, floored at
+    # min_timeout_s so short entries get enough time for container setup before their run starts.
+    timeout_s = max(entry.get("timeout_s", default_timeout_s) + cleanup_timeout_s, min_timeout_s)
     time_str = seconds_to_time(timeout_s)
 
     return {
@@ -87,6 +97,10 @@ def generate_pipeline(curator_dir: str, scope: str) -> dict:
     if scope == "NONE":
         scope = "nightly"
 
+    default_timeout_s = config.get("default_timeout_s", DEFAULT_TIMEOUT_S)
+    cleanup_timeout_s = config.get("cleanup_timeout_s", DEFAULT_CLEANUP_TIMEOUT_S)
+    min_timeout_s = config.get("min_timeout_s", DEFAULT_MIN_TIMEOUT_S)
+
     pipeline = {
         "include": ["curator/curator_ci_template.yml"],
     }
@@ -97,7 +111,7 @@ def generate_pipeline(curator_dir: str, scope: str) -> dict:
         if not entry.get("enabled", True):
             continue
 
-        pipeline[entry["name"]] = generate_job(entry, scope)
+        pipeline[entry["name"]] = generate_job(entry, scope, default_timeout_s, cleanup_timeout_s, min_timeout_s)
         job_count += 1
 
     if job_count == 0:


### PR DESCRIPTION
## Description

- Move the benchmark CI job timeout knobs into nightly-benchmark.yaml as the single source of truth: default_timeout_s (now also consumed by generate_ci_tests.py, matching the runner), plus new cleanup_timeout_s (60s) and min_timeout_s (600s). Generated job time is now max(entry.timeout_s or default_timeout_s + cleanup_timeout_s, min_timeout_s), replacing the hardcoded MIN_TIME_S constant.

- This fixes two issues with the old max(timeout_s, 600) logic: entries omitting timeout_s now default consistently with the runner (7200s instead of 600s), and every job gets a cleanup buffer so long-running benchmarks (e.g. 4h) no longer get a wall-clock equal to their own timeout with no room to terminate and clean up. The 600s floor is retained for short entries to cover container setup.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
