### PR TITLE
docs: add Related Topics section to Quality Assessment & Filtering

### DIFF
--- a/fern/versions/main/pages/curate-text/process-data/quality-assessment/index.mdx
+++ b/fern/versions/main/pages/curate-text/process-data/quality-assessment/index.mdx
@@ -196,3 +196,10 @@ When filtering large datasets, consider these performance tips:
 3. **Use vectorization**: Implement batched methods for compute-intensive filters
 4. **Disk I/O**: Consider compression and chunking strategies for large datasets
 5. **Distributed processing**: For TB-scale datasets, use distributed filtering with the XennaExecutor
+
+## Related Topics
+
+- [Get Started with Text Curation](/get-started/text)
+- [Process Data for Text Curation](/curate-text/process-data)
+- [Deduplication](/curate-text/process-data/deduplication)
+- [Language Management](/curate-text/process-data/language-management)


### PR DESCRIPTION
## What

Adds the template-required **Related Topics** section to the *Quality Assessment & Filtering* conceptual page (`fern/versions/main/pages/curate-text/process-data/quality-assessment/index.mdx`).

## Why

This page is the cited example for the **Conceptual Topics** template in NVIDIA's tech-docs template-library. During a link/conformance audit of that library, it was the one Conceptual example missing the template-required `## Related Topics` section.

## Change

Appends a `## Related Topics` section (additive — no other content touched) linking to four related text-curation pages, each verified to resolve (HTTP 200) on the live docs site:

- Get Started with Text Curation — `/get-started/text`
- Process Data for Text Curation — `/curate-text/process-data`
- Deduplication — `/curate-text/process-data/deduplication`
- Language Management — `/curate-text/process-data/language-management`

Per the template convention, pages already linked earlier on the page (the Filtering Approaches cards and the data-processing concept link) are intentionally not relisted.

Opened as **draft** for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)