### PR TITLE
fix: read remote parquet removal directories

### DIFF
--- a/nemo_curator/stages/text/deduplication/removal.py
+++ b/nemo_curator/stages/text/deduplication/removal.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import pandas as pd
+from fsspec.core import split_protocol, url_to_fs
 
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
@@ -74,11 +75,23 @@ class TextDuplicatesRemovalStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         input_df_min_max_time = time.perf_counter() - input_df_t0
         # Filter the parquet files for IDs to remove within this range
         read_dupes_t0 = time.perf_counter()
+        read_path = self.ids_to_remove_path
+        read_kwargs = self.read_kwargs.copy()
+        protocol, _ = split_protocol(read_path)
+        if protocol not in (None, "file"):
+            filesystem = read_kwargs.get("filesystem")
+            if filesystem is None:
+                filesystem, read_path = url_to_fs(read_path, **read_kwargs.pop("storage_options", {}))
+                read_kwargs["filesystem"] = filesystem
+            else:
+                read_kwargs.pop("storage_options", None)
+                strip_protocol = getattr(filesystem, "_strip_protocol", None)
+                read_path = strip_protocol(read_path) if strip_protocol else split_protocol(read_path)[1]
         removal_df = pd.read_parquet(
-            self.ids_to_remove_path,
+            read_path,
             filters=[(self.duplicate_id_field, ">=", min_id), (self.duplicate_id_field, "<=", max_id)],
             columns=[self.duplicate_id_field],
-            **self.read_kwargs,
+            **read_kwargs,
         )
         read_dupes_time = time.perf_counter() - read_dupes_t0
 

--- a/nemo_curator/stages/text/deduplication/removal.py
+++ b/nemo_curator/stages/text/deduplication/removal.py
@@ -60,6 +60,19 @@ class TextDuplicatesRemovalStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         super().__init__()
         self.name = "DuplicatesRemovalStage"
         self.read_kwargs = self.read_kwargs.copy() if self.read_kwargs else {}
+        self._read_path = self.ids_to_remove_path
+        protocol, _ = split_protocol(self._read_path)
+        if protocol not in (None, "file"):
+            filesystem = self.read_kwargs.get("filesystem")
+            if filesystem is None:
+                filesystem, self._read_path = url_to_fs(self._read_path, **self.read_kwargs.pop("storage_options", {}))
+                self.read_kwargs["filesystem"] = filesystem
+            else:
+                self.read_kwargs.pop("storage_options", None)
+                strip_protocol = getattr(filesystem, "_strip_protocol", None)
+                self._read_path = (
+                    strip_protocol(self._read_path) if strip_protocol else split_protocol(self._read_path)[1]
+                )
 
     def process(self, task: DocumentBatch) -> DocumentBatch:
         """
@@ -75,23 +88,11 @@ class TextDuplicatesRemovalStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         input_df_min_max_time = time.perf_counter() - input_df_t0
         # Filter the parquet files for IDs to remove within this range
         read_dupes_t0 = time.perf_counter()
-        read_path = self.ids_to_remove_path
-        read_kwargs = self.read_kwargs.copy()
-        protocol, _ = split_protocol(read_path)
-        if protocol not in (None, "file"):
-            filesystem = read_kwargs.get("filesystem")
-            if filesystem is None:
-                filesystem, read_path = url_to_fs(read_path, **read_kwargs.pop("storage_options", {}))
-                read_kwargs["filesystem"] = filesystem
-            else:
-                read_kwargs.pop("storage_options", None)
-                strip_protocol = getattr(filesystem, "_strip_protocol", None)
-                read_path = strip_protocol(read_path) if strip_protocol else split_protocol(read_path)[1]
         removal_df = pd.read_parquet(
-            read_path,
+            self._read_path,
             filters=[(self.duplicate_id_field, ">=", min_id), (self.duplicate_id_field, "<=", max_id)],
             columns=[self.duplicate_id_field],
-            **read_kwargs,
+            **self.read_kwargs,
         )
         read_dupes_time = time.perf_counter() - read_dupes_t0
 

--- a/tests/stages/text/deduplication/test_removal.py
+++ b/tests/stages/text/deduplication/test_removal.py
@@ -116,15 +116,26 @@ class TestTextDuplicatesRemovalStage:
         filesystem, removal_path = fsspec.core.url_to_fs(removal_url)
         pd.DataFrame({"id": [2, 4]}).to_parquet(f"{removal_url}/ids.parquet")
 
-        stage = TextDuplicatesRemovalStage(ids_to_remove_path=removal_url)
-        with patch(
-            "nemo_curator.stages.text.deduplication.removal.pd.read_parquet", wraps=pd.read_parquet
-        ) as read_parquet:
+        with (
+            patch(
+                "nemo_curator.stages.text.deduplication.removal.url_to_fs", wraps=fsspec.core.url_to_fs
+            ) as url_to_fs,
+            patch(
+                "nemo_curator.stages.text.deduplication.removal.pd.read_parquet", wraps=pd.read_parquet
+            ) as read_parquet,
+        ):
+            stage = TextDuplicatesRemovalStage(ids_to_remove_path=removal_url)
             result = stage.process(sample_document_batch)
+            stage.process(sample_document_batch)
+            provided_stage = TextDuplicatesRemovalStage(
+                ids_to_remove_path=removal_url, read_kwargs={"filesystem": filesystem}
+            )
+            provided_stage.process(sample_document_batch)
 
         assert sorted(result.to_pandas()[CURATOR_DEDUP_ID_STR].tolist()) == [1, 3, 5]
-        assert read_parquet.call_args.args[0] == removal_path
-        assert read_parquet.call_args.kwargs["filesystem"] is filesystem
+        assert all(call.args[0] == removal_path for call in read_parquet.call_args_list)
+        assert all(call.kwargs["filesystem"] is filesystem for call in read_parquet.call_args_list)
+        url_to_fs.assert_called_once_with(removal_url)
 
     @patch("pandas.read_parquet")
     def test_process_with_no_matching_ids(

--- a/tests/stages/text/deduplication/test_removal.py
+++ b/tests/stages/text/deduplication/test_removal.py
@@ -15,6 +15,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import fsspec
 import pandas as pd
 import pytest
 
@@ -109,6 +110,21 @@ class TestTextDuplicatesRemovalStage:
         assert all(
             stage._custom_metrics[k] > 0 for k in ["input_df_min_max_time", "read_dupes_time", "id_removal_time"]
         )
+
+    def test_process_reads_remote_removal_directory(self, sample_document_batch: DocumentBatch):
+        removal_url = "memory://curator-test/removals"
+        filesystem, removal_path = fsspec.core.url_to_fs(removal_url)
+        pd.DataFrame({"id": [2, 4]}).to_parquet(f"{removal_url}/ids.parquet")
+
+        stage = TextDuplicatesRemovalStage(ids_to_remove_path=removal_url)
+        with patch(
+            "nemo_curator.stages.text.deduplication.removal.pd.read_parquet", wraps=pd.read_parquet
+        ) as read_parquet:
+            result = stage.process(sample_document_batch)
+
+        assert sorted(result.to_pandas()[CURATOR_DEDUP_ID_STR].tolist()) == [1, 3, 5]
+        assert read_parquet.call_args.args[0] == removal_path
+        assert read_parquet.call_args.kwargs["filesystem"] is filesystem
 
     @patch("pandas.read_parquet")
     def test_process_with_no_matching_ids(


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

Closes #1217.

Normalize remote removal-dataset URLs to the path expected by their filesystem before passing them to PyArrow. This keeps directory discovery on GCS and other fsspec backends within the same base path, while preserving caller-provided filesystems and storage options. An in-memory remote-filesystem regression test covers the directory-read path.

## Usage
<!-- Potentially add a usage example below -->
```python
TextDuplicatesRemovalStage(
    ids_to_remove_path="gs://bucket/removal-ids",
    read_kwargs={"storage_options": {"token": "cloud"}},
)
```

## Testing

- `tests/stages/text/deduplication/test_removal.py` — 6 passed.
- `ruff check nemo_curator/stages/text/deduplication/removal.py tests/stages/text/deduplication/test_removal.py` — passed.
- `ruff format --check nemo_curator/stages/text/deduplication/removal.py tests/stages/text/deduplication/test_removal.py` — passed.

## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
