### PR TITLE
ci: use NVIDIA inference for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,8 +13,9 @@ permissions:
 jobs:
   claude-review:
     if: github.event.issue.pull_request != null && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v0.88.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.7.0
     with:
+      model: ${{ vars.CLAUDE_MODEL }}
       prompt: |
         You are doing a light code review. Keep it concise and actionable.
 
@@ -36,4 +37,5 @@ jobs:
         It's perfectly acceptable to not have anything to comment on.
         If you do not have anything to comment on, post "LGTM".
     secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      NVIDIA_INFERENCE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+      NVIDIA_INFERENCE_KEY: ${{ secrets.NVIDIA_INFERENCE_KEY }}


### PR DESCRIPTION
## Description

Updates the Claude review workflow to use the released FW-CI-templates `v1.7.0` NVIDIA inference configuration.

- Bumps `_claude_review.yml` to `v1.7.0`.
- Passes `vars.CLAUDE_MODEL`, `secrets.NVIDIA_INFERENCE_URL`, and `secrets.NVIDIA_INFERENCE_KEY`.

Linear: AUT-644

## Usage

N/A. CI workflow configuration only.

## Checklist

- [x] All commits are signed and signed off.
- [x] New or Existing tests cover these changes. N/A, workflow-only change; YAML parsing validated locally.
- [x] The documentation is up to date with these changes. N/A.