### PR TITLE
[codex] Fix Fern preview metadata upload

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -60,4 +60,5 @@ jobs:
           path: |
             fern/
             .preview-metadata/
+          include-hidden-files: true
           retention-days: 1


### PR DESCRIPTION
## Summary

- include hidden files when uploading the Fern preview artifact
- preserve the existing `.preview-metadata/` producer/consumer contract

## Root cause

`actions/upload-artifact` v4 excludes hidden files by default. The Fern preview build stores the pull request number, head ref, and changed-file list under `.preview-metadata/`, so the companion `workflow_run` downloaded the Fern sources without that metadata.

As a result, `HEAD_REF` and `PR_NUMBER` were empty: Fern published to the shared `preview-default` identifier and the PR-comment request failed with HTTP 404. This affected draft and ready-for-review pull requests alike.

Example failed publisher run: https://github.com/NVIDIA-NeMo/Curator/actions/runs/28404447988

## Validation

- workflow YAML parses successfully
- `git diff --check` passes
- the pinned `actions/upload-artifact@v4.6.2` step receives its supported `include-hidden-files` input

The PR's own `Preview Fern Docs: Build` and subsequent `Preview Fern Docs: Comment` runs provide the end-to-end validation.
