### PR TITLE
Added optional language parameter to FastTextLangId and updated logic…

### DIFF
--- a/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
+++ b/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
@@ -93,7 +93,7 @@ class FastTextLangId(DocumentFilter):
         elif isinstance(score, (list, tuple)):
             score = score[0]
             lang = score[1].upper()
-        elif isinstance(score, int):
+        elif isinstance(score, (int, float)):
             score = score
             lang = None
         else :

--- a/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
+++ b/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
@@ -89,7 +89,13 @@ class FastTextLangId(DocumentFilter):
         if isinstance(score, str):
             score_lang = eval(score)  # noqa: S307
             score = score_lang[0]
-            lang = score_lang[1]
+            lang = score_lang[1].upper()
+        elif isinstance(score, (list, tuple)):
+            score = score[0]
+            lang = score[1].upper()
+        else :
+            msg = "score must be either a string or a list/tuple containing int score and lang code"
+            raise ValueError(msg)
         if self._lang_code:
             return score >= self._cutoff and lang == self._lang_code
         return score >= self._cutoff

--- a/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
+++ b/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
@@ -56,12 +56,12 @@ class FastTextQualityFilter(DocumentFilter):
 
 
 class FastTextLangId(DocumentFilter):
-    def __init__(self, model_path: str | None = None, min_langid_score: float = 0.3):
+    def __init__(self, model_path: str | None = None, min_langid_score: float = 0.3, lang: str | None = None):
         if model_path is None:
             msg = "Must provide a valid path to a FastText model to identify languages with this filter"
             raise ValueError(msg)
         self._model_path = model_path
-        self._lang_code = None
+        self._lang_code = lang.upper() if lang else None
         self._cutoff = min_langid_score
         self._name = "lang_id"
 
@@ -87,6 +87,9 @@ class FastTextLangId(DocumentFilter):
 
     def keep_document(self, score: float | str) -> bool:
         if isinstance(score, str):
-            score = eval(score)  # noqa: S307
-
-        return score[0] >= self._cutoff
+            score_lang = eval(score)  # noqa: S307
+            score = score_lang[0]
+            lang = score_lang[1]
+        if self._lang_code:
+            return score >= self._cutoff and lang == self._lang_code
+        return score >= self._cutoff

--- a/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
+++ b/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
@@ -90,11 +90,7 @@ class FastTextLangId(DocumentFilter):
             score_lang = eval(score)  # noqa: S307
             score = score_lang[0]
             lang = score_lang[1].upper()
-        elif isinstance(score, (list, tuple)):
-            score = score[0]
-            lang = score[1].upper()
         elif isinstance(score, (int, float)):
-            score = score
             lang = None
         else :
             msg = "score must be either a string or a list/tuple containing int score and lang code"

--- a/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
+++ b/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
@@ -95,7 +95,7 @@ class FastTextLangId(DocumentFilter):
             lang = score[1].upper()
         else :
             msg = "score must be either a string or a list/tuple containing int score and lang code"
-            raise ValueError(msg)
+            raise TypeError(msg)
         if self._lang_code:
             return score >= self._cutoff and lang == self._lang_code
         return score >= self._cutoff

--- a/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
+++ b/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
@@ -93,7 +93,7 @@ class FastTextLangId(DocumentFilter):
         elif isinstance(score, (int, float)):
             lang = None
         else :
-            msg = "score must be either a string or a list/tuple containing int score and lang code"
+            msg = "score must be either a string convertible to list or an int/float containing lang score"
             raise TypeError(msg)
         if self._lang_code:
             return score >= self._cutoff and lang == self._lang_code

--- a/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
+++ b/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
@@ -93,6 +93,9 @@ class FastTextLangId(DocumentFilter):
         elif isinstance(score, (list, tuple)):
             score = score[0]
             lang = score[1].upper()
+        elif isinstance(score, int):
+            score = score
+            lang = None
         else :
             msg = "score must be either a string or a list/tuple containing int score and lang code"
             raise TypeError(msg)

--- a/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
+++ b/nemo_curator/stages/text/filters/fasttext/fasttext_filters.py
@@ -90,10 +90,8 @@ class FastTextLangId(DocumentFilter):
             score_lang = eval(score)  # noqa: S307
             score = score_lang[0]
             lang = score_lang[1].upper()
-        elif isinstance(score, (int, float)):
-            lang = None
         else :
-            msg = "score must be either a string convertible to list or an int/float containing lang score"
+            msg = "score must be a string convertible to list"
             raise TypeError(msg)
         if self._lang_code:
             return score >= self._cutoff and lang == self._lang_code


### PR DESCRIPTION
Add optional language filtering support to `FastTextLangId` filter.

## Description

Adds an optional `lang` parameter to `FastTextLangId` that allows filtering documents by a specific language in addition to the existing minimum language identification confidence score.

When `lang` is provided, a document is kept only if:
- the predicted language identification score is greater than or equal to `min_langid_score`, and
- the predicted language matches the specified language code.

If `lang` is not specified, the filter retains its previous behavior and filters documents only by the confidence score.

Closes #855.

## Usage

```python
from nemo_curator.stages.text.filters.fasttext.fasttext_filters import FastTextLangId

lang_filter = FastTextLangId(
    model_path="/path/to/model",
    min_langid_score=0.8,
    lang="en",
)
```

## Checklist

- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.