### PR TITLE
Update Ray Data Backend to use `compute` strategy + Allow min/max/initial workers to be specified

### DIFF
--- a/nemo_curator/backends/ray_actor_pool/utils.py
+++ b/nemo_curator/backends/ray_actor_pool/utils.py
@@ -54,12 +54,21 @@ def calculate_optimal_actors_for_stage(
     # Take the minimum constraint
     max_actors_resources = min(max_actors_cpu, max_actors_gpu)
 
-    # Ensure we don't create more actors than configured maximum
-    max_actors_resources = min(max_actors_resources, stage.num_workers() or _LARGE_INT)
-
     if max_actors_resources == 0:
         msg = f"No resources available for stage {stage.name}."
         raise ValueError(msg)
+
+    num_workers = stage.num_workers()
+    if num_workers is not None and num_workers > 0:
+        if num_workers > max_actors_resources:
+            msg = (
+                f"Stage {stage.name} requires {num_workers} actors from num_workers(), "
+                f"but only {max_actors_resources} fit with available resources. "
+                f"Capping actor count to {max_actors_resources}."
+            )
+            logger.warning(msg)
+            return max_actors_resources
+        return num_workers
 
     number_of_batches = (
         math.ceil(num_tasks / stage.batch_size) if stage.batch_size is not None and stage.batch_size > 0 else num_tasks

--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -25,6 +25,8 @@ from nemo_curator.stages.base import ProcessingStage
 
 from .utils import get_actor_compute_strategy_for_stage, get_configured_actor_pool_sizing_keys, is_actor_stage
 
+CURATOR_MANAGED_MAP_BATCHES_KWARGS = {"compute", "max_calls", "num_cpus", "num_gpus"}
+
 
 class RayDataStageAdapter(BaseStageAdapter):
     """Adapts ProcessingStage to Ray Data operations.
@@ -71,11 +73,12 @@ class RayDataStageAdapter(BaseStageAdapter):
         # For Task objects, we return them in the 'item' column
         return {"item": results}
 
-    def process_dataset(self, dataset: Dataset) -> Dataset:
+    def process_dataset(self, dataset: Dataset, ignore_head_node: bool = False) -> Dataset:
         """Process a Ray Data dataset through this stage.
 
         Args:
             dataset (Dataset): Ray Data dataset containing Task objects
+            ignore_head_node (bool): Whether to exclude head-node resources from the actor-pool max size.
 
         Returns:
             Dataset: Processed Ray Data dataset
@@ -85,7 +88,9 @@ class RayDataStageAdapter(BaseStageAdapter):
 
         if stage_is_actor:
             map_batches_fn = create_actor_from_stage(self.stage)
-            map_batches_kwargs = {"compute": get_actor_compute_strategy_for_stage(self.stage)}
+            map_batches_kwargs = {
+                "compute": get_actor_compute_strategy_for_stage(self.stage, ignore_head_node=ignore_head_node)
+            }
         else:
             map_batches_fn = create_task_from_stage(self.stage)
             map_batches_kwargs = {}
@@ -119,6 +124,14 @@ class RayDataStageAdapter(BaseStageAdapter):
         # caches an isolated virtualenv for this stage's workers.
         if self.stage.runtime_env:
             ray_remote_args["runtime_env"] = self.stage.runtime_env
+
+        colliding_ray_remote_args = sorted(CURATOR_MANAGED_MAP_BATCHES_KWARGS & ray_remote_args.keys())
+        if colliding_ray_remote_args:
+            msg = (
+                f"ray_remote_args for Ray Data stage {self.stage.name} must not override "
+                f"Curator-managed map_batches arguments {colliding_ray_remote_args}."
+            )
+            raise ValueError(msg)
 
         map_batches_kwargs.update(ray_remote_args)
 

--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -23,7 +23,7 @@ from nemo_curator.backends.base import BaseStageAdapter
 from nemo_curator.backends.utils import RayStageSpecKeys, get_worker_metadata_and_node_id
 from nemo_curator.stages.base import ProcessingStage
 
-from .utils import calculate_concurrency_for_actors_for_stage, is_actor_stage
+from .utils import get_actor_compute_strategy_for_stage, get_configured_actor_pool_sizing_keys, is_actor_stage
 
 
 class RayDataStageAdapter(BaseStageAdapter):
@@ -71,7 +71,7 @@ class RayDataStageAdapter(BaseStageAdapter):
         # For Task objects, we return them in the 'item' column
         return {"item": results}
 
-    def process_dataset(self, dataset: Dataset, ignore_head_node: bool = False) -> Dataset:
+    def process_dataset(self, dataset: Dataset) -> Dataset:
         """Process a Ray Data dataset through this stage.
 
         Args:
@@ -80,43 +80,54 @@ class RayDataStageAdapter(BaseStageAdapter):
         Returns:
             Dataset: Processed Ray Data dataset
         """
+        ray_stage_spec = self.stage.ray_stage_spec()
+        stage_is_actor = ray_stage_spec.get(RayStageSpecKeys.IS_ACTOR_STAGE, is_actor_stage(self.stage))
 
-        is_actor_stage_ = self.stage.ray_stage_spec().get(RayStageSpecKeys.IS_ACTOR_STAGE, is_actor_stage(self.stage))
-
-        if is_actor_stage_:
+        if stage_is_actor:
             map_batches_fn = create_actor_from_stage(self.stage)
-            concurrency_kwargs = {
-                "concurrency": calculate_concurrency_for_actors_for_stage(
-                    self.stage, ignore_head_node=ignore_head_node
-                ),
-            }
+            map_batches_kwargs = {"compute": get_actor_compute_strategy_for_stage(self.stage)}
         else:
             map_batches_fn = create_task_from_stage(self.stage)
-            concurrency_kwargs = {"concurrency": None}
-            max_calls = self.stage.ray_stage_spec().get(RayStageSpecKeys.MAX_CALLS_PER_WORKER, None)
+            map_batches_kwargs = {}
+
+            actor_pool_sizing_keys = get_configured_actor_pool_sizing_keys(ray_stage_spec)
+            if actor_pool_sizing_keys:
+                logger.warning(
+                    f"Ignoring ray_stage_spec worker sizing keys {actor_pool_sizing_keys} "
+                    f"for Ray Data task stage {self.stage.name}; these keys only apply to actor stages."
+                )
+
+            num_workers = self.stage.num_workers()
+            if num_workers is not None and num_workers > 0:
+                logger.warning(
+                    f"Ignoring num_workers={num_workers} for Ray Data task stage {self.stage.name}; "
+                    "num_workers requires an actor stage to represent a fixed worker pool."
+                )
+
+            max_calls = ray_stage_spec.get(RayStageSpecKeys.MAX_CALLS_PER_WORKER)
             if max_calls is not None:
-                concurrency_kwargs["max_calls"] = max_calls
+                map_batches_kwargs["max_calls"] = max_calls
 
         if self.stage.resources.cpus > 0:
-            concurrency_kwargs["num_cpus"] = self.stage.resources.cpus  # type: ignore[reportArgumentType]
+            map_batches_kwargs["num_cpus"] = self.stage.resources.cpus  # type: ignore[reportArgumentType]
         if self.stage.resources.gpus > 0:
-            concurrency_kwargs["num_gpus"] = self.stage.resources.gpus  # type: ignore[reportArgumentType]
+            map_batches_kwargs["num_gpus"] = self.stage.resources.gpus  # type: ignore[reportArgumentType]
 
         # Per-stage ray_remote_args (e.g. runtime_env with different pip versions per stage).
-        ray_remote_args = copy.deepcopy(self.stage.ray_stage_spec().get(RayStageSpecKeys.RAY_REMOTE_ARGS) or {})
+        ray_remote_args = copy.deepcopy(ray_stage_spec.get(RayStageSpecKeys.RAY_REMOTE_ARGS) or {})
         # If the stage declares runtime_env, forward it directly to Ray so Ray creates and
         # caches an isolated virtualenv for this stage's workers.
         if self.stage.runtime_env:
             ray_remote_args["runtime_env"] = self.stage.runtime_env
 
-        concurrency_kwargs.update(ray_remote_args)
+        map_batches_kwargs.update(ray_remote_args)
 
-        # Calculate concurrency based on available resources
-        logger.info(f"{self.stage.__class__.__name__} {is_actor_stage_=} with {concurrency_kwargs=}")
+        # Let Ray Data apply the selected compute strategy and resource requirements.
+        logger.info(f"{self.stage.__class__.__name__} stage_is_actor={stage_is_actor} with {map_batches_kwargs=}")
 
-        processed_dataset = dataset.map_batches(map_batches_fn, batch_size=self.batch_size, **concurrency_kwargs)  # type: ignore[reportArgumentType]
+        processed_dataset = dataset.map_batches(map_batches_fn, batch_size=self.batch_size, **map_batches_kwargs)  # type: ignore[reportArgumentType]
 
-        if self.stage.ray_stage_spec().get(RayStageSpecKeys.IS_FANOUT_STAGE, False):
+        if ray_stage_spec.get(RayStageSpecKeys.IS_FANOUT_STAGE, False):
             processed_dataset = processed_dataset.repartition(target_num_rows_per_block=1)
 
         return processed_dataset

--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -73,12 +73,11 @@ class RayDataStageAdapter(BaseStageAdapter):
         # For Task objects, we return them in the 'item' column
         return {"item": results}
 
-    def process_dataset(self, dataset: Dataset, ignore_head_node: bool = False) -> Dataset:
+    def process_dataset(self, dataset: Dataset) -> Dataset:
         """Process a Ray Data dataset through this stage.
 
         Args:
             dataset (Dataset): Ray Data dataset containing Task objects
-            ignore_head_node (bool): Whether to exclude head-node resources from the actor-pool max size.
 
         Returns:
             Dataset: Processed Ray Data dataset
@@ -88,9 +87,7 @@ class RayDataStageAdapter(BaseStageAdapter):
 
         if stage_is_actor:
             map_batches_fn = create_actor_from_stage(self.stage)
-            map_batches_kwargs = {
-                "compute": get_actor_compute_strategy_for_stage(self.stage, ignore_head_node=ignore_head_node)
-            }
+            map_batches_kwargs = {"compute": get_actor_compute_strategy_for_stage(self.stage)}
         else:
             map_batches_fn = create_task_from_stage(self.stage)
             map_batches_kwargs = {}

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -87,7 +87,7 @@ class RayDataExecutor(BaseExecutor):
                 adapter = RayDataStageAdapter(stage)
 
                 # Apply stage transformation
-                current_dataset = adapter.process_dataset(current_dataset, ignore_head_node=self.ignore_head_node)
+                current_dataset = adapter.process_dataset(current_dataset)
         except Exception as e:
             logger.error(f"Error during pipeline execution: {e}")
             raise

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -87,7 +87,7 @@ class RayDataExecutor(BaseExecutor):
                 adapter = RayDataStageAdapter(stage)
 
                 # Apply stage transformation
-                current_dataset = adapter.process_dataset(current_dataset, self.ignore_head_node)
+                current_dataset = adapter.process_dataset(current_dataset)
         except Exception as e:
             logger.error(f"Error during pipeline execution: {e}")
             raise

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -87,7 +87,7 @@ class RayDataExecutor(BaseExecutor):
                 adapter = RayDataStageAdapter(stage)
 
                 # Apply stage transformation
-                current_dataset = adapter.process_dataset(current_dataset)
+                current_dataset = adapter.process_dataset(current_dataset, ignore_head_node=self.ignore_head_node)
         except Exception as e:
             logger.error(f"Error during pipeline execution: {e}")
             raise

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -32,13 +32,22 @@ class RayDataExecutor(BaseExecutor):
     """Ray Data-based executor for pipeline execution.
 
     This executor:
-    1. Executes setup on all nodes for all stages
+    1. Executes setup on Ray nodes for all stages
     2. Converts initial tasks to Ray Data dataset
     3. Applies each stage as a Ray Data transformation (as a task or actor in map_batches)
     4. Returns final results as a list of tasks
     """
 
     def __init__(self, config: dict[str, Any] | None = None, ignore_head_node: bool = False):
+        """Initialize the executor.
+
+        Args:
+            config (dict[str, Any], optional): Configuration dictionary.
+            ignore_head_node (bool, optional): Whether to skip the Ray head node for
+                ``setup_on_node``. Ray Data controls ``map_batches`` task/actor placement
+                through Ray's scheduler; this flag does not cap actor-pool size or force
+                Ray Data workers away from the head node.
+        """
         super().__init__(config, ignore_head_node)
 
     def execute(self, stages: list["ProcessingStage"], initial_tasks: list[Task] | None = None) -> list[Task]:

--- a/nemo_curator/backends/ray_data/utils.py
+++ b/nemo_curator/backends/ray_data/utils.py
@@ -17,7 +17,7 @@ from collections.abc import Mapping
 from loguru import logger
 from ray.data import ActorPoolStrategy
 
-from nemo_curator.backends.utils import RayStageSpecKeys
+from nemo_curator.backends.utils import RayStageSpecKeys, get_available_cpu_gpu_resources
 from nemo_curator.stages.base import ProcessingStage
 
 ACTOR_POOL_SIZING_KEYS = (
@@ -33,7 +33,9 @@ def get_configured_actor_pool_sizing_keys(ray_stage_spec: Mapping[str, object]) 
     return [key.value for key in ACTOR_POOL_SIZING_KEYS if key.value in stage_spec_keys]
 
 
-def get_actor_compute_strategy_for_stage(stage: ProcessingStage) -> ActorPoolStrategy:
+def get_actor_compute_strategy_for_stage(
+    stage: ProcessingStage, *, ignore_head_node: bool = False
+) -> ActorPoolStrategy:
     """Get the Ray Data actor-pool compute strategy for a processing stage.
 
     Explicit stage ``num_workers`` requests a fixed-size actor pool. Otherwise,
@@ -51,11 +53,38 @@ def get_actor_compute_strategy_for_stage(stage: ProcessingStage) -> ActorPoolStr
         return ActorPoolStrategy(size=num_workers)
 
     ray_stage_spec = stage.ray_stage_spec()
-    return ActorPoolStrategy(
-        min_size=ray_stage_spec.get(RayStageSpecKeys.MIN_WORKERS, 1),
-        max_size=ray_stage_spec.get(RayStageSpecKeys.MAX_WORKERS),
-        initial_size=ray_stage_spec.get(RayStageSpecKeys.INITIAL_WORKERS),
+    min_size = ray_stage_spec.get(RayStageSpecKeys.MIN_WORKERS, 1)
+    max_size = ray_stage_spec.get(RayStageSpecKeys.MAX_WORKERS)
+    initial_size = ray_stage_spec.get(RayStageSpecKeys.INITIAL_WORKERS)
+
+    if ignore_head_node and max_size is None:
+        max_size = calculate_actor_pool_max_size_for_stage(stage, ignore_head_node=True)
+
+    try:
+        return ActorPoolStrategy(min_size=min_size, max_size=max_size, initial_size=initial_size)
+    except ValueError as e:
+        msg = f"Invalid Ray Data actor pool sizing for stage {stage.name}: {e}"
+        raise ValueError(msg) from e
+
+
+def calculate_actor_pool_max_size_for_stage(stage: ProcessingStage, *, ignore_head_node: bool = False) -> int | None:
+    """Calculate a resource-limited actor-pool max size for legacy resource caps."""
+    available_cpus, available_gpus = get_available_cpu_gpu_resources(
+        init_and_shutdown=False, ignore_head_node=ignore_head_node
     )
+
+    max_cpu_actors = float("inf")
+    if stage.resources.cpus > 0:
+        max_cpu_actors = available_cpus // stage.resources.cpus
+
+    max_gpu_actors = float("inf")
+    if stage.resources.gpus > 0:
+        max_gpu_actors = available_gpus // stage.resources.gpus
+
+    max_actors = min(max_cpu_actors, max_gpu_actors)
+    if max_actors == float("inf"):
+        return None
+    return int(max_actors)
 
 
 def is_actor_stage(stage: ProcessingStage) -> bool:

--- a/nemo_curator/backends/ray_data/utils.py
+++ b/nemo_curator/backends/ray_data/utils.py
@@ -12,45 +12,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo_curator.backends.utils import get_available_cpu_gpu_resources
+from collections.abc import Mapping
+
+from loguru import logger
+from ray.data import ActorPoolStrategy
+
+from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
 
+ACTOR_POOL_SIZING_KEYS = (
+    RayStageSpecKeys.MIN_WORKERS,
+    RayStageSpecKeys.MAX_WORKERS,
+    RayStageSpecKeys.INITIAL_WORKERS,
+)
 
-def calculate_concurrency_for_actors_for_stage(
-    stage: ProcessingStage, ignore_head_node: bool = False
-) -> tuple[int, int] | int:
-    """
-    Calculate concurrency if we want to spin up actors based on available resources and stage requirements.
 
-    Returns:
-        int | tuple[int, int]: Number of actors to use
-            int: Number of workers to use
-            tuple[int, int]: tuple of min / max actors to use and number of workers to use
+def get_configured_actor_pool_sizing_keys(ray_stage_spec: Mapping[str, object]) -> list[str]:
+    """Return actor-pool sizing keys configured in a ray stage spec."""
+    stage_spec_keys = {key.value if isinstance(key, RayStageSpecKeys) else key for key in ray_stage_spec}
+    return [key.value for key in ACTOR_POOL_SIZING_KEYS if key.value in stage_spec_keys]
+
+
+def get_actor_compute_strategy_for_stage(stage: ProcessingStage) -> ActorPoolStrategy:
+    """Get the Ray Data actor-pool compute strategy for a processing stage.
+
+    Explicit stage ``num_workers`` requests a fixed-size actor pool. Otherwise,
+    actor stages use Ray Data's autoscaling pool and can optionally override
+    min/max/initial workers through ``ray_stage_spec``.
     """
-    # If explicitly set, use the specified number of workers
     num_workers = stage.num_workers()
     if num_workers is not None and num_workers > 0:
-        return max(1, num_workers)
+        actor_pool_sizing_keys = get_configured_actor_pool_sizing_keys(stage.ray_stage_spec())
+        if actor_pool_sizing_keys:
+            logger.warning(
+                f"Stage {stage.name} uses num_workers={num_workers}; ignoring ray_stage_spec "
+                f"actor-pool sizing keys {actor_pool_sizing_keys}."
+            )
+        return ActorPoolStrategy(size=num_workers)
 
-    # Get available resources from Ray
-    available_cpus, available_gpus = get_available_cpu_gpu_resources(
-        init_and_shutdown=False, ignore_head_node=ignore_head_node
+    ray_stage_spec = stage.ray_stage_spec()
+    return ActorPoolStrategy(
+        min_size=ray_stage_spec.get(RayStageSpecKeys.MIN_WORKERS, 1),
+        max_size=ray_stage_spec.get(RayStageSpecKeys.MAX_WORKERS),
+        initial_size=ray_stage_spec.get(RayStageSpecKeys.INITIAL_WORKERS),
     )
-    # Calculate based on CPU and GPU requirements
-    max_cpu_actors = float("inf")
-    max_gpu_actors = float("inf")
-
-    # CPU constraint
-    if stage.resources.cpus > 0:
-        max_cpu_actors = available_cpus // stage.resources.cpus
-
-    # GPU constraint
-    if stage.resources.gpus > 0:
-        max_gpu_actors = available_gpus // stage.resources.gpus
-
-    # Take the minimum of CPU and GPU constraints
-    max_actors = min(max_cpu_actors, max_gpu_actors)
-    return (1, int(max_actors))
 
 
 def is_actor_stage(stage: ProcessingStage) -> bool:

--- a/nemo_curator/backends/ray_data/utils.py
+++ b/nemo_curator/backends/ray_data/utils.py
@@ -17,7 +17,7 @@ from collections.abc import Mapping
 from loguru import logger
 from ray.data import ActorPoolStrategy
 
-from nemo_curator.backends.utils import RayStageSpecKeys, get_available_cpu_gpu_resources
+from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
 
 ACTOR_POOL_SIZING_KEYS = (
@@ -33,9 +33,7 @@ def get_configured_actor_pool_sizing_keys(ray_stage_spec: Mapping[str, object]) 
     return [key.value for key in ACTOR_POOL_SIZING_KEYS if key.value in stage_spec_keys]
 
 
-def get_actor_compute_strategy_for_stage(
-    stage: ProcessingStage, *, ignore_head_node: bool = False
-) -> ActorPoolStrategy:
+def get_actor_compute_strategy_for_stage(stage: ProcessingStage) -> ActorPoolStrategy:
     """Get the Ray Data actor-pool compute strategy for a processing stage.
 
     Explicit stage ``num_workers`` requests a fixed-size actor pool. Otherwise,
@@ -57,34 +55,11 @@ def get_actor_compute_strategy_for_stage(
     max_size = ray_stage_spec.get(RayStageSpecKeys.MAX_WORKERS)
     initial_size = ray_stage_spec.get(RayStageSpecKeys.INITIAL_WORKERS)
 
-    if ignore_head_node and max_size is None:
-        max_size = calculate_actor_pool_max_size_for_stage(stage, ignore_head_node=True)
-
     try:
         return ActorPoolStrategy(min_size=min_size, max_size=max_size, initial_size=initial_size)
     except ValueError as e:
         msg = f"Invalid Ray Data actor pool sizing for stage {stage.name}: {e}"
         raise ValueError(msg) from e
-
-
-def calculate_actor_pool_max_size_for_stage(stage: ProcessingStage, *, ignore_head_node: bool = False) -> int | None:
-    """Calculate a resource-limited actor-pool max size for legacy resource caps."""
-    available_cpus, available_gpus = get_available_cpu_gpu_resources(
-        init_and_shutdown=False, ignore_head_node=ignore_head_node
-    )
-
-    max_cpu_actors = float("inf")
-    if stage.resources.cpus > 0:
-        max_cpu_actors = available_cpus // stage.resources.cpus
-
-    max_gpu_actors = float("inf")
-    if stage.resources.gpus > 0:
-        max_gpu_actors = available_gpus // stage.resources.gpus
-
-    max_actors = min(max_cpu_actors, max_gpu_actors)
-    if max_actors == float("inf"):
-        return None
-    return int(max_actors)
 
 
 def is_actor_stage(stage: ProcessingStage) -> bool:

--- a/nemo_curator/backends/utils.py
+++ b/nemo_curator/backends/utils.py
@@ -130,6 +130,9 @@ class RayStageSpecKeys(str, Enum):
     IS_LSH_STAGE = "is_lsh_stage"
     IS_SHUFFLE_STAGE = "is_shuffle_stage"
     MAX_CALLS_PER_WORKER = "max_calls_per_worker"
+    MIN_WORKERS = "min_workers"
+    MAX_WORKERS = "max_workers"
+    INITIAL_WORKERS = "initial_workers"
     RAY_REMOTE_ARGS = "ray_remote_args"
 
 

--- a/tests/backends/ray_actor_pool/test_executor.py
+++ b/tests/backends/ray_actor_pool/test_executor.py
@@ -14,7 +14,11 @@
 
 from unittest import mock
 
+import pytest
+
 from nemo_curator.backends.ray_actor_pool.executor import _parse_runtime_env
+from nemo_curator.backends.ray_actor_pool.utils import calculate_optimal_actors_for_stage
+from nemo_curator.stages.resources import Resources
 
 
 class TestRayActorPoolExecutor:
@@ -31,3 +35,39 @@ class TestRayActorPoolExecutor:
             "env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": ""},
             "some_other_key": "some_other_value",
         }
+
+    @pytest.mark.parametrize(
+        ("available_cpus", "expected_actors", "expected_warning"),
+        [
+            (8.0, 4, None),
+            (2.0, 2, "requires 4 actors from num_workers(), but only 2 fit"),
+        ],
+    )
+    def test_calculate_optimal_actors_respects_explicit_num_workers(
+        self, available_cpus: float, expected_actors: int, expected_warning: str | None
+    ) -> None:
+        stage = _stage_with_num_workers(num_workers=4, cpus=1.0, batch_size=10)
+
+        with (
+            mock.patch(
+                "nemo_curator.backends.ray_actor_pool.utils.get_available_cpu_gpu_resources",
+                return_value=(available_cpus, 0.0),
+            ),
+            mock.patch("nemo_curator.backends.ray_actor_pool.utils.logger.warning") as mock_warning,
+        ):
+            assert calculate_optimal_actors_for_stage(stage, num_tasks=1) == expected_actors
+
+        if expected_warning is None:
+            mock_warning.assert_not_called()
+        else:
+            mock_warning.assert_called_once()
+            assert expected_warning in mock_warning.call_args.args[0]
+
+
+def _stage_with_num_workers(*, num_workers: int, cpus: float, batch_size: int) -> mock.Mock:
+    stage = mock.Mock()
+    stage.name = "stage"
+    stage.resources = Resources(cpus=cpus, gpus=0.0)
+    stage.batch_size = batch_size
+    stage.num_workers.return_value = num_workers
+    return stage

--- a/tests/backends/ray_data/test_adapter.py
+++ b/tests/backends/ray_data/test_adapter.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+from ray.data import ActorPoolStrategy
+
+from nemo_curator.backends.ray_data.adapter import RayDataStageAdapter
+from nemo_curator.backends.utils import RayStageSpecKeys
+from nemo_curator.stages.base import ProcessingStage, Resources
+from nemo_curator.tasks import EmptyTask
+
+
+class RecordingDataset:
+    """Minimal stand-in for Ray Data Dataset that records map_batches kwargs."""
+
+    def __init__(self):
+        self.map_batches_kwargs: dict[str, object] | None = None
+        self.batch_size: int | None = None
+
+    def map_batches(self, _fn: object, *, batch_size: int | None = None, **kwargs: object):
+        self.batch_size = batch_size
+        self.map_batches_kwargs = kwargs
+        return self
+
+
+class ConfigurableActorStage(ProcessingStage[EmptyTask, EmptyTask]):
+    name = "configurable_actor"
+    resources = Resources(cpus=2.0)
+    batch_size = 7
+
+    def __init__(self, ray_stage_spec: dict[str, object] | None = None, num_workers: int | None = None):
+        self._ray_stage_spec = ray_stage_spec or {}
+        self._num_workers = num_workers
+
+    def ray_stage_spec(self) -> dict[str, object]:
+        return {
+            RayStageSpecKeys.IS_ACTOR_STAGE: True,
+            **self._ray_stage_spec,
+        }
+
+    def num_workers(self) -> int | None:
+        return self._num_workers
+
+    def process(self, task: EmptyTask) -> EmptyTask:
+        return task
+
+
+class ConfigurableTaskStage(ConfigurableActorStage):
+    name = "configurable_task"
+    resources = Resources(cpus=2.0)
+    batch_size = 7
+
+    def ray_stage_spec(self) -> dict[str, object]:
+        return self._ray_stage_spec
+
+
+class TestRayDataStageAdapter:
+    def test_process_dataset_uses_compute_for_actor_stages_and_ray_default_for_task_stages(self):
+        fixed_actor_kwargs = _map_batches_kwargs(ConfigurableActorStage(num_workers=3))
+        autoscaling_actor_kwargs = _map_batches_kwargs(
+            ConfigurableActorStage(
+                ray_stage_spec={
+                    RayStageSpecKeys.MIN_WORKERS: 2,
+                    RayStageSpecKeys.MAX_WORKERS: 8,
+                    RayStageSpecKeys.INITIAL_WORKERS: 4,
+                }
+            )
+        )
+        task_kwargs = _map_batches_kwargs(ConfigurableTaskStage())
+
+        assert fixed_actor_kwargs["compute"] == ActorPoolStrategy(size=3)
+        assert autoscaling_actor_kwargs["compute"] == ActorPoolStrategy(min_size=2, max_size=8, initial_size=4)
+        assert "compute" not in task_kwargs
+        for kwargs in (fixed_actor_kwargs, autoscaling_actor_kwargs, task_kwargs):
+            assert "concurrency" not in kwargs
+
+    def test_task_stage_warns_when_worker_sizing_is_ignored(self):
+        stage = ConfigurableTaskStage(
+            ray_stage_spec={
+                RayStageSpecKeys.MIN_WORKERS: 2,
+                RayStageSpecKeys.MAX_WORKERS: 8,
+                RayStageSpecKeys.INITIAL_WORKERS: 4,
+            },
+            num_workers=3,
+        )
+
+        with mock.patch("nemo_curator.backends.ray_data.adapter.logger.warning") as mock_warning:
+            task_kwargs = _map_batches_kwargs(stage)
+
+        assert "compute" not in task_kwargs
+        assert mock_warning.call_count == 2
+        warning_messages = [call.args[0] for call in mock_warning.call_args_list]
+        assert "Ignoring ray_stage_spec worker sizing keys" in warning_messages[0]
+        assert "Ignoring num_workers=3" in warning_messages[1]
+
+
+def _map_batches_kwargs(stage: ProcessingStage) -> dict[str, object]:
+    dataset = RecordingDataset()
+    RayDataStageAdapter(stage).process_dataset(dataset)  # type: ignore[arg-type]
+    assert dataset.map_batches_kwargs is not None
+    assert dataset.batch_size == stage.batch_size
+    return dataset.map_batches_kwargs

--- a/tests/backends/ray_data/test_adapter.py
+++ b/tests/backends/ray_data/test_adapter.py
@@ -14,6 +14,7 @@
 
 from unittest import mock
 
+import pytest
 from ray.data import ActorPoolStrategy
 
 from nemo_curator.backends.ray_data.adapter import RayDataStageAdapter
@@ -105,10 +106,29 @@ class TestRayDataStageAdapter:
         assert "Ignoring ray_stage_spec worker sizing keys" in warning_messages[0]
         assert "Ignoring num_workers=3" in warning_messages[1]
 
+    def test_process_dataset_applies_head_node_actor_pool_cap(self):
+        with mock.patch(
+            "nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources",
+            return_value=(6.0, 0.0),
+        ):
+            actor_kwargs = _map_batches_kwargs(ConfigurableActorStage(), ignore_head_node=True)
 
-def _map_batches_kwargs(stage: ProcessingStage) -> dict[str, object]:
+        assert actor_kwargs["compute"] == ActorPoolStrategy(min_size=1, max_size=3)
+
+    def test_process_dataset_rejects_managed_ray_remote_args(self):
+        stage = ConfigurableActorStage(
+            ray_stage_spec={
+                RayStageSpecKeys.RAY_REMOTE_ARGS: {"compute": ActorPoolStrategy(size=2)},
+            }
+        )
+
+        with pytest.raises(ValueError, match="must not override Curator-managed map_batches arguments"):
+            _map_batches_kwargs(stage)
+
+
+def _map_batches_kwargs(stage: ProcessingStage, *, ignore_head_node: bool = False) -> dict[str, object]:
     dataset = RecordingDataset()
-    RayDataStageAdapter(stage).process_dataset(dataset)  # type: ignore[arg-type]
+    RayDataStageAdapter(stage).process_dataset(dataset, ignore_head_node=ignore_head_node)  # type: ignore[arg-type]
     assert dataset.map_batches_kwargs is not None
     assert dataset.batch_size == stage.batch_size
     return dataset.map_batches_kwargs

--- a/tests/backends/ray_data/test_adapter.py
+++ b/tests/backends/ray_data/test_adapter.py
@@ -106,15 +106,6 @@ class TestRayDataStageAdapter:
         assert "Ignoring ray_stage_spec worker sizing keys" in warning_messages[0]
         assert "Ignoring num_workers=3" in warning_messages[1]
 
-    def test_process_dataset_applies_head_node_actor_pool_cap(self):
-        with mock.patch(
-            "nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources",
-            return_value=(6.0, 0.0),
-        ):
-            actor_kwargs = _map_batches_kwargs(ConfigurableActorStage(), ignore_head_node=True)
-
-        assert actor_kwargs["compute"] == ActorPoolStrategy(min_size=1, max_size=3)
-
     def test_process_dataset_rejects_managed_ray_remote_args(self):
         stage = ConfigurableActorStage(
             ray_stage_spec={
@@ -126,9 +117,9 @@ class TestRayDataStageAdapter:
             _map_batches_kwargs(stage)
 
 
-def _map_batches_kwargs(stage: ProcessingStage, *, ignore_head_node: bool = False) -> dict[str, object]:
+def _map_batches_kwargs(stage: ProcessingStage) -> dict[str, object]:
     dataset = RecordingDataset()
-    RayDataStageAdapter(stage).process_dataset(dataset, ignore_head_node=ignore_head_node)  # type: ignore[arg-type]
+    RayDataStageAdapter(stage).process_dataset(dataset)  # type: ignore[arg-type]
     assert dataset.map_batches_kwargs is not None
     assert dataset.batch_size == stage.batch_size
     return dataset.map_batches_kwargs

--- a/tests/backends/ray_data/test_max_calls_pid.py
+++ b/tests/backends/ray_data/test_max_calls_pid.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import os
 import re
 import tempfile
+from collections import Counter
 
 import pandas as pd
 import pytest
@@ -136,12 +136,8 @@ def test_pid_recycling(max_calls_per_worker: int | None):
     results = executor.execute(stages=[stage], initial_tasks=tasks)
 
     pids = [r.data["worker_pid"].iloc[0] for r in results]
-    expected_unique_pids = math.ceil(len(tasks) / max_calls_per_worker) if max_calls_per_worker else 1
 
-    assert len(set(pids)) == expected_unique_pids, (
-        f"Expected {expected_unique_pids} unique PIDs with max_calls={max_calls_per_worker}, "
-        f"got {len(set(pids))}: {pids}"
-    )
+    _assert_max_calls_respected(pids, max_calls_per_worker)
 
 
 @pytest.mark.parametrize("max_calls_per_worker", [2, None])
@@ -150,13 +146,11 @@ def test_max_calls_not_fused_with_actor_stage(max_calls_per_worker: int | None):
     """Verify that a task stage with max_calls is not fused with a following actor stage.
 
     Ray Data's operator fusion optimization can merge consecutive map_batches
-    operations. If PidRecorderStage (task-based, max_calls=1) were fused with
-    PassthroughActorStage (actor-based), the max_calls setting would be lost
-    and we'd see only 1 unique PID instead of one per task.
+    operations. If PidRecorderStage were fused into the following stage, Ray Data
+    could lose the max_calls setting.
 
-    By chaining the two stages and asserting PID recycling still occurs, we
-    confirm that Ray Data keeps them as separate operators. We also verify
-    the execution plan directly to ensure no fusion occurred.
+    The worker PID check verifies max_calls without assuming exact Ray worker
+    reuse. The execution plan check verifies fusion behavior directly.
     """
     num_tasks = 4
     tasks = [EmptyTask()] * num_tasks
@@ -169,15 +163,10 @@ def test_max_calls_not_fused_with_actor_stage(max_calls_per_worker: int | None):
         results = executor.execute(stages=[pid_stage, actor_stage], initial_tasks=tasks)
         all_logs = log_buffer.getvalue()
 
-    # Verify PID recycling
+    # Verify max_calls without assuming exact Ray worker reuse.
     pids = [r.data["worker_pid"].iloc[0] for r in results]
-    expected_unique_pids = math.ceil(num_tasks / max_calls_per_worker) if max_calls_per_worker else 1
 
-    assert len(set(pids)) == expected_unique_pids, (
-        f"Expected {expected_unique_pids} unique PIDs (max_calls={max_calls_per_worker}, "
-        f"{num_tasks} tasks), got {len(set(pids))}: {pids}. "
-        f"Stages may have been fused by Ray Data, defeating max_calls."
-    )
+    _assert_max_calls_respected(pids, max_calls_per_worker)
 
     # Verify execution plan fusion behavior
     matches = re.findall(r"Execution plan of Dataset.*?:\s*(.+)", all_logs, re.MULTILINE)
@@ -213,11 +202,11 @@ def test_max_calls_not_fused_with_task_stage(max_calls_per_worker: int | None):
     """Verify that a task stage with max_calls is not fused with a following task stage.
 
     Ray Data's operator fusion optimization can merge consecutive map_batches
-    operations. If PidRecorderStage (task-based, max_calls=1) were fused with
-    PassthroughTaskStage (task-based), the max_calls setting would be lost
-    and we'd see only 1 unique PID instead of one per task.
+    operations. If PidRecorderStage were fused into the following stage, Ray Data
+    could lose the max_calls setting.
 
-    We also verify the execution plan directly to ensure no fusion occurred.
+    The worker PID check verifies max_calls without assuming exact Ray worker
+    reuse. The execution plan check verifies fusion behavior directly.
     """
     num_tasks = 4
     tasks = [EmptyTask()] * num_tasks
@@ -230,15 +219,10 @@ def test_max_calls_not_fused_with_task_stage(max_calls_per_worker: int | None):
         results = executor.execute(stages=[task_stage, pid_stage], initial_tasks=tasks)
         all_logs = log_buffer.getvalue()
 
-    # Verify PID recycling
+    # Verify max_calls without assuming exact Ray worker reuse.
     pids = [r.data["worker_pid"].iloc[0] for r in results]
-    expected_unique_pids = math.ceil(num_tasks / max_calls_per_worker) if max_calls_per_worker else 1
 
-    assert len(set(pids)) == expected_unique_pids, (
-        f"Expected {expected_unique_pids} unique PIDs (max_calls={max_calls_per_worker}, "
-        f"{num_tasks} tasks), got {len(set(pids))}: {pids}. "
-        f"Stages may have been fused by Ray Data, defeating max_calls."
-    )
+    _assert_max_calls_respected(pids, max_calls_per_worker)
 
     # Verify execution plan fusion behavior
     matches = re.findall(r"Execution plan of Dataset.*?:\s*(.+)", all_logs, re.MULTILINE)
@@ -266,3 +250,14 @@ def test_max_calls_not_fused_with_task_stage(max_calls_per_worker: int | None):
             f"Expected fused operator with 2 MapBatches, got: {map_batches_stages[0]}. "
             f"Full execution plan: {matches[-1]}"
         )
+
+
+def _assert_max_calls_respected(pids: list[int], max_calls_per_worker: int | None) -> None:
+    assert pids
+    if max_calls_per_worker is None:
+        return
+
+    pid_counts = Counter(pids)
+    assert max(pid_counts.values()) <= max_calls_per_worker, (
+        f"Expected no worker PID to process more than {max_calls_per_worker} batches, got {pid_counts}."
+    )

--- a/tests/backends/ray_data/test_utils.py
+++ b/tests/backends/ray_data/test_utils.py
@@ -67,6 +67,8 @@ class TestGetActorComputeStrategyForStage:
         ("num_workers", "ray_stage_spec", "expected", "expected_warning"),
         [
             (4, {}, ActorPoolStrategy(size=4), None),
+            (0, {}, ActorPoolStrategy(min_size=1, max_size=None), None),
+            (-1, {}, ActorPoolStrategy(min_size=1, max_size=None), None),
             (None, {}, ActorPoolStrategy(min_size=1, max_size=None), None),
             (
                 None,
@@ -98,6 +100,7 @@ class TestGetActorComputeStrategyForStage:
         expected_warning: str | None,
     ):
         mock_stage = Mock(num_workers=lambda: num_workers, ray_stage_spec=lambda: ray_stage_spec)
+        mock_stage.name = "stage"
 
         with patch("nemo_curator.backends.ray_data.utils.logger.warning") as mock_warning:
             assert get_actor_compute_strategy_for_stage(mock_stage) == expected
@@ -107,3 +110,17 @@ class TestGetActorComputeStrategyForStage:
         else:
             mock_warning.assert_called_once()
             assert expected_warning in mock_warning.call_args.args[0]
+
+    def test_actor_compute_strategy_rejects_invalid_sizing(self):
+        mock_stage = Mock(
+            num_workers=lambda: None,
+            ray_stage_spec=lambda: {
+                RayStageSpecKeys.MIN_WORKERS: 1,
+                RayStageSpecKeys.MAX_WORKERS: 4,
+                RayStageSpecKeys.INITIAL_WORKERS: 10,
+            },
+        )
+        mock_stage.name = "stage"
+
+        with pytest.raises(ValueError, match="Invalid Ray Data actor pool sizing for stage stage"):
+            get_actor_compute_strategy_for_stage(mock_stage)

--- a/tests/backends/ray_data/test_utils.py
+++ b/tests/backends/ray_data/test_utils.py
@@ -15,12 +15,12 @@
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from ray.data import ActorPoolStrategy
 
 from nemo_curator.backends.ray_data.utils import (
-    calculate_concurrency_for_actors_for_stage,
-    get_available_cpu_gpu_resources,
+    get_actor_compute_strategy_for_stage,
 )
-from nemo_curator.stages.resources import Resources
+from nemo_curator.backends.utils import RayStageSpecKeys, get_available_cpu_gpu_resources
 from tests.backends.test_utils import reset_head_node_cache  # noqa: F401
 
 
@@ -60,78 +60,50 @@ class TestGetAvailableCpuGpuResources:
         mock_available_resources.assert_called_once()
 
 
-class TestCalculateConcurrencyForActorsForStage:
-    """Test class for calculate_concurrency_for_actors_for_stage function."""
+class TestGetActorComputeStrategyForStage:
+    """Test class for Ray Data compute strategy construction."""
 
-    @patch("nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources")
-    def test_calculate_concurrency_explicit_num_workers(self, mock_get_resources: MagicMock):
-        """Test calculate_concurrency when num_workers is explicitly set."""
-        mock_stage = Mock(num_workers=lambda: 4, resources=Resources(cpus=2.0, gpus=0.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == 4
-        # Should not call get_resources if num_workers is set
-        mock_get_resources.assert_not_called()
+    @pytest.mark.parametrize(
+        ("num_workers", "ray_stage_spec", "expected", "expected_warning"),
+        [
+            (4, {}, ActorPoolStrategy(size=4), None),
+            (None, {}, ActorPoolStrategy(min_size=1, max_size=None), None),
+            (
+                None,
+                {
+                    RayStageSpecKeys.MIN_WORKERS: 2,
+                    RayStageSpecKeys.MAX_WORKERS: 8,
+                    RayStageSpecKeys.INITIAL_WORKERS: 4,
+                },
+                ActorPoolStrategy(min_size=2, max_size=8, initial_size=4),
+                None,
+            ),
+            (
+                3,
+                {
+                    RayStageSpecKeys.MIN_WORKERS: 1,
+                    RayStageSpecKeys.MAX_WORKERS: 8,
+                    RayStageSpecKeys.INITIAL_WORKERS: 2,
+                },
+                ActorPoolStrategy(size=3),
+                "uses num_workers=3",
+            ),
+        ],
+    )
+    def test_actor_compute_strategy(
+        self,
+        num_workers: int | None,
+        ray_stage_spec: dict[str, object],
+        expected: ActorPoolStrategy,
+        expected_warning: str | None,
+    ):
+        mock_stage = Mock(num_workers=lambda: num_workers, ray_stage_spec=lambda: ray_stage_spec)
 
-    @patch("nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources", return_value=(8.0, 2.0))
-    def test_calculate_concurrency_explicit_num_workers_zero_or_negative(self, mock_get_resources: MagicMock):
-        """Test calculate_concurrency when num_workers is explicitly set to 0 or negative."""
-        mock_stage = Mock(num_workers=lambda: 0, resources=Resources(cpus=2.0, gpus=0.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 4)
-        mock_get_resources.assert_called_once()
+        with patch("nemo_curator.backends.ray_data.utils.logger.warning") as mock_warning:
+            assert get_actor_compute_strategy_for_stage(mock_stage) == expected
 
-    @patch("nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources", return_value=(8.0, 2.0))
-    def test_calculate_concurrency_cpu_only_constraint(self, mock_get_resources: MagicMock):
-        """Test calculate_concurrency with CPU-only constraint."""
-        mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=2.0, gpus=0.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 4)
-        mock_get_resources.assert_called_once()
-
-    @patch("nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources", return_value=(8.0, 4.0))
-    def test_calculate_concurrency_gpu_only_constraint(self, mock_get_resources: MagicMock):
-        """Test calculate_concurrency with GPU-only constraint."""
-        mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=0.0, gpus=1.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 4)
-        mock_get_resources.assert_called_once()
-
-    @patch("nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources", return_value=(8.0, 4.0))
-    def test_calculate_concurrency_both_cpu_gpu_constraints(self, mock_get_resources: MagicMock):
-        """Test calculate_concurrency with both CPU and GPU constraints."""
-        mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=2.0, gpus=1.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 4)
-        mock_get_resources.assert_called_once()
-
-    @patch("nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources", return_value=(4.0, 8.0))
-    def test_calculate_concurrency_cpu_more_limiting(self, mock_get_resources: MagicMock):
-        """Test calculate_concurrency when CPU is more limiting than GPU."""
-        mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=2.0, gpus=1.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 2)
-        mock_get_resources.assert_called_once()
-
-    @patch("nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources", return_value=(16.0, 2.0))
-    def test_calculate_concurrency_gpu_more_limiting(self, mock_get_resources: MagicMock):
-        """Test calculate_concurrency when GPU is more limiting than CPU."""
-        mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=2.0, gpus=1.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 2)
-        mock_get_resources.assert_called_once()
-
-    @patch("nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources", return_value=(8.0, 2.0))
-    def test_calculate_concurrency_no_resource_requirements(self, mock_get_resources: MagicMock):
-        """Test calculate_concurrency when stage has no resource requirements."""
-        mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=0.0, gpus=0.0))
-        with pytest.raises(OverflowError, match="cannot convert float infinity to integer"):
-            calculate_concurrency_for_actors_for_stage(mock_stage)
-
-        mock_get_resources.assert_called_once()
-
-    @patch("nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources", return_value=(1.0, 0.0))
-    def test_calculate_concurrency_insufficient_resources(self, mock_get_resources: MagicMock):
-        """Test calculate_concurrency when there are insufficient resources."""
-        mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=4.0, gpus=2.0))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 0)
-        mock_get_resources.assert_called_once()
-
-    @patch("nemo_curator.backends.ray_data.utils.get_available_cpu_gpu_resources", return_value=(8.0, 2.0))
-    def test_calculate_concurrency_fractional_resources(self, mock_get_resources: MagicMock):
-        """Test calculate_concurrency with fractional resource requirements."""
-        mock_stage = Mock(num_workers=lambda: None, resources=Resources(cpus=0.5, gpus=0.25))
-        assert calculate_concurrency_for_actors_for_stage(mock_stage) == (1, 8)
-        mock_get_resources.assert_called_once()
+        if expected_warning is None:
+            mock_warning.assert_not_called()
+        else:
+            mock_warning.assert_called_once()
+            assert expected_warning in mock_warning.call_args.args[0]

--- a/tests/backends/test_utils.py
+++ b/tests/backends/test_utils.py
@@ -259,7 +259,14 @@ class TestRayStageSpecKeys:
     def test_enum_membership_compatibility(self):
         """Test that the fixed pattern works across Python versions."""
         # Test data
-        valid_keys = ["is_actor_stage", "is_fanout_stage", "is_lsh_stage"]
+        valid_keys = [
+            "is_actor_stage",
+            "is_fanout_stage",
+            "is_lsh_stage",
+            "min_workers",
+            "max_workers",
+            "initial_workers",
+        ]
         invalid_keys = ["invalid_key", "another_bad_key"]
 
         # Test the fixed pattern - this is what's now used in the adapter


### PR DESCRIPTION
## Description
This PR updates the Ray Data backend to use Ray Data's `compute` API for actor stages instead of the deprecated `concurrency` argument.

Key changes:
- Use `ray.data.ActorPoolStrategy` for Ray Data actor stages.
- Treat `num_workers` as an exact fixed-size actor pool with `ActorPoolStrategy(size=n)`.
- Add `ray_stage_spec` overrides for autoscaling actor pools: `min_workers`, `max_workers`, and `initial_workers`.
- Leave Ray Data task stages on Ray Data's default task scheduling path, and warn when actor-pool worker sizing options are configured on task stages.
- Warn when `num_workers` takes precedence over actor-pool min/max/initial sizing.
- Simplify the Ray Data actor concurrency helper now that Ray Data owns actor-pool scaling and resource scheduling. (i.e. `max_size=None` is the same as the math we used to do before)
- Update the custom Ray actor pool backend so `num_workers` still requests an exact worker count when resources fit, but warns and caps to available resources when they do not.
- Tighten tests around Ray Data compute kwargs, actor-pool sizing, and `max_calls` behavior without relying on exact Ray worker PID reuse.

## Usage
```python
from nemo_curator.backends.utils import RayStageSpecKeys


class MyActorStage(...):
    def ray_stage_spec(self) -> dict:
        return {
            RayStageSpecKeys.IS_ACTOR_STAGE: True,
            RayStageSpecKeys.MIN_WORKERS: 2,
            RayStageSpecKeys.MAX_WORKERS: 8,
            RayStageSpecKeys.INITIAL_WORKERS: 4,
        }
```

If `num_workers()` returns a positive value for an actor stage, it takes precedence and creates a fixed-size actor pool:

```python
def num_workers(self) -> int:
    return 4
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
