### PR TITLE
fix: use Ray compute strategies instead of concurrency

### DIFF
--- a/nemo_curator/backends/experimental/ray_data/adapter.py
+++ b/nemo_curator/backends/experimental/ray_data/adapter.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 from typing import Any
 
 from loguru import logger
-from ray.data import Dataset
+from ray.data import ActorPoolStrategy, Dataset
 
 from nemo_curator.backends.base import BaseStageAdapter
 from nemo_curator.backends.experimental.utils import RayStageSpecKeys, get_worker_metadata_and_node_id
@@ -89,13 +89,11 @@ class RayDataStageAdapter(BaseStageAdapter):
         if is_actor_stage_:
             map_batches_fn = create_actor_from_stage(self.stage)
             concurrency_kwargs = {
-                "concurrency": calculate_concurrency_for_actors_for_stage(
-                    self.stage, ignore_head_node=ignore_head_node
-                ),
+                "compute": self._actor_compute_strategy(ignore_head_node=ignore_head_node),
             }
         else:
             map_batches_fn = create_task_from_stage(self.stage)
-            concurrency_kwargs = {"concurrency": None}
+            concurrency_kwargs = {}
             max_calls = self.stage.ray_stage_spec().get(RayStageSpecKeys.MAX_CALLS_PER_WORKER, None)
             if max_calls is not None:
                 concurrency_kwargs["max_calls"] = max_calls
@@ -114,6 +112,13 @@ class RayDataStageAdapter(BaseStageAdapter):
             processed_dataset = processed_dataset.repartition(target_num_rows_per_block=1)
 
         return processed_dataset
+
+    def _actor_compute_strategy(self, ignore_head_node: bool = False) -> ActorPoolStrategy:
+        concurrency = calculate_concurrency_for_actors_for_stage(self.stage, ignore_head_node=ignore_head_node)
+        if isinstance(concurrency, tuple):
+            min_size, max_size = concurrency
+            return ActorPoolStrategy(min_size=min_size, max_size=max_size)
+        return ActorPoolStrategy(size=concurrency)
 
 
 def create_actor_from_stage(stage: ProcessingStage) -> type[RayDataStageAdapter]:

--- a/tests/backends/experimental/ray_data/test_adapter.py
+++ b/tests/backends/experimental/ray_data/test_adapter.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+from ray.data import ActorPoolStrategy
+
+from nemo_curator.backends.experimental.ray_data.adapter import RayDataStageAdapter
+from nemo_curator.backends.experimental.utils import RayStageSpecKeys
+from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.tasks import DocumentBatch
+
+
+class ActorStage(ProcessingStage[DocumentBatch, DocumentBatch]):
+    name = "actor_stage"
+
+    def ray_stage_spec(self) -> dict[str, bool]:
+        return {RayStageSpecKeys.IS_ACTOR_STAGE: True}
+
+    def process(self, task: DocumentBatch) -> DocumentBatch:
+        return task
+
+
+class TaskStage(ProcessingStage[DocumentBatch, DocumentBatch]):
+    name = "task_stage"
+
+    def process(self, task: DocumentBatch) -> DocumentBatch:
+        return task
+
+
+class TestRayDataStageAdapter:
+    @patch("nemo_curator.backends.experimental.ray_data.adapter.create_actor_from_stage", return_value=Mock())
+    @patch("nemo_curator.backends.experimental.ray_data.adapter.calculate_concurrency_for_actors_for_stage")
+    def test_actor_stages_use_compute_strategy(self, mock_calculate_concurrency: Mock, mock_create_actor: Mock):
+        dataset = Mock()
+        dataset.map_batches.return_value = dataset
+        mock_calculate_concurrency.return_value = (1, 4)
+        assert mock_create_actor is not None
+
+        adapter = RayDataStageAdapter(ActorStage())
+        adapter.process_dataset(dataset)
+
+        compute = dataset.map_batches.call_args.kwargs["compute"]
+        assert isinstance(compute, ActorPoolStrategy)
+        assert compute.min_size == 1
+        assert compute.max_size == 4
+        assert "concurrency" not in dataset.map_batches.call_args.kwargs
+
+    @patch("nemo_curator.backends.experimental.ray_data.adapter.create_task_from_stage", return_value=Mock())
+    def test_task_stages_do_not_pass_deprecated_concurrency(self, mock_create_task: Mock):
+        dataset = Mock()
+        dataset.map_batches.return_value = dataset
+        assert mock_create_task is not None
+
+        adapter = RayDataStageAdapter(TaskStage())
+        adapter.process_dataset(dataset)
+
+        assert "concurrency" not in dataset.map_batches.call_args.kwargs
+        assert "compute" not in dataset.map_batches.call_args.kwargs


### PR DESCRIPTION
## Description
closes #1520

- replace deprecated Ray Data `concurrency=` usage for actor-backed stages with `compute=ActorPoolStrategy(...)`
- preserve the current autoscaling/fixed-size behavior by translating the existing concurrency calculation into the equivalent actor pool strategy
- stop passing `concurrency=None` for task stages, which lets Ray use its default task pool strategy without triggering the deprecation path
- add focused adapter tests that assert the computed `map_batches()` kwargs

## Usage
```python
adapter = RayDataStageAdapter(stage)
processed = dataset.map_batches(
    actor_cls,
    compute=ray.data.ActorPoolStrategy(min_size=1, max_size=4),
)
```
## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

Validation run locally:
- `python3 -m ruff check nemo_curator/backends/experimental/ray_data/adapter.py tests/backends/experimental/ray_data/test_adapter.py`
- `python3 -m pytest --noconftest tests/backends/experimental/ray_data/test_adapter.py -q` *(blocked in this environment: `ray` is not installed)*