### PR TITLE
fix(benchmarks): bump video timeout_s for ffmpeg source-build overhead

### DIFF
--- a/benchmarking/nightly-benchmark.yaml
+++ b/benchmarking/nightly-benchmark.yaml
@@ -877,7 +877,7 @@ entries:
       --video-dir={dataset:videos,mp4}
       --model-dir={dataset:videos_model_weights,files}
       --video-limit=1000
-    timeout_s: 400
+    timeout_s: 800
     sink_data:
       - name: slack
         ping_on_failure:
@@ -1116,7 +1116,7 @@ entries:
       --aesthetic-threshold=3.5
       --transnetv2-frame-decoder-mode ffmpeg_cpu
       --video-limit=1000
-    timeout_s: 1200
+    timeout_s: 1800
     sink_data:
       - name: slack
         ping_on_failure:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,11 +62,6 @@ RUN uv venv ${UV_PROJECT_ENVIRONMENT} --python /usr/bin/python3.13 --system-site
 
 FROM build AS nemo_curator_dep
 
-# Install FFmpeg
-COPY docker/common/install_ffmpeg.sh .
-RUN bash install_ffmpeg.sh && \
-    rm install_ffmpeg.sh
-
 # Install etcd + nats-server (required by the Dynamo inference backend)
 COPY docker/common/install_etcd_nats.sh .
 RUN bash install_etcd_nats.sh && \


### PR DESCRIPTION
## Description
video_embedding_xenna: 400→800 (wall 627s, was hitting min_timeout_s=600 floor) 
video_transnetv2_..._raydata: 1200→1800 (wall 1268s, killed 1 item from completion)

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
