### PR TITLE
fix(deps): remove system ffmpeg from container image (part 2/2)

### DIFF
--- a/benchmarking/tools/ci_benchmark_launcher.sh
+++ b/benchmarking/tools/ci_benchmark_launcher.sh
@@ -24,6 +24,11 @@ mkdir -p "/tmp/curator/results/${BRANCH_NAME}"
 # discarded with the container.
 apt-get update -qq && apt-get install -y --no-install-recommends lynx
 
+# ffmpeg not in image (CVE removal); audio/video benchmarks need it at runtime
+if [[ "${ENTRY_NAME}" == audio_* ]] || [[ "${ENTRY_NAME}" == video_* ]]; then
+    apt-get install -y --no-install-recommends ffmpeg
+fi
+
 cd /opt/Curator
 uv pip install GitPython pynvml pyyaml rich
 

--- a/benchmarking/tools/ci_benchmark_launcher.sh
+++ b/benchmarking/tools/ci_benchmark_launcher.sh
@@ -24,9 +24,11 @@ mkdir -p "/tmp/curator/results/${BRANCH_NAME}"
 # discarded with the container.
 apt-get update -qq && apt-get install -y --no-install-recommends lynx
 
-# ffmpeg not in image (CVE removal); audio/video benchmarks need it at runtime
-if [[ "${ENTRY_NAME}" == audio_* ]] || [[ "${ENTRY_NAME}" == video_* ]]; then
+# ffmpeg not in image (CVE removal); install at runtime per modality
+if [[ "${ENTRY_NAME}" == audio_* ]]; then
     apt-get install -y --no-install-recommends ffmpeg
+elif [[ "${ENTRY_NAME}" == video_* ]]; then
+    bash /opt/Curator/docker/common/install_ffmpeg.sh
 fi
 
 cd /opt/Curator

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,11 +62,6 @@ RUN uv venv ${UV_PROJECT_ENVIRONMENT} --python /usr/bin/python3.13 --system-site
 
 FROM build AS nemo_curator_dep
 
-# Install FFmpeg
-COPY docker/common/install_ffmpeg.sh .
-RUN bash install_ffmpeg.sh && \
-    rm install_ffmpeg.sh
-
 # Install etcd + nats-server (required by the Dynamo inference backend)
 COPY docker/common/install_etcd_nats.sh .
 RUN bash install_etcd_nats.sh && \

--- a/nemo_curator/stages/video/clipping/clip_extraction_stages.py
+++ b/nemo_curator/stages/video/clipping/clip_extraction_stages.py
@@ -14,6 +14,7 @@
 
 import copy
 import pathlib
+import shutil
 import subprocess
 import uuid
 from dataclasses import dataclass
@@ -73,6 +74,9 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
         Args:
             worker_metadata (WorkerMetadata, optional): Information about the worker (provided by some backends)
         """
+        if not shutil.which("ffmpeg"):
+            msg = "ClipTranscodingStage requires 'ffmpeg'. Install with: sudo apt-get install -y ffmpeg"
+            raise RuntimeError(msg)
         if self.encoder not in {"libopenh264", "libx264", "h264_nvenc"}:
             error_msg = f"Expected encoder of `libopenh264`, `libx264`, or `h264_nvenc`. Got {self.encoder}"
             raise ValueError(error_msg)

--- a/nemo_curator/stages/video/clipping/clip_extraction_stages.py
+++ b/nemo_curator/stages/video/clipping/clip_extraction_stages.py
@@ -75,7 +75,7 @@ class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
             worker_metadata (WorkerMetadata, optional): Information about the worker (provided by some backends)
         """
         if not shutil.which("ffmpeg"):
-            msg = "ClipTranscodingStage requires 'ffmpeg'. Install with: sudo apt-get install -y ffmpeg"
+            msg = "ClipTranscodingStage requires 'ffmpeg' built with libopenh264/NVENC support. See docker/common/install_ffmpeg.sh."
             raise RuntimeError(msg)
         if self.encoder not in {"libopenh264", "libx264", "h264_nvenc"}:
             error_msg = f"Expected encoder of `libopenh264`, `libx264`, or `h264_nvenc`. Got {self.encoder}"

--- a/nemo_curator/stages/video/clipping/video_frame_extraction.py
+++ b/nemo_curator/stages/video/clipping/video_frame_extraction.py
@@ -122,7 +122,7 @@ class VideoFrameExtractionStage(ProcessingStage[VideoTask, VideoTask]):
         """
         uses_ffmpeg = self.decoder_mode != "pynvc" or not _PYNVC_AVAILABLE
         if uses_ffmpeg and not shutil.which("ffmpeg"):
-            msg = "VideoFrameExtractionStage requires 'ffmpeg'. Install with: sudo apt-get install -y ffmpeg"
+            msg = "VideoFrameExtractionStage requires 'ffmpeg' built with libopenh264/NVENC support. See docker/common/install_ffmpeg.sh."
             raise RuntimeError(msg)
         if self.decoder_mode == "pynvc":
             if _PYNVC_AVAILABLE:

--- a/nemo_curator/stages/video/clipping/video_frame_extraction.py
+++ b/nemo_curator/stages/video/clipping/video_frame_extraction.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,6 +39,9 @@ def get_frames_from_ffmpeg(
     use_gpu: bool = False,
 ) -> npt.NDArray[np.uint8] | None:
     """Fetch resized frames for video."""
+    if not shutil.which("ffmpeg"):
+        msg = "get_frames_from_ffmpeg requires 'ffmpeg'. Install with: sudo apt-get install -y ffmpeg"
+        raise RuntimeError(msg)
     if use_gpu:
         command = [
             "ffmpeg",

--- a/nemo_curator/stages/video/clipping/video_frame_extraction.py
+++ b/nemo_curator/stages/video/clipping/video_frame_extraction.py
@@ -39,9 +39,6 @@ def get_frames_from_ffmpeg(
     use_gpu: bool = False,
 ) -> npt.NDArray[np.uint8] | None:
     """Fetch resized frames for video."""
-    if not shutil.which("ffmpeg"):
-        msg = "get_frames_from_ffmpeg requires 'ffmpeg'. Install with: sudo apt-get install -y ffmpeg"
-        raise RuntimeError(msg)
     if use_gpu:
         command = [
             "ffmpeg",
@@ -123,6 +120,10 @@ class VideoFrameExtractionStage(ProcessingStage[VideoTask, VideoTask]):
         Args:
             worker_metadata (WorkerMetadata, optional): Information about the worker (provided by some backends)
         """
+        uses_ffmpeg = self.decoder_mode != "pynvc" or not _PYNVC_AVAILABLE
+        if uses_ffmpeg and not shutil.which("ffmpeg"):
+            msg = "VideoFrameExtractionStage requires 'ffmpeg'. Install with: sudo apt-get install -y ffmpeg"
+            raise RuntimeError(msg)
         if self.decoder_mode == "pynvc":
             if _PYNVC_AVAILABLE:
                 self.pynvc_frame_extractor = PyNvcFrameExtractor(

--- a/nemo_curator/utils/windowing_utils.py
+++ b/nemo_curator/utils/windowing_utils.py
@@ -140,7 +140,7 @@ def split_video_into_windows(  # noqa: PLR0913
 
         if return_bytes:
             if not shutil.which("ffmpeg"):
-                msg = "split_video_into_windows with return_bytes=True requires 'ffmpeg'. Install with: sudo apt-get install -y ffmpeg"
+                msg = "split_video_into_windows with return_bytes=True requires 'ffmpeg' built with libopenh264/NVENC support. See docker/common/install_ffmpeg.sh."
                 raise RuntimeError(msg)
             if len(windows) == 1:
                 return [mp4_bytes], video_frames, windows

--- a/nemo_curator/utils/windowing_utils.py
+++ b/nemo_curator/utils/windowing_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import shutil
 import subprocess
 from dataclasses import dataclass
 
@@ -138,6 +139,9 @@ def split_video_into_windows(  # noqa: PLR0913
                 index += count
 
         if return_bytes:
+            if not shutil.which("ffmpeg"):
+                msg = "split_video_into_windows with return_bytes=True requires 'ffmpeg'. Install with: sudo apt-get install -y ffmpeg"
+                raise RuntimeError(msg)
             if len(windows) == 1:
                 return [mp4_bytes], video_frames, windows
 

--- a/tests/L0_Unit_Test_GPU.sh
+++ b/tests/L0_Unit_Test_GPU.sh
@@ -26,4 +26,8 @@ uv sync --no-progress --link-mode copy --locked $EXTRA_FLAGS --group test
 
 export CUSTOM_HF_DATASET=/home/TestData/HF_HOME
 
+if [[ "$GPU_TEST_PATHS" == *"stages/audio"* ]]; then
+    apt-get update -qq && apt-get install -y --no-install-recommends ffmpeg
+fi
+
 CUDA_VISIBLE_DEVICES="0,1" coverage run -a --source=nemo_curator -m pytest -m gpu $GPU_TEST_PATHS

--- a/tests/stages/video/clipping/test_clip_transcoding_stage.py
+++ b/tests/stages/video/clipping/test_clip_transcoding_stage.py
@@ -37,6 +37,11 @@ class MockGpuInfo:
 class TestClipTranscodingStage:
     """Test cases for ClipTranscodingStage."""
 
+    @pytest.fixture(autouse=True)
+    def _ffmpeg_available(self) -> None:
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            yield
+
     @classmethod
     def setup_class(cls) -> None:
         """Set up class-level fixtures."""

--- a/tests/stages/video/clipping/test_video_frame_extraction.py
+++ b/tests/stages/video/clipping/test_video_frame_extraction.py
@@ -189,6 +189,11 @@ class TestGetFramesFromFfmpeg:
 class TestVideoFrameExtractionStage:
     """Test suite for VideoFrameExtractionStage class."""
 
+    @pytest.fixture(autouse=True)
+    def _ffmpeg_available(self) -> Any:
+        with patch("shutil.which", return_value="/usr/bin/ffmpeg"):
+            yield
+
     def setup_method(self) -> None:
         """Set up test fixtures."""
         self.output_hw = (27, 48)


### PR DESCRIPTION
## Description
Drops the install_ffmpeg.sh build step from the nemo_curator_dep stage, clearing CVE-2026-40962 (Critical) and 3 High CVEs tied to ffmpeg 8.0.1. The script is kept at docker/common/install_ffmpeg.sh for reference.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
