### PR TITLE
fix: exclude eval/ from check-manifest sdist validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -500,4 +500,5 @@ ignore = [
   "**/test_*.py",
   "**/*.bat",
   "**/.gitkeep",
+  "eval/**",
 ]


### PR DESCRIPTION
## Description

- Adds eval/** to the [tool.check-manifest] ignore list in pyproject.toml to fix the validate-wheel/check-manifest CI failure
- eval/ contains internal video evaluation tooling (caption_clipscore.py, build_benchmark_dataset.py) that is not intended for PyPI distribution — excluded from sdist rather than included

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
