### PR TITLE
Support running minhash on DocumentBatches

### DIFF
--- a/nemo_curator/stages/deduplication/fuzzy/minhash.py
+++ b/nemo_curator/stages/deduplication/fuzzy/minhash.py
@@ -17,14 +17,17 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import cudf
 import numpy as np
+import pandas as pd
+import pyarrow as pa
 import rmm
+from loguru import logger
 
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.deduplication.fuzzy.utils import CURATOR_DEFAULT_MINHASH_FIELD
 from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR, get_id_generator_actor
 from nemo_curator.stages.deduplication.io_utils import DeduplicationIO
 from nemo_curator.stages.resources import Resources
-from nemo_curator.tasks import FileGroupTask
+from nemo_curator.tasks import DocumentBatch, FileGroupTask
 from nemo_curator.utils.file_utils import create_or_overwrite_dir, get_fs
 
 if TYPE_CHECKING:
@@ -176,18 +179,20 @@ class GPUMinHash(MinHash):
         return minhash_method(text_series)
 
 
-class MinHashStage(ProcessingStage[FileGroupTask, FileGroupTask], DeduplicationIO):
+class MinHashStage(ProcessingStage[FileGroupTask | DocumentBatch, FileGroupTask], DeduplicationIO):
     """
     ProcessingStage for computing MinHash signatures on documents for fuzzy deduplication.
 
-    This stage takes FileGroupTask containing paths to input documents and produces
+    This stage accepts either a FileGroupTask (paths to input documents) or a DocumentBatch
+    (in-memory pandas/pyarrow data already read by an upstream stage) and produces a
     FileGroupTask containing paths to computed minhash signature files. It uses GPU-accelerated
     MinHash computation to generate locality-sensitive hash signatures that can be used
     for approximate duplicate detection.
 
     The stage automatically handles:
-    - Reading input files (JSONL or Parquet format)
-    - Assigning unique Integer IDs to documents using the IdGenerator actor
+    - Reading input files (JSONL or Parquet format), OR converting a DocumentBatch to cuDF
+    - Assigning unique Integer IDs to documents using the IdGenerator actor (file path only;
+      a DocumentBatch must already contain the ``_curator_dedup_id`` column)
     - Computing MinHash signatures using GPU acceleration
     - Writing results to Parquet files
 
@@ -207,10 +212,12 @@ class MinHashStage(ProcessingStage[FileGroupTask, FileGroupTask], DeduplicationI
         Random seed for reproducible minhash generation
     use_64bit_hash : bool, default=False
         Whether to use 64-bit hash functions (vs 32-bit)
-    read_format : Literal["jsonl", "parquet"], default="jsonl"
-        Format of input files
+    read_format : Literal["jsonl", "parquet"] | None, default="jsonl"
+        Format of input files. Only applies to FileGroupTask inputs; ignored for DocumentBatch
+        inputs (which are already in memory). May be None when only DocumentBatch inputs are used.
     read_kwargs : dict[str, Any] | None, default=None
-        Additional keyword arguments for reading input files
+        Additional keyword arguments for reading input files. Only applies to FileGroupTask inputs;
+        ignored for DocumentBatch inputs.
     write_kwargs : dict[str, Any] | None, default=None
         Additional keyword arguments for writing output files
 
@@ -234,7 +241,7 @@ class MinHashStage(ProcessingStage[FileGroupTask, FileGroupTask], DeduplicationI
         num_hashes: int = 260,
         seed: int = 42,
         use_64bit_hash: bool = False,
-        read_format: Literal["jsonl", "parquet"] = "jsonl",
+        read_format: Literal["jsonl", "parquet"] | None = "jsonl",
         read_kwargs: dict[str, Any] | None = None,
         write_kwargs: dict[str, Any] | None = None,
         pool: bool = True,
@@ -263,16 +270,14 @@ class MinHashStage(ProcessingStage[FileGroupTask, FileGroupTask], DeduplicationI
 
     def setup(self, _worker_metadata: "WorkerMetadata | None" = None) -> None:
         """Initialize the GPU MinHash processor and ID generator."""
-        # Initialize the ID generator (will be shared across workers)
-
+        # The ID generator is only required for the FileGroupTask (file-read) path, where IDs
+        # are assigned at read time. DocumentBatch inputs must already carry _curator_dedup_id,
+        # so a missing actor is tolerated here; the file path surfaces a clear error at
+        # process time if it actually needs the ID generator.
         try:
             self.id_generator = get_id_generator_actor()
-        except ValueError as e:
-            err_msg = """
-            Failed to get ID generator actor. Start an ID generator actor via `create_id_generator_actor` if calling this stage directly.
-            If using the FuzzyDedup API this should be started automatically.
-            """
-            raise ValueError(err_msg) from e
+        except ValueError:
+            self.id_generator = None
 
         # Initialize the GPU minhash processor
         self.minhash_processor = GPUMinHash(
@@ -284,40 +289,57 @@ class MinHashStage(ProcessingStage[FileGroupTask, FileGroupTask], DeduplicationI
         )
 
     def inputs(self) -> tuple[list[str], list[str]]:
-        """Define input requirements."""
-        return (["data"], [])
+        """Define input requirements.
+
+        The required columns apply to the DocumentBatch input path; they are declared here for
+        documentation / ``Pipeline.describe()`` and enforced type-aware in ``validate_input``
+        (a FileGroupTask has no columns until its files are read).
+        """
+        return (["data"], [CURATOR_DEDUP_ID_STR, self.text_field])
 
     def outputs(self) -> tuple[list[str], list[str]]:
         """Define outputs - produces FileGroupTask with minhash files."""
         return (["data"], [])
 
-    def process(self, task: FileGroupTask) -> FileGroupTask:
+    def validate_input(self, task: FileGroupTask | DocumentBatch) -> bool:
+        """Validate input for either a FileGroupTask or a DocumentBatch.
+
+        The base implementation checks required columns via ``hasattr(task.data, col)``, which is
+        wrong for this union (a FileGroupTask's ``data`` is a ``list[str]`` and a pyarrow-backed
+        DocumentBatch does not expose columns as attributes). We therefore validate the required
+        columns for a DocumentBatch via ``get_columns()`` and only check ``data`` presence for a
+        FileGroupTask (its columns are unknown until the files are read).
         """
-        Process a group of files to compute minhashes.
+        if not hasattr(task, "data"):
+            logger.error(f"Task {task.task_id} missing required attribute: data")
+            return False
+        if isinstance(task, DocumentBatch):
+            missing = {CURATOR_DEDUP_ID_STR, self.text_field} - set(task.get_columns())
+            if missing:
+                logger.error(f"DocumentBatch {task.task_id} missing required columns: {sorted(missing)}")
+                return False
+        return True
+
+    def process(self, task: FileGroupTask | DocumentBatch) -> FileGroupTask:
+        """
+        Process a FileGroupTask or DocumentBatch to compute minhashes.
 
         Args:
-            task: FileGroupTask containing file paths to process
+            task: FileGroupTask containing file paths to process, or a DocumentBatch whose data
+                already contains the ``_curator_dedup_id`` and text columns.
 
         Returns:
             FileGroupTask containing paths to minhash output files
         """
 
-        if self.minhash_processor is None or self.id_generator is None:
-            msg = "MinHash processor or ID generator not initialized. Call setup() first."
+        if self.minhash_processor is None:
+            msg = "MinHash processor not initialized. Call setup() first."
             raise RuntimeError(msg)
 
+        # Read/convert the input into a cuDF DataFrame with the text and ID columns.
+        df = self._read_document_batch(task) if isinstance(task, DocumentBatch) else self._read_file_group(task)
+
         output_file = self.output_fs.sep.join([self.output_path, f"{task.task_id}.parquet"])
-
-        read_kwargs = self.read_kwargs.copy()
-
-        # Read input file based on format
-        if self.read_format == "jsonl":
-            df = self.read_jsonl(filepath=task.data, columns=[self.text_field], assign_id=True, **read_kwargs)
-        elif self.read_format == "parquet":
-            df = self.read_parquet(filepath=task.data, columns=[self.text_field], assign_id=True, **read_kwargs)
-        else:
-            msg = f"Unsupported read format: {self.read_format}"
-            raise ValueError(msg)
 
         result_df = df[[CURATOR_DEDUP_ID_STR]]
         result_df[self.minhash_field] = self.minhash_processor.compute_minhashes(df[self.text_field])
@@ -337,3 +359,41 @@ class MinHashStage(ProcessingStage[FileGroupTask, FileGroupTask], DeduplicationI
             },
             _stage_perf=task._stage_perf,
         )
+
+    def _read_file_group(self, task: FileGroupTask) -> "cudf.DataFrame":
+        """Read a FileGroupTask's files into cuDF, assigning IDs at read time."""
+        if self.id_generator is None:
+            msg = (
+                "IdGenerator actor is required for FileGroupTask input but was not found. "
+                "Start it via create_id_generator_actor(), or pass a DocumentBatch whose data "
+                "already contains the _curator_dedup_id column."
+            )
+            raise RuntimeError(msg)
+
+        read_kwargs = self.read_kwargs.copy()
+
+        # Read input file based on format
+        if self.read_format == "jsonl":
+            return self.read_jsonl(filepath=task.data, columns=[self.text_field], assign_id=True, **read_kwargs)
+        elif self.read_format == "parquet":
+            return self.read_parquet(filepath=task.data, columns=[self.text_field], assign_id=True, **read_kwargs)
+        else:
+            msg = f"read_format must be 'jsonl' or 'parquet' to process a FileGroupTask; got {self.read_format!r}"
+            raise ValueError(msg)
+
+    def _read_document_batch(self, task: DocumentBatch) -> "cudf.DataFrame":
+        """Convert an in-memory DocumentBatch to cuDF, keeping only the ID and text columns.
+
+        Non-relevant columns are dropped on the host (before the GPU transfer), mirroring how the
+        file path only reads ``columns=[text_field]``. The required columns are guaranteed present
+        by ``validate_input``; when ``process`` is called directly a missing column will raise here.
+        """
+        keep = [CURATOR_DEDUP_ID_STR, self.text_field]
+        data = task.data
+        if isinstance(data, pa.Table):
+            return cudf.DataFrame.from_arrow(data.select(keep))
+        elif isinstance(data, pd.DataFrame):
+            return cudf.from_pandas(data[keep])
+        else:
+            msg = f"Unsupported DocumentBatch data type: {type(data)}"
+            raise TypeError(msg)

--- a/tests/stages/deduplication/fuzzy/test_minhash_stage.py
+++ b/tests/stages/deduplication/fuzzy/test_minhash_stage.py
@@ -19,6 +19,7 @@ from contextlib import suppress
 from pathlib import Path
 
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 # Suppress GPU-related import errors when running pytest -m "not gpu"
@@ -30,7 +31,7 @@ with suppress(ImportError):
     from nemo_curator.stages.deduplication.fuzzy.minhash import MinHashStage
     from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
 
-from nemo_curator.tasks import FileGroupTask
+from nemo_curator.tasks import DocumentBatch, FileGroupTask
 
 
 @pytest.fixture
@@ -79,44 +80,48 @@ def sample_data_with_duplicates() -> tuple[pd.DataFrame, pd.DataFrame]:
     return data1, data2
 
 
-@pytest.fixture
-def sample_files(
-    tmp_path: Path, sample_data_with_duplicates: tuple[pd.DataFrame, pd.DataFrame], request: "pytest.FixtureRequest"
-) -> tuple[list[str], str]:
-    """Create sample files in the requested format."""
+@pytest.fixture(params=["jsonl", "parquet", "docbatch_pandas", "docbatch_pyarrow"])
+def input_task(
+    request: "pytest.FixtureRequest",
+    tmp_path: Path,
+    sample_data_with_duplicates: tuple[pd.DataFrame, pd.DataFrame],
+) -> "FileGroupTask | DocumentBatch":
+    """Provide the MinHash input as each supported task/format combination.
+
+    Covers both FileGroupTask formats (jsonl, parquet) and both DocumentBatch backings
+    (pandas, pyarrow). DocumentBatch inputs are the two frames concatenated into a single batch
+    and carry the pre-assigned ``_curator_dedup_id`` column (the stage assigns IDs only on the
+    file-read path). All variants therefore yield the same 9 rows with the same duplicate layout.
+    """
     data1, data2 = sample_data_with_duplicates
-    format_type = request.param  # Will be either 'jsonl' or 'parquet'
+    kind = request.param
 
-    if format_type == "jsonl":
-        file1 = tmp_path / "data1.jsonl"
-        file2 = tmp_path / "data2.jsonl"
-        data1.to_json(file1, orient="records", lines=True)
-        data2.to_json(file2, orient="records", lines=True)
-    else:  # parquet
-        file1 = tmp_path / "data1.parquet"
-        file2 = tmp_path / "data2.parquet"
-        data1.to_parquet(file1)
-        data2.to_parquet(file2)
+    if kind in ("jsonl", "parquet"):
+        if kind == "jsonl":
+            file1, file2 = tmp_path / "data1.jsonl", tmp_path / "data2.jsonl"
+            data1.to_json(file1, orient="records", lines=True)
+            data2.to_json(file2, orient="records", lines=True)
+        else:
+            file1, file2 = tmp_path / "data1.parquet", tmp_path / "data2.parquet"
+            data1.to_parquet(file1)
+            data2.to_parquet(file2)
+        return FileGroupTask(
+            dataset_name="test_dataset",
+            data=[str(file1), str(file2)],
+            _metadata={"batch_id": 0, "total_batches": 1, "format": kind},
+        )
 
-    return [str(file1), str(file2)], format_type
-
-
-@pytest.fixture
-def input_task(sample_files: tuple[list[str], str]) -> FileGroupTask:
-    """Create a FileGroupTask from sample files."""
-    files, format_type = sample_files
-    return FileGroupTask(
-        dataset_name="test_dataset",
-        data=files,
-        _metadata={"batch_id": 0, "total_batches": 1, "format": format_type},
-    )
+    # DocumentBatch: combine both frames and pre-assign the dedup id column.
+    combined = pd.concat([data1, data2], ignore_index=True)
+    combined.insert(0, CURATOR_DEDUP_ID_STR, list(range(len(combined))))
+    data = combined if kind == "docbatch_pandas" else pa.Table.from_pandas(combined, preserve_index=False)
+    return DocumentBatch(dataset_name="test_dataset", data=data, _metadata={})
 
 
 @pytest.mark.gpu
 class TestMinHashStage:
     """Test suite for MinHashStage ProcessingStage."""
 
-    @pytest.mark.parametrize("sample_files", ["jsonl", "parquet"], indirect=True)
     @pytest.mark.parametrize("use_64bit_hash", [False, True])
     @pytest.mark.parametrize(
         ("num_hashes", "char_ngrams", "text_field"),
@@ -129,20 +134,20 @@ class TestMinHashStage:
     @pytest.mark.usefixtures("ray_client_with_id_generator")
     def test_minhash_processing(  # noqa: PLR0913
         self,
-        input_task: FileGroupTask,
+        input_task: "FileGroupTask | DocumentBatch",
         tmp_path: Path,
         use_64bit_hash: bool,
         num_hashes: int,
         char_ngrams: int,
         text_field: str,
     ) -> None:
-        """Test minhash processing with various parameter combinations."""
-        # Get format from task metadata
-        read_format = input_task._metadata["format"]
+        """Test minhash processing across all input types (FileGroupTask jsonl/parquet, DocumentBatch pandas/pyarrow)."""
+        # read_format only applies to the file path; DocumentBatch inputs ignore it.
+        read_format = input_task._metadata.get("format", "jsonl")
 
         # Create stage
         stage = MinHashStage(
-            output_path=str(tmp_path / f"output_{read_format}_{use_64bit_hash}_{num_hashes}"),
+            output_path=str(tmp_path / "output"),
             text_field=text_field,
             minhash_field="_minhash_signature",
             char_ngrams=char_ngrams,
@@ -155,9 +160,10 @@ class TestMinHashStage:
 
         # Setup and process
         stage.setup()
+        assert stage.validate_input(input_task) is True
         output_task = stage.process(input_task)
 
-        # Verify output task structure
+        # Verify output task structure (output is always a FileGroupTask)
         assert isinstance(output_task, FileGroupTask)
         assert len(output_task.data) == 1
         assert output_task._metadata["minhash_field"] == "_minhash_signature"
@@ -170,9 +176,8 @@ class TestMinHashStage:
         # Read and verify the output
         result_df = cudf.read_parquet(output_file)
 
-        # Check required columns exist
-        assert CURATOR_DEDUP_ID_STR in result_df.columns
-        assert "_minhash_signature" in result_df.columns
+        # Only the ID + minhash columns survive; all other input columns are pruned
+        assert set(result_df.columns) == {CURATOR_DEDUP_ID_STR, "_minhash_signature"}
 
         assert len(result_df) == 9
 
@@ -259,7 +264,7 @@ class TestMinHashStage:
         input_task = FileGroupTask(dataset_name="test_dataset", data=["dummy.jsonl"], _metadata={})
 
         # Should raise error because setup wasn't called
-        with pytest.raises(RuntimeError, match="MinHash processor or ID generator not initialized"):
+        with pytest.raises(RuntimeError, match="MinHash processor not initialized"):
             stage.process(input_task)
 
     @pytest.mark.usefixtures("ray_client_with_id_generator")
@@ -402,3 +407,131 @@ class TestMinHashStage:
         # IDs should be sequential integers
         assert ids_batch1 == [0, 1, 2]
         assert ids_batch2 == [3, 4, 5]
+
+    # --- Validation / IdGenerator edge cases (end-to-end processing for every input type,
+    # --- including DocumentBatch pandas/pyarrow, is covered by test_minhash_processing above) ---
+
+    @pytest.fixture
+    def batch_dataframe(self) -> pd.DataFrame:
+        """A DocumentBatch-style frame with pre-assigned IDs and extra columns to be dropped."""
+        return pd.DataFrame(
+            {
+                CURATOR_DEDUP_ID_STR: [10, 11, 12, 13, 14],
+                "text": [
+                    "The quick brown fox jumps over the lazy dog",
+                    "A test string for deduplication",
+                    "Another test string that is similar",
+                    "This is an exact duplicate",
+                    "This is an exact duplicate",  # Exact duplicate of the previous row
+                ],
+                # Extra columns that must be dropped by the stage
+                "content": ["a", "b", "c", "d", "e"],
+                "meta": ["doc1", "doc2", "doc3", "doc4", "doc5"],
+            }
+        )
+
+    @pytest.mark.usefixtures("shared_ray_client")
+    def test_document_batch_validate_input_missing_id_column(self, tmp_path: Path) -> None:
+        """A DocumentBatch without the ID column fails validation."""
+        data = pd.DataFrame({"text": ["a", "b"], "meta": ["x", "y"]})
+        task = DocumentBatch(dataset_name="no_id", data=data, _metadata={})
+        stage = MinHashStage(output_path=str(tmp_path / "no_id"), text_field="text", pool=False)
+        assert stage.validate_input(task) is False
+
+    @pytest.mark.usefixtures("shared_ray_client")
+    def test_document_batch_validate_input_missing_text_column(self, tmp_path: Path) -> None:
+        """A DocumentBatch without the text column fails validation."""
+        data = pd.DataFrame({CURATOR_DEDUP_ID_STR: [0, 1], "meta": ["x", "y"]})
+        task = DocumentBatch(dataset_name="no_text", data=data, _metadata={})
+        stage = MinHashStage(output_path=str(tmp_path / "no_text"), text_field="text", pool=False)
+        assert stage.validate_input(task) is False
+
+    @pytest.mark.usefixtures("shared_ray_client")
+    def test_validate_input_filegroup_passes(self, tmp_path: Path) -> None:
+        """A FileGroupTask passes validation without any column checks."""
+        task = FileGroupTask(dataset_name="fg", data=["dummy.parquet"], _metadata={})
+        stage = MinHashStage(output_path=str(tmp_path / "fg"), text_field="text", pool=False)
+        assert stage.validate_input(task) is True
+
+    @pytest.mark.usefixtures("ray_client_with_id_generator")
+    def test_document_batch_without_id_generator(self, batch_dataframe: pd.DataFrame, tmp_path: Path) -> None:
+        """The DocumentBatch path runs even when the IdGenerator actor is unavailable."""
+        task = DocumentBatch(dataset_name="lazy_doc", data=batch_dataframe, _metadata={})
+        stage = MinHashStage(
+            output_path=str(tmp_path / "lazy_doc"),
+            text_field="text",
+            num_hashes=64,
+            char_ngrams=3,
+            pool=False,
+        )
+        stage.setup()
+        # Simulate a missing IdGenerator actor; the DocumentBatch path must not need it.
+        stage.id_generator = None
+        output_task = stage.process(task)
+
+        result_df = cudf.read_parquet(output_task.data[0])
+        assert len(result_df) == 5
+        assert result_df[CURATOR_DEDUP_ID_STR].to_pandas().tolist() == [10, 11, 12, 13, 14]
+
+    @pytest.mark.usefixtures("ray_client_with_id_generator")
+    def test_filegroup_without_id_generator_raises(self, tmp_path: Path) -> None:
+        """The FileGroupTask path raises a clear error when the IdGenerator is unavailable."""
+        data = pd.DataFrame({"text": ["a", "b"]})
+        input_file = tmp_path / "data.jsonl"
+        data.to_json(input_file, orient="records", lines=True)
+        task = FileGroupTask(dataset_name="fg", data=[str(input_file)], _metadata={})
+
+        stage = MinHashStage(
+            output_path=str(tmp_path / "fg_out"),
+            text_field="text",
+            read_format="jsonl",
+            pool=False,
+        )
+        stage.setup()
+        stage.id_generator = None  # simulate missing actor
+        with pytest.raises(RuntimeError, match="IdGenerator actor is required"):
+            stage.process(task)
+
+    @pytest.mark.usefixtures("shared_ray_client")
+    def test_setup_tolerates_missing_id_generator(self, tmp_path: Path) -> None:
+        """setup() stores None (does not raise) when no IdGenerator actor is running."""
+        from nemo_curator.stages.deduplication.id_generator import kill_id_generator_actor
+
+        # Ensure no actor lingers from a prior test in the shared cluster.
+        with suppress(Exception):
+            kill_id_generator_actor()
+
+        stage = MinHashStage(output_path=str(tmp_path / "no_actor"), text_field="text", pool=False)
+        stage.setup()
+        assert stage.id_generator is None
+
+    @pytest.mark.usefixtures("ray_client_with_id_generator")
+    def test_read_format_none_ok_for_document_batch(self, batch_dataframe: pd.DataFrame, tmp_path: Path) -> None:
+        """read_format=None is fine for DocumentBatch input (no file reading happens)."""
+        task = DocumentBatch(dataset_name="docbatch", data=batch_dataframe, _metadata={})
+        stage = MinHashStage(
+            output_path=str(tmp_path / "rf_none"),
+            text_field="text",
+            read_format=None,
+            num_hashes=64,
+            char_ngrams=3,
+            pool=False,
+        )
+        stage.setup()
+        output_task = stage.process(task)
+        result_df = cudf.read_parquet(output_task.data[0])
+        assert len(result_df) == 5
+
+    @pytest.mark.usefixtures("ray_client_with_id_generator")
+    def test_read_format_none_raises_for_filegroup(self, tmp_path: Path) -> None:
+        """A FileGroupTask with read_format=None raises a clear error."""
+        data = pd.DataFrame({"text": ["a", "b"]})
+        input_file = tmp_path / "data.jsonl"
+        data.to_json(input_file, orient="records", lines=True)
+        task = FileGroupTask(dataset_name="fg", data=[str(input_file)], _metadata={})
+
+        stage = MinHashStage(output_path=str(tmp_path / "rf_none_fg"), text_field="text", read_format=None, pool=False)
+        stage.setup()
+        with pytest.raises(ValueError, match="read_format must be 'jsonl' or 'parquet'"):
+            stage.process(task)
+        assert stage.minhash_processor is not None


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
MinHash currently is FileGroupTask in and out. However for many use cases it might make sense for it to support generic DocumentBatch tasks with the id_Generator already run. This helps for cases where we need to run some Cpu based preprocessing on the text before minhashing.

## Usage
<!-- Potentially add a usage example below -->
```python
Pipeline(
   JsonlReader(generate_id=True),
    MinHashStage(...)
)
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
