### PR TITLE
fix(deps): bump etcd 3.5.21->3.5.30 to clear grpc-go auth-bypass CVE

### DIFF
--- a/docker/common/install_etcd_nats.sh
+++ b/docker/common/install_etcd_nats.sh
@@ -15,10 +15,10 @@
 
 set -xeuo pipefail
 
-# Versions pinned to match upstream ai-dynamo/dynamo container/context.yaml,
-# so Dynamo-Curator integration runs the same etcd/nats-server binaries as
-# Dynamo's own runtime images.
-ETCD_VERSION=3.5.30
+# nats-server matches upstream ai-dynamo/dynamo container/context.yaml. etcd
+# leads Dynamo's pin (3.5.30) to the latest 3.5.x patch to clear the bundled
+# grpc-go + x/net CVEs; 3.5.x binaries stay wire-compatible with Dynamo.
+ETCD_VERSION=3.5.32
 NATS_VERSION=2.10.28
 
 for i in "$@"; do

--- a/docker/common/install_etcd_nats.sh
+++ b/docker/common/install_etcd_nats.sh
@@ -18,7 +18,7 @@ set -xeuo pipefail
 # Versions pinned to match upstream ai-dynamo/dynamo container/context.yaml,
 # so Dynamo-Curator integration runs the same etcd/nats-server binaries as
 # Dynamo's own runtime images.
-ETCD_VERSION=3.5.21
+ETCD_VERSION=3.5.30
 NATS_VERSION=2.10.28
 
 for i in "$@"; do


### PR DESCRIPTION
## Description
Bumps the bundled `etcd`/`etcdctl` binaries (`docker/common/install_etcd_nats.sh`) from 3.5.21 → 3.5.32 to clear three CVEs in their vendored Go dependencies, all flagged in the container scan:

| Vendored dep | 1.59→ | Advisory |
|---|---|---|
| `google.golang.org/grpc` | v1.59.0 → v1.79.3 | GHSA-p77j-4mvh-x3m3 — auth bypass (critical) |
| `golang.org/x/net` | v0.38.0 → v0.55.0 | CVE-2026-39821 — idna privilege escalation (high) |
| `go.opentelemetry.io/otel/sdk` | v1.20.0 → v1.43.0 | GHSA-hfvc-g4fc-pqhx — PATH hijacking (high) |

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
