### PR TITLE
fix: validate PyArrow table columns

### DIFF
--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -190,8 +190,10 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
 
         # Check required columns exist
         missing_data_attrs = []
+        get_columns = getattr(task, "get_columns", None)
+        data_columns = get_columns() if callable(get_columns) else getattr(task.data, "column_names", ())
         for attr in required_data_attrs:
-            if not hasattr(task.data, attr):
+            if not hasattr(task.data, attr) and attr not in data_columns:
                 missing_data_attrs.append(attr)
 
         # Log warning with missing attributes

--- a/tests/stages/common/test_base.py
+++ b/tests/stages/common/test_base.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
+
+import pandas as pd
+import pyarrow as pa
 import pytest
 
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.resources import Resources
-from nemo_curator.tasks import Task
+from nemo_curator.tasks import DocumentBatch, Task
 
 
 class MockTask(Task[dict]):
@@ -64,6 +68,22 @@ class BackendConfiguredStage(ConcreteProcessingStage):
 
     def num_workers(self) -> int | None:
         return 2
+
+
+@pytest.mark.parametrize("table_factory", [pa.table, pd.DataFrame], ids=["pyarrow", "pandas"])
+def test_validate_input_with_tabular_columns(
+    table_factory: Callable[[dict[str, list[str]]], pa.Table | pd.DataFrame],
+) -> None:
+    class TextProcessingStage(ConcreteProcessingStage):
+        def inputs(self) -> tuple[list[str], list[str]]:
+            return ["data"], ["text content"]
+
+    stage = TextProcessingStage()
+    valid_batch = DocumentBatch(dataset_name="test", data=table_factory({"text content": ["hello"]}))
+    missing_batch = DocumentBatch(dataset_name="test", data=table_factory({"other": ["hello"]}))
+
+    assert stage.validate_input(valid_batch)
+    assert not stage.validate_input(missing_batch)
 
 
 class TestProcessingStageWith:


### PR DESCRIPTION
## Description

Closes #2151.

Processing stage input validation now recognizes columns exposed through a PyArrow table's `column_names`, while preserving attribute-based validation for other task data types. A regression test covers both present and missing PyArrow columns.

## Usage

N/A — this fixes validation for existing `DocumentBatch` inputs and adds no new API.

## Checklist

- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
