### PR TITLE
Use --reason for benchmark run reason

### DIFF
--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -358,7 +358,7 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         ),
     )
     parser.add_argument(
-        "--run-reason",
+        "--reason",
         default=None,
         help=(
             "Free-text reason for this run, recorded in env.json and surfaced in the Slack "
@@ -421,8 +421,8 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
 
     # Record an optional free-text reason for the run (e.g. "regression check after MR !2442").
     # Appears in env.json and the Slack environment block. No-op when unset.
-    if args.run_reason:
-        env_dict["run_reason"] = args.run_reason
+    if args.reason:
+        env_dict["run_reason"] = args.reason
 
     # Surface an optional run-viewer URL in the Slack sink. Patch sink_config in-process
     # so we don't have to teach the YAML config loader about a per-launch viewer URL.

--- a/benchmarking/tools/ci_benchmark_launcher.sh
+++ b/benchmarking/tools/ci_benchmark_launcher.sh
@@ -56,5 +56,5 @@ python benchmarking/run.py \
   --config /opt/Curator/benchmarking/test-paths.yaml \
   --session-name "${SESSION_NAME}" \
   ${VIEWER_URL:+--viewer-url "${VIEWER_URL}"} \
-  ${NEMO_CI_RUN_REASON:+--run-reason "${NEMO_CI_RUN_REASON}"} \
+  ${NEMO_CI_RUN_REASON:+--reason "${NEMO_CI_RUN_REASON}"} \
   --entries-exact "${ENTRY_NAME}"


### PR DESCRIPTION
## Summary

- Rename the benchmarking runner's run-reason CLI option from `--run-reason` to `--reason`.
- This aligns the public benchmark-runner option with internal launch tooling that already exposes a user-facing `--reason` flag, keeping the terminology consistent across the Curator launch path.
- Update the CI benchmark launcher to pass `--reason` when `NEMO_CI_RUN_REASON` is set.
- Do not keep a hidden `--run-reason` alias, so the public CLI surface is unambiguous.

## Test plan

- `python -m py_compile benchmarking/run.py`
- `bash -n benchmarking/tools/ci_benchmark_launcher.sh`
- `git diff --check`