### PR TITLE
docs(audio): document arm64/aarch64 platform constraints

### DIFF
--- a/fern/versions/main/pages/get-started/audio.mdx
+++ b/fern/versions/main/pages/get-started/audio.mdx
@@ -19,11 +19,15 @@ To use NeMo Curator's audio curation modules, ensure you meet the following requ
 * Python 3.10, 3.11, or 3.12
   * packaging &gt;= 22.0
 * uv (for package management and installation)
-* Ubuntu 22.04/20.04
+* **x86_64 Linux** (Ubuntu 22.04/20.04 recommended)
 * NVIDIA GPU (recommended for ASR inference)
   * Volta™ or higher (compute capability 7.0+)
   * CUDA 12 (or above)
 * Audio processing libraries (automatically installed with audio extras)
+
+<Warning>
+**Platform support:** Audio curation requires **x86_64 Linux**. The `audio_cpu` and `audio_cuda12` extras intentionally omit several dependencies on arm64/aarch64 (including NeMo ASR, diarization, and related tooling) because upstream packages do not ship aarch64 wheels. The arm64 NeMo Curator container therefore does not include the full audio stack. Use an amd64 host or container for ASR, diarization, and tagging workflows.
+</Warning>
 
 <Tip>
 If you don't have `uv` installed, refer to the [Installation Guide](/get-started/installation) for setup instructions, or install it quickly with:

--- a/fern/versions/main/pages/reference/infrastructure/container-environments.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/container-environments.mdx
@@ -37,11 +37,15 @@ The primary container includes comprehensive support for all curation modalities
 
 **Container registry:** `nvcr.io/nvidia/nemo-curator:{{ container_version }}`
 
-**Supported modalities:**
+**Supported modalities (amd64/x86_64):**
 - ✅ Text curation (CPU/GPU)
 - ✅ Image curation (GPU required)
 - ✅ Video curation (GPU required, FFmpeg included)
-- ✅ Audio curation (GPU required for ASR)
+- ✅ Audio curation (GPU required for ASR; x86_64 Linux only)
+
+<Note>
+**arm64/aarch64 containers:** Text, image, and video curation are supported on arm64 builds. Audio curation is **not supported** on arm64 because key dependencies (NeMo ASR, diarization, and related packages) are gated to x86_64 Linux in `pyproject.toml`. Missing audio packages on the arm64 image are expected, not a packaging defect. Use an amd64 container or host for audio workflows.
+</Note>
 
 **Pre-installed components:**
 - NeMo Curator with all optional dependencies (`[all]` extras)

--- a/tutorials/audio/README.md
+++ b/tutorials/audio/README.md
@@ -4,6 +4,10 @@ Hands-on tutorials for curating audio data with NeMo Curator.
 
 **New to audio curation?** Start with the [Audio Getting Started Guide](https://docs.nvidia.com/nemo/curator/latest/get-started/audio.html) for setup and basic concepts.
 
+## Platform support
+
+Audio curation requires **x86_64 Linux**. The `audio_cpu` and `audio_cuda12` extras omit several dependencies on arm64/aarch64 (NeMo ASR, diarization, and related tooling) because upstream packages do not ship aarch64 wheels. The arm64 NeMo Curator container therefore does not include the full audio stack — use amd64 for ASR, diarization, and tagging tutorials below.
+
 ## Getting started in 5 minutes
 
 No data download needed — run the ALM pipeline on bundled fixtures:


### PR DESCRIPTION
## Summary
- Document that audio curation requires **x86_64 Linux** and is not supported on arm64/aarch64
- Clarify that missing audio packages on the arm64 container are intentional dependency gating in `pyproject.toml`, not a packaging regression
- Update the audio getting-started guide, container environments reference, and repo tutorial index

Closes #2168

## Context
Follow-up to internal nvbugs thread (6400678, 6409435): users pulling the arm64 image expected audio parity with amd64. Engineering confirmed audio deps are gated to x86_64 Linux because upstream packages (NeMo ASR, diarization stack, etc.) do not ship aarch64 wheels.

## Pages touched
- `fern/versions/main/pages/get-started/audio.mdx`
- `fern/versions/main/pages/reference/infrastructure/container-environments.mdx`
- `tutorials/audio/README.md`

## Test plan
- [x] `fern check` passes (0 errors)
- [ ] Preview Fern docs on PR comment
- [ ] Coordinate merge timing with #2162 if both touch audio pages


Made with [Cursor](https://cursor.com)