### PR TITLE
feat: infer fanout stages from process annotations

### DIFF
--- a/nemo_curator/stages/audio/alm/pretrain/extraction.py
+++ b/nemo_curator/stages/audio/alm/pretrain/extraction.py
@@ -31,7 +31,6 @@ import torch
 import torchaudio.functional as taf
 from loguru import logger
 
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio.alm.pretrain.planning import relativize_segments
 from nemo_curator.stages.audio.alm.pretrain.utils import (
     _PLAN_DATA_KEY,
@@ -115,9 +114,6 @@ class SnippetExtractionStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.audio_filepath_key, "snippet_id", "duration", "segments"]
-
-    def ray_stage_spec(self) -> dict[str, Any]:
-        return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
 
     def setup_on_node(
         self,

--- a/nemo_curator/stages/audio/alm/pretrain/io.py
+++ b/nemo_curator/stages/audio/alm/pretrain/io.py
@@ -33,7 +33,6 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio.alm.pretrain.utils import (
     _AUDIO_PATH_RESOLUTION_MODES,
     _MANIFEST_SHARD_EXT,
@@ -154,9 +153,6 @@ class ReadLongFormManifestStage(ProcessingStage[EmptyTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.audio_filepath_key, "id", "segments"]
-
-    def ray_stage_spec(self) -> dict[str, Any]:
-        return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
 
     def num_workers(self) -> int | None:
         return 1

--- a/nemo_curator/stages/audio/common.py
+++ b/nemo_curator/stages/audio/common.py
@@ -171,9 +171,6 @@ class ManifestReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
         )
         return results
 
-    def ray_stage_spec(self) -> dict[str, Any]:
-        return {"is_fanout_stage": True}
-
     def num_workers(self) -> int | None:
         return 1
 

--- a/nemo_curator/stages/audio/datasets/fleurs/create_initial_manifest.py
+++ b/nemo_curator/stages/audio/datasets/fleurs/create_initial_manifest.py
@@ -15,12 +15,10 @@
 import os
 import shutil
 from dataclasses import dataclass
-from typing import Any
 
 from huggingface_hub import hf_hub_download
 from loguru import logger
 
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio.datasets.file_utils import extract_archive
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import AudioTask, EmptyTask
@@ -205,9 +203,6 @@ class CreateInitialManifestFleursStage(ProcessingStage[EmptyTask, AudioTask]):
             )
             raise FileNotFoundError(msg)
         return tsv_path, audio_root
-
-    def ray_stage_spec(self) -> dict[str, Any]:
-        return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
 
     def process(self, _: EmptyTask) -> list[AudioTask]:
         data_dir = self.language_data_dir()

--- a/nemo_curator/stages/audio/datasets/readspeech/create_initial_manifest.py
+++ b/nemo_curator/stages/audio/datasets/readspeech/create_initial_manifest.py
@@ -16,11 +16,9 @@ import glob
 import os
 import subprocess
 from dataclasses import dataclass
-from typing import Any
 
 from loguru import logger
 
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio.datasets.file_utils import download_file
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import AudioTask, EmptyTask
@@ -67,9 +65,6 @@ class CreateInitialManifestReadSpeechStage(ProcessingStage[EmptyTask, AudioTask]
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.filepath_key, self.text_key]
-
-    def ray_stage_spec(self) -> dict[str, Any]:
-        return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
 
     def download_and_extract(self) -> str:
         """Download and extract DNS Challenge Read Speech dataset (~4.88 GB)."""

--- a/nemo_curator/stages/audio/segmentation/speaker_separation.py
+++ b/nemo_curator/stages/audio/segmentation/speaker_separation.py
@@ -44,7 +44,6 @@ except ImportError:
     SortformerEncLabelModel = None
 
 from nemo_curator.backends.base import WorkerMetadata
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio.common import resolve_waveform_from_item
 from nemo_curator.stages.audio.segmentation.speaker_separation_module.speaker_sep import SpeakerSeparator
 from nemo_curator.stages.base import ProcessingStage
@@ -101,9 +100,6 @@ class SpeakerSeparationStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], ["waveform", "sample_rate", "speaker_id", "num_speakers", "duration"]
-
-    def ray_stage_spec(self) -> dict[str, Any]:
-        return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
 
     def setup_on_node(self, _node_info: Any = None, _worker_metadata: Any = None) -> None:  # noqa: ANN401
         try:

--- a/nemo_curator/stages/audio/segmentation/vad_segmentation.py
+++ b/nemo_curator/stages/audio/segmentation/vad_segmentation.py
@@ -47,7 +47,6 @@ from loguru import logger
 from silero_vad import get_speech_timestamps, load_silero_vad
 
 from nemo_curator.backends.base import WorkerMetadata
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio.common import ensure_waveform_2d, load_audio_file
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
@@ -109,7 +108,7 @@ class VADSegmentationStage(ProcessingStage[AudioTask, AudioTask]):
     def ray_stage_spec(self) -> dict[str, Any]:
         if self.nested:
             return {}
-        return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
+        return super().ray_stage_spec()
 
     def setup(self, _: WorkerMetadata | None = None) -> None:
         self._initialize_model()

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -19,7 +19,20 @@ import copy
 import time
 from abc import ABC, ABCMeta, abstractmethod
 from inspect import isabstract
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast, final
+from types import UnionType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Generic,
+    TypeVar,
+    Union,
+    cast,
+    final,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 from loguru import logger
 
@@ -393,7 +406,34 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
         Returns (dict[str, Any]):
             Dictionary containing Ray-specific configuration
         """
-        return {}
+        return {"is_fanout_stage": self.is_fanout_stage()}
+
+    def is_fanout_stage(self) -> bool:
+        """Infer whether `process()` can fan out one input task into many outputs."""
+        try:
+            process_hints = get_type_hints(type(self).process)
+        except (AttributeError, NameError, TypeError) as exc:
+            logger.debug(
+                "Could not resolve type hints for {}.process; defaulting is_fanout_stage to False: {}",
+                type(self).__name__,
+                exc,
+            )
+            return False
+
+        return self._annotation_contains_list(process_hints.get("return"))
+
+    @classmethod
+    def _annotation_contains_list(cls, annotation: object) -> bool:
+        if annotation is None:
+            return False
+
+        if get_origin(annotation) is list:
+            return True
+
+        if get_origin(annotation) in (UnionType, Union):
+            return any(cls._annotation_contains_list(arg) for arg in get_args(annotation))
+
+        return False
 
     # --- Custom per-stage metrics helpers ---
     def _log_metrics(self, metrics: dict[str, float]) -> None:

--- a/nemo_curator/stages/deduplication/semantic/pairwise_io.py
+++ b/nemo_curator/stages/deduplication/semantic/pairwise_io.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from nemo_curator.backends.base import WorkerMetadata
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import EmptyTask, FileGroupTask
@@ -64,12 +63,6 @@ class ClusterWiseFilePartitioningStage(ProcessingStage[EmptyTask, FileGroupTask]
     def setup(self, _: WorkerMetadata | None = None) -> None:
         self.fs = get_fs(self.input_path, storage_options=self.storage_options)
         self.path_normalizer = self.fs.unstrip_protocol if is_remote_url(self.input_path) else (lambda x: x)
-
-    def ray_stage_spec(self) -> dict[str, Any]:
-        """Ray stage specification for this stage."""
-        return {
-            RayStageSpecKeys.IS_FANOUT_STAGE: True,
-        }
 
     def num_workers(self) -> int | None:
         return 1

--- a/nemo_curator/stages/file_partitioning.py
+++ b/nemo_curator/stages/file_partitioning.py
@@ -17,7 +17,6 @@ from typing import Any
 
 from loguru import logger
 
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import EmptyTask, FileGroupTask
@@ -96,12 +95,6 @@ class FilePartitioningStage(ProcessingStage[EmptyTask, FileGroupTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], []
-
-    def ray_stage_spec(self) -> dict[str, Any]:
-        """Ray stage specification for this stage."""
-        return {
-            RayStageSpecKeys.IS_FANOUT_STAGE: True,
-        }
 
     def num_workers(self) -> int | None:
         return 1

--- a/nemo_curator/stages/image/io/image_reader.py
+++ b/nemo_curator/stages/image/io/image_reader.py
@@ -15,13 +15,11 @@
 import pathlib
 from collections.abc import Generator
 from dataclasses import dataclass
-from typing import Any
 
 import numpy as np
 import torch
 from loguru import logger
 
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import FileGroupTask, ImageBatch, ImageObject
@@ -52,12 +50,6 @@ class ImageReaderStage(ProcessingStage[FileGroupTask, ImageBatch]):
             self.resources = Resources(gpus=self.num_gpus_per_worker)
         else:
             self.resources = Resources()
-
-    def ray_stage_spec(self) -> dict[str, Any]:
-        """Ray stage specification for this stage."""
-        return {
-            RayStageSpecKeys.IS_FANOUT_STAGE: True,
-        }
 
     def inputs(self) -> tuple[list[str], list[str]]:
         return [], []

--- a/nemo_curator/stages/interleaved/pdf/nemotron_parse/partitioning.py
+++ b/nemo_curator/stages/interleaved/pdf/nemotron_parse/partitioning.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass, field
 
 from loguru import logger
 
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import EmptyTask, FileGroupTask
@@ -79,9 +78,6 @@ class PDFPartitioningStage(ProcessingStage[EmptyTask, FileGroupTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], []
-
-    def ray_stage_spec(self) -> dict[str, object]:
-        return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
 
     def num_workers(self) -> int | None:
         return 1

--- a/nemo_curator/stages/synthetic/omni/io.py
+++ b/nemo_curator/stages/synthetic/omni/io.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
 from loguru import logger
 from PIL import Image
 
-from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import EmptyTask
@@ -105,9 +104,6 @@ class HFDatasetImageReaderStage(ProcessingStage[EmptyTask, ImageSampleTask[T_Tas
         self.id_column = id_column
         self.limit = limit
         self.task_type = task_type
-
-    def ray_stage_spec(self) -> dict[str, Any]:
-        return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
 
     def inputs(self) -> tuple[list[str], list[str]]:
         return [], []

--- a/nemo_curator/stages/text/download/base/url_generation.py
+++ b/nemo_curator/stages/text/download/base/url_generation.py
@@ -14,7 +14,6 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
 
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
@@ -75,11 +74,6 @@ class URLGenerationStage(ProcessingStage[EmptyTask, FileGroupTask]):
             )
             for i, url in enumerate(urls)
         ]
-
-    def ray_stage_spec(self) -> dict[str, Any]:
-        return {
-            "is_fanout_stage": True,
-        }
 
     def num_workers(self) -> int | None:
         return 1

--- a/nemo_curator/stages/video/clipping/clip_extraction_stages.py
+++ b/nemo_curator/stages/video/clipping/clip_extraction_stages.py
@@ -105,12 +105,12 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
 
     def ray_stage_spec(self) -> dict[str, Any]:
         """Ray stage specification for this stage."""
-        spec: dict[str, Any] = {RayStageSpecKeys.IS_FANOUT_STAGE: True}
+        spec = super().ray_stage_spec()
         if self.ray_data_num_cpus is not None:
             spec[RayStageSpecKeys.RAY_NUM_CPUS] = self.ray_data_num_cpus
         return spec
 
-    def process(self, task: VideoTask) -> VideoTask:
+    def process(self, task: VideoTask) -> VideoTask | list[VideoTask]:
         video = task.data
 
         if not video.clips:

--- a/tests/stages/audio/alm/pretrain/test_extraction.py
+++ b/tests/stages/audio/alm/pretrain/test_extraction.py
@@ -74,6 +74,16 @@ def _task_with_plan(audio_path: Path, plan: list[dict], extras: dict | None = No
 # ----------------------------------------------------------------------
 
 
+def test_ray_stage_spec(tmp_path: Path) -> None:
+    stage = SnippetExtractionStage(
+        output_dir=str(tmp_path / "snips"),
+        output_audio_tar_path=str(tmp_path / "snips.tar"),
+        dry_run=True,
+    )
+
+    assert stage.ray_stage_spec()["is_fanout_stage"] is True
+
+
 class TestSnippetExtractionStageReal:
     @staticmethod
     def _make_stage(tmp_path: Path, *, output_format: str = "wav") -> tuple[SnippetExtractionStage, Path]:

--- a/tests/stages/audio/alm/pretrain/test_io.py
+++ b/tests/stages/audio/alm/pretrain/test_io.py
@@ -72,6 +72,7 @@ class TestReadLongFormManifestStage:
     def test_worker_defaults(self, tmp_path: Path, manifest_path: Path) -> None:
         stage = ReadLongFormManifestStage(input_manifest=str(manifest_path), audio_dir=str(tmp_path))
         assert stage.num_workers() == 1
+        assert stage.ray_stage_spec()["is_fanout_stage"] is True
         assert stage.xenna_stage_spec() == {}
 
     def test_emits_one_task_per_valid_row(self, tmp_path: Path, manifest_path: Path) -> None:

--- a/tests/stages/audio/segmentation/test_speaker_separation.py
+++ b/tests/stages/audio/segmentation/test_speaker_separation.py
@@ -39,6 +39,11 @@ def _make_task(duration_sec: float = 10.0, sample_rate: int = 48000) -> AudioTas
 
 
 class TestSpeakerSeparationStage:
+    def test_ray_stage_spec(self) -> None:
+        stage = SpeakerSeparationStage()
+
+        assert stage.ray_stage_spec()["is_fanout_stage"] is True
+
     @patch("nemo_curator.stages.audio.segmentation.speaker_separation.SpeakerSeparationStage._initialize_separator")
     def test_process_returns_per_speaker_tasks(self, mock_init: MagicMock) -> None:
         stage = SpeakerSeparationStage(min_duration=0.5)

--- a/tests/stages/audio/test_common.py
+++ b/tests/stages/audio/test_common.py
@@ -176,6 +176,7 @@ class TestManifestReaderStage:
     def test_worker_defaults(self) -> None:
         stage = ManifestReaderStage()
         assert stage.num_workers() == 1
+        assert stage.ray_stage_spec()["is_fanout_stage"] is True
         assert stage.xenna_stage_spec() == {}
 
     def test_reads_multiple_manifests(self, tmp_path: Path) -> None:

--- a/tests/stages/common/test_base.py
+++ b/tests/stages/common/test_base.py
@@ -532,6 +532,20 @@ class MockStageC(ProcessingStage[MockTask, MockTask]):
         return [], []
 
 
+class MockFanoutStage(ProcessingStage[MockTask, MockTask]):
+    name = "MockFanoutStage"
+
+    def process(self, task: MockTask) -> list[MockTask]:
+        return [task]
+
+
+class MockOptionalFanoutStage(ProcessingStage[MockTask, MockTask]):
+    name = "MockOptionalFanoutStage"
+
+    def process(self, task: MockTask) -> MockTask | list[MockTask]:
+        return task
+
+
 class ConcreteCompositeStage(CompositeStage[MockTask, MockTask]):
     """Concrete implementation of CompositeStage for testing."""
 
@@ -752,3 +766,23 @@ class TestCompositeStageWith:
             "xenna_only": True,
         }
         assert modified_stages[0].num_workers() == 4
+
+
+class TestProcessingStageFanoutDetection:
+    def test_base_ray_stage_spec_marks_non_list_outputs_as_non_fanout(self):
+        stage = MockStageA()
+
+        assert stage.is_fanout_stage() is False
+        assert stage.ray_stage_spec()["is_fanout_stage"] is False
+
+    def test_base_ray_stage_spec_marks_list_outputs_as_fanout(self):
+        stage = MockFanoutStage()
+
+        assert stage.is_fanout_stage() is True
+        assert stage.ray_stage_spec()["is_fanout_stage"] is True
+
+    def test_base_ray_stage_spec_marks_union_list_outputs_as_fanout(self):
+        stage = MockOptionalFanoutStage()
+
+        assert stage.is_fanout_stage() is True
+        assert stage.ray_stage_spec()["is_fanout_stage"] is True

--- a/tests/stages/deduplication/semantic/test_pairwise_io.py
+++ b/tests/stages/deduplication/semantic/test_pairwise_io.py
@@ -34,6 +34,7 @@ class TestClusterWiseFilePartitioningStage:
         stage = ClusterWiseFilePartitioningStage("/test/path")
 
         assert stage.num_workers() == 1
+        assert stage.ray_stage_spec()["is_fanout_stage"] is True
         assert stage.xenna_stage_spec() == {}
 
     def test_setup(self):

--- a/tests/stages/image/io/test_image_reader.py
+++ b/tests/stages/image/io/test_image_reader.py
@@ -128,6 +128,7 @@ def test_inputs_outputs_and_name() -> None:
     assert stage.inputs() == ([], [])
     assert stage.outputs() == (["data"], ["image_data", "image_path", "image_id"])
     assert stage.name == "image_reader"
+    assert stage.ray_stage_spec()["is_fanout_stage"] is True
 
 
 def test_init_allows_cpu_when_no_cuda() -> None:

--- a/tests/stages/synthetic/omni/test_io.py
+++ b/tests/stages/synthetic/omni/test_io.py
@@ -23,7 +23,11 @@ from pathlib import Path
 from PIL import Image
 
 from nemo_curator.backends.base import WorkerMetadata
-from nemo_curator.stages.synthetic.omni.io import JsonlSampleWriterStage, merge_output_shards
+from nemo_curator.stages.synthetic.omni.io import (
+    HFDatasetImageReaderStage,
+    JsonlSampleWriterStage,
+    merge_output_shards,
+)
 from nemo_curator.tasks.image import ImageSampleTask, ImageTaskData
 from nemo_curator.tasks.ocr import OCRData
 
@@ -58,6 +62,12 @@ def _write_jsonl(path: Path, records: list[dict]) -> None:
     with path.open("w") as f:
         for rec in records:
             f.write(json.dumps(rec) + "\n")
+
+
+def test_hf_dataset_image_reader_ray_stage_spec(tmp_path: Path) -> None:
+    stage = HFDatasetImageReaderStage(dataset_name="unused", image_dir=tmp_path)
+
+    assert stage.ray_stage_spec()["is_fanout_stage"] is True
 
 
 class TestJsonlSampleWriterStage:


### PR DESCRIPTION
## Description
closes #1613

- infer `is_fanout_stage` from the annotated `process()` return type in the base `ProcessingStage`
- treat both `list[Task]` and unions that include `list[...]` as fanout-capable outputs
- drop the manual `ray_stage_spec()` override from `URLGenerationStage` now that the base behavior covers it
- add focused regression tests for the inferred fanout behavior

## Usage
```python
class URLGenerationStage(ProcessingStage[_EmptyTask, FileGroupTask]):
    def process(self, task: _EmptyTask) -> list[FileGroupTask]:
        ...

assert URLGenerationStage(...).ray_stage_spec()["is_fanout_stage"] is True
```
## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

Validation run locally:
- `python3 -m ruff check nemo_curator/stages/base.py nemo_curator/stages/text/download/base/url_generation.py tests/stages/common/test_base.py tests/stages/text/download/base/test_url_generation.py`
- `python3 -m pytest --noconftest tests/stages/common/test_base.py tests/stages/text/download/base/test_url_generation.py -q` *(blocked in this environment: `cosmos_xenna` is not installed for package import; the full test setup also requires `ray` via `tests/conftest.py`)*