### PR TITLE
Interleaved Lance Reader

### DIFF
--- a/nemo_curator/core/utils.py
+++ b/nemo_curator/core/utils.py
@@ -274,16 +274,3 @@ def split_table_by_group(
     starts = [0, *split_points]
     ends = [*split_points, num_rows]
     return [table.slice(start, end - start) for start, end in zip(starts, ends, strict=True)]
-
-
-def split_table_by_group_max_bytes(
-    table: pa.Table,
-    group_column: str,
-    max_batch_bytes: int | None,
-) -> list[pa.Table]:
-    """Backward-compatible wrapper for byte-limited interleaved batching."""
-    return split_table_by_group(
-        table,
-        group_column,
-        max_batch_bytes=max_batch_bytes,
-    )

--- a/nemo_curator/core/utils.py
+++ b/nemo_curator/core/utils.py
@@ -214,54 +214,76 @@ def init_cluster(  # noqa: PLR0913
     return proc
 
 
+def split_table_by_group(
+    table: pa.Table,
+    group_column: str,
+    *,
+    max_batch_bytes: int | None = None,
+    max_batch_rows: int | None = None,
+) -> list[pa.Table]:
+    """Split an Arrow table without reordering or splitting consecutive groups.
+
+    Rows for each group must be consecutive. If a single group exceeds a batch
+    limit, it is still emitted as one chunk.
+    """
+    for name, value in (("max_batch_bytes", max_batch_bytes), ("max_batch_rows", max_batch_rows)):
+        if value is not None and value <= 0:
+            msg = f"{name} must be > 0, got {value}"
+            raise ValueError(msg)
+
+    if group_column not in table.column_names:
+        msg = f"Group column '{group_column}' not found in table"
+        raise ValueError(msg)
+    if table.num_rows == 0:
+        return [table]
+
+    chunked = table[group_column]
+    groups = chunked.combine_chunks() if len(chunked.chunks) > 1 else chunked.chunks[0]
+    if pc.any(pc.is_null(groups)).as_py():
+        msg = f"Group column '{group_column}' contains null values"
+        raise ValueError(msg)
+    if max_batch_bytes is None and max_batch_rows is None:
+        return [table]
+
+    num_rows = table.num_rows
+    group_change = pc.not_equal(groups.slice(1), groups.slice(0, num_rows - 1))
+    group_ends = [*(point + 1 for point in pc.indices_nonzero(group_change).to_pylist()), num_rows]
+
+    split_points: list[int] = []
+    chunk_start = 0
+    chunk_bytes = 0.0
+    chunk_rows = 0
+    avg_bytes_per_row = table.nbytes / num_rows
+    for group_end in group_ends:
+        group_start = chunk_start + chunk_rows
+        group_rows = group_end - group_start
+        group_bytes = group_rows * avg_bytes_per_row
+        exceeds_batch_limit = chunk_rows > 0 and (
+            (max_batch_bytes is not None and chunk_bytes + group_bytes > max_batch_bytes)
+            or (max_batch_rows is not None and chunk_rows + group_rows > max_batch_rows)
+        )
+        if exceeds_batch_limit:
+            split_points.append(group_start)
+            chunk_start = group_start
+            chunk_bytes = 0.0
+            chunk_rows = 0
+
+        chunk_bytes += group_bytes
+        chunk_rows += group_rows
+
+    starts = [0, *split_points]
+    ends = [*split_points, num_rows]
+    return [table.slice(start, end - start) for start, end in zip(starts, ends, strict=True)]
+
+
 def split_table_by_group_max_bytes(
     table: pa.Table,
     group_column: str,
     max_batch_bytes: int | None,
 ) -> list[pa.Table]:
-    """Split an Arrow table by approximate byte size without splitting group rows.
-
-    Each unique value in ``group_column`` is kept in a single output table.
-    If a single group exceeds ``max_batch_bytes``, it is still emitted as one chunk.
-
-    Note: null values in ``group_column`` are grouped together (consecutive
-    nulls are not split).  Callers should ensure the column is non-nullable
-    or handle nulls upstream.
-    """
-    if max_batch_bytes is None or table.num_rows == 0:
-        return [table]
-    if max_batch_bytes <= 0:
-        msg = f"max_batch_bytes must be > 0, got {max_batch_bytes}"
-        raise ValueError(msg)
-    if group_column not in table.column_names:
-        msg = f"Group column '{group_column}' not found in table"
-        raise ValueError(msg)
-
-    sort_indices = pc.sort_indices(table, sort_keys=[(group_column, "ascending")])
-    table = table.take(sort_indices)
-    col = table[group_column]
-    n = table.num_rows
-
-    if n <= 1:
-        return [table]
-
-    ne = pc.not_equal(col.slice(1), col.slice(0, n - 1))
-    split_points = pc.indices_nonzero(ne).to_pylist()
-    group_starts = [0, *(p + 1 for p in split_points)]
-    group_ends = [*(p + 1 for p in split_points), n]
-
-    avg_bytes_per_row = table.nbytes / n
-    chunk_split_indices: list[int] = []
-    chunk_bytes = 0.0
-    for i, (gs, ge) in enumerate(zip(group_starts, group_ends, strict=True)):
-        group_bytes = (ge - gs) * avg_bytes_per_row
-        if i > 0 and chunk_bytes > 0 and (chunk_bytes + group_bytes > max_batch_bytes):
-            chunk_split_indices.append(gs)
-            chunk_bytes = 0.0
-        chunk_bytes += group_bytes
-
-    if not chunk_split_indices:
-        return [table]
-    all_starts = [0, *chunk_split_indices]
-    all_ends = [*chunk_split_indices, n]
-    return [table.slice(s, e - s) for s, e in zip(all_starts, all_ends, strict=True)]
+    """Backward-compatible wrapper for byte-limited interleaved batching."""
+    return split_table_by_group(
+        table,
+        group_column,
+        max_batch_bytes=max_batch_bytes,
+    )

--- a/nemo_curator/stages/interleaved/__init__.py
+++ b/nemo_curator/stages/interleaved/__init__.py
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nemo_curator.stages.interleaved.lance import InterleavedLanceReader, InterleavedLanceReaderStage
 from nemo_curator.stages.interleaved.stages import (
     BaseInterleavedAnnotatorStage,
     BaseInterleavedFilterStage,
     InterleavedAspectRatioFilterStage,
 )
 
-__all__ = ["BaseInterleavedAnnotatorStage", "BaseInterleavedFilterStage", "InterleavedAspectRatioFilterStage"]
+__all__ = [
+    "BaseInterleavedAnnotatorStage",
+    "BaseInterleavedFilterStage",
+    "InterleavedAspectRatioFilterStage",
+    "InterleavedLanceReader",
+    "InterleavedLanceReaderStage",
+]

--- a/nemo_curator/stages/interleaved/__init__.py
+++ b/nemo_curator/stages/interleaved/__init__.py
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo_curator.stages.interleaved.lance import InterleavedLanceReader, InterleavedLanceReaderStage
+from importlib import import_module
+
 from nemo_curator.stages.interleaved.stages import (
     BaseInterleavedAnnotatorStage,
     BaseInterleavedFilterStage,
     InterleavedAspectRatioFilterStage,
 )
+
+_LAZY = {
+    "InterleavedLanceReader": ".lance",
+    "InterleavedLanceReaderStage": ".lance",
+}
 
 __all__ = [
     "BaseInterleavedAnnotatorStage",
@@ -26,3 +32,11 @@ __all__ = [
     "InterleavedLanceReader",
     "InterleavedLanceReaderStage",
 ]
+
+
+def __getattr__(name: str) -> object:
+    target = _LAZY.get(name)
+    if target is None:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    return getattr(import_module(target, package=__name__), name)

--- a/nemo_curator/stages/interleaved/io/__init__.py
+++ b/nemo_curator/stages/interleaved/io/__init__.py
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from importlib import import_module
+
 from nemo_curator.stages.interleaved.io.reader import InterleavedParquetReader, InterleavedWebdatasetReader
 from nemo_curator.stages.interleaved.io.writers.tabular import InterleavedParquetWriterStage
 from nemo_curator.stages.interleaved.io.writers.webdataset import InterleavedWebdatasetWriterStage
-from nemo_curator.stages.interleaved.lance import InterleavedLanceReader
+
+_LAZY = {
+    "InterleavedLanceReader": "nemo_curator.stages.interleaved.lance",
+}
 
 __all__ = [
     "InterleavedLanceReader",
@@ -24,3 +29,11 @@ __all__ = [
     "InterleavedWebdatasetReader",
     "InterleavedWebdatasetWriterStage",
 ]
+
+
+def __getattr__(name: str) -> object:
+    target = _LAZY.get(name)
+    if target is None:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+    return getattr(import_module(target), name)

--- a/nemo_curator/stages/interleaved/io/readers/base.py
+++ b/nemo_curator/stages/interleaved/io/readers/base.py
@@ -19,7 +19,7 @@ import pyarrow as pa
 from loguru import logger
 
 from nemo_curator.stages.base import ProcessingStage
-from nemo_curator.stages.interleaved.utils.schema import align_table, reconcile_schema, resolve_schema
+from nemo_curator.stages.interleaved.utils.schema import align_interleaved_table, resolve_schema
 from nemo_curator.tasks import FileGroupTask, InterleavedBatch
 
 
@@ -61,9 +61,7 @@ class BaseInterleavedReader(ProcessingStage[FileGroupTask, InterleavedBatch]):
 
     def _align_output(self, table: pa.Table) -> pa.Table:
         """Reconcile or align *table* to the declared schema."""
-        if self.schema is not None:
-            return align_table(table, self.schema)
-        return table.cast(reconcile_schema(table.schema))
+        return align_interleaved_table(table, self.schema)
 
     @staticmethod
     def _source_files_for_split(

--- a/nemo_curator/stages/interleaved/io/readers/parquet.py
+++ b/nemo_curator/stages/interleaved/io/readers/parquet.py
@@ -22,7 +22,7 @@ import pyarrow.parquet as pq
 from fsspec.core import url_to_fs
 from pyarrow.fs import FSSpecHandler, PyFileSystem
 
-from nemo_curator.core.utils import split_table_by_group_max_bytes
+from nemo_curator.core.utils import split_table_by_group
 from nemo_curator.stages.interleaved.utils import resolve_storage_options
 from nemo_curator.tasks import FileGroupTask, InterleavedBatch
 from nemo_curator.tasks.interleaved import INTERLEAVED_SCHEMA, RESERVED_COLUMNS
@@ -113,7 +113,7 @@ class InterleavedParquetReaderStage(BaseInterleavedReader):
             base = self.schema if self.schema is not None else INTERLEAVED_SCHEMA
             combined = pa.Table.from_pylist([], schema=base)
 
-        splits = split_table_by_group_max_bytes(combined, "sample_id", self.max_batch_bytes)
+        splits = split_table_by_group(combined, "sample_id", max_batch_bytes=self.max_batch_bytes)
         batches: list[InterleavedBatch] = []
         for idx, split in enumerate(splits):
             f"{task.task_id}_processed" if len(splits) == 1 else f"{task.task_id}_processed_{idx:05d}"

--- a/nemo_curator/stages/interleaved/io/readers/webdataset.py
+++ b/nemo_curator/stages/interleaved/io/readers/webdataset.py
@@ -25,7 +25,7 @@ import fsspec
 import pyarrow as pa
 from loguru import logger
 
-from nemo_curator.core.utils import split_table_by_group_max_bytes
+from nemo_curator.core.utils import split_table_by_group
 from nemo_curator.stages.interleaved.utils import (
     DEFAULT_IMAGE_EXTENSIONS,
     DEFAULT_JSON_EXTENSIONS,
@@ -453,7 +453,7 @@ class InterleavedWebdatasetReaderStage(BaseInterleavedReader):
             # Empty tables use _empty_output_schema(); passthrough columns get
             # pa.null() type which is intentional (no data to infer from).
             table = pa.Table.from_pylist([], schema=self._empty_output_schema())
-        splits = split_table_by_group_max_bytes(table, "sample_id", self.max_batch_bytes)
+        splits = split_table_by_group(table, "sample_id", max_batch_bytes=self.max_batch_bytes)
         batches: list[InterleavedBatch] = []
         for idx, split in enumerate(splits):
             f"{task.task_id}_processed" if len(splits) == 1 else f"{task.task_id}_processed_{idx:05d}"

--- a/nemo_curator/stages/interleaved/lance/__init__.py
+++ b/nemo_curator/stages/interleaved/lance/__init__.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo_curator.stages.interleaved.io.reader import InterleavedParquetReader, InterleavedWebdatasetReader
-from nemo_curator.stages.interleaved.io.writers.tabular import InterleavedParquetWriterStage
-from nemo_curator.stages.interleaved.io.writers.webdataset import InterleavedWebdatasetWriterStage
-from nemo_curator.stages.interleaved.lance import InterleavedLanceReader
+"""Lance-backed interleaved readers."""
+
+from nemo_curator.stages.interleaved.lance.reader import InterleavedLanceReader, InterleavedLanceReaderStage
 
 __all__ = [
     "InterleavedLanceReader",
-    "InterleavedParquetReader",
-    "InterleavedParquetWriterStage",
-    "InterleavedWebdatasetReader",
-    "InterleavedWebdatasetWriterStage",
+    "InterleavedLanceReaderStage",
 ]

--- a/nemo_curator/stages/interleaved/lance/reader.py
+++ b/nemo_curator/stages/interleaved/lance/reader.py
@@ -16,9 +16,8 @@
 
 from __future__ import annotations
 
-import copy
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
@@ -42,6 +41,18 @@ def _validate_positive_optional(name: str, value: int | None) -> None:
         raise ValueError(msg)
 
 
+@dataclass
+class _BatchAccumulator:
+    pending_groups: list[pa.Table] = field(default_factory=list)
+    pending_bytes: int = 0
+    pending_rows: int = 0
+
+    def clear(self) -> None:
+        self.pending_groups.clear()
+        self.pending_bytes = 0
+        self.pending_rows = 0
+
+
 def _split_table_by_consecutive_group(table: pa.Table, group_column: str) -> list[pa.Table]:
     """Split a table into consecutive group slices without reordering rows."""
     if table.num_rows == 0:
@@ -49,7 +60,8 @@ def _split_table_by_consecutive_group(table: pa.Table, group_column: str) -> lis
     if group_column not in table.column_names:
         msg = f"Group column '{group_column}' not found in table"
         raise ValueError(msg)
-    col = table[group_column].combine_chunks()
+    chunked = table[group_column]
+    col = chunked.combine_chunks() if len(chunked.chunks) > 1 else chunked.chunks[0]
     if pc.any(pc.is_null(col)).as_py():
         msg = f"Group column '{group_column}' contains null values"
         raise ValueError(msg)
@@ -64,35 +76,35 @@ def _split_table_by_consecutive_group(table: pa.Table, group_column: str) -> lis
     return [table.slice(start, end - start) for start, end in zip(starts, ends, strict=True)]
 
 
-def _append_group_to_size_limited_chunks(  # noqa: PLR0913
+def _append_group_to_size_limited_chunks(
     group: pa.Table,
     *,
     max_batch_bytes: int | None,
     max_batch_rows: int | None,
     chunks: list[pa.Table],
-    pending_groups: list[pa.Table],
-    pending_bytes: list[int],
-    pending_rows: list[int],
-) -> None:
+    acc: _BatchAccumulator,
+) -> int:
     """Append one whole group, flushing before it if it would exceed limits."""
     group_bytes = group.nbytes
     group_rows = group.num_rows
+    flushed_rows = 0
     should_flush = bool(
-        pending_groups
+        acc.pending_groups
         and (
-            (max_batch_bytes is not None and pending_bytes[0] + group_bytes > max_batch_bytes)
-            or (max_batch_rows is not None and pending_rows[0] + group_rows > max_batch_rows)
+            (max_batch_bytes is not None and acc.pending_bytes + group_bytes > max_batch_bytes)
+            or (max_batch_rows is not None and acc.pending_rows + group_rows > max_batch_rows)
         )
     )
     if should_flush:
-        chunks.append(pa.concat_tables(pending_groups, promote_options="default"))
-        pending_groups.clear()
-        pending_bytes[0] = 0
-        pending_rows[0] = 0
+        chunk = pa.concat_tables(acc.pending_groups, promote_options="default")
+        chunks.append(chunk)
+        flushed_rows = chunk.num_rows
+        acc.clear()
 
-    pending_groups.append(group)
-    pending_bytes[0] += group_bytes
-    pending_rows[0] += group_rows
+    acc.pending_groups.append(group)
+    acc.pending_bytes += group_bytes
+    acc.pending_rows += group_rows
+    return flushed_rows
 
 
 def _tables_from_record_batches(  # noqa: C901
@@ -110,26 +122,22 @@ def _tables_from_record_batches(  # noqa: C901
     stream early, the in-progress group is not emitted as a partial sample.
     """
     chunks: list[pa.Table] = []
-    pending_groups: list[pa.Table] = []
-    pending_bytes = [0]
-    pending_rows = [0]
+    acc = _BatchAccumulator()
     carry: pa.Table | None = None
     emitted_rows = 0
     stopped_early = False
 
     def flush_pending() -> None:
         nonlocal emitted_rows
-        if not pending_groups:
+        if not acc.pending_groups:
             return
-        chunk = pa.concat_tables(pending_groups, promote_options="default")
+        chunk = pa.concat_tables(acc.pending_groups, promote_options="default")
         chunks.append(chunk)
         emitted_rows += chunk.num_rows
-        pending_groups.clear()
-        pending_bytes[0] = 0
-        pending_rows[0] = 0
+        acc.clear()
 
     def output_limit_reached(next_group_rows: int) -> bool:
-        return max_output_rows is not None and emitted_rows + pending_rows[0] + next_group_rows > max_output_rows
+        return max_output_rows is not None and emitted_rows + acc.pending_rows + next_group_rows > max_output_rows
 
     for batch in batches:
         table = pa.Table.from_batches([batch]) if isinstance(batch, pa.RecordBatch) else batch
@@ -150,14 +158,12 @@ def _tables_from_record_batches(  # noqa: C901
                 flush_pending()
                 stopped_early = True
                 break
-            _append_group_to_size_limited_chunks(
+            emitted_rows += _append_group_to_size_limited_chunks(
                 group,
                 max_batch_bytes=max_batch_bytes,
                 max_batch_rows=max_batch_rows,
                 chunks=chunks,
-                pending_groups=pending_groups,
-                pending_bytes=pending_bytes,
-                pending_rows=pending_rows,
+                acc=acc,
             )
         if stopped_early:
             break
@@ -166,14 +172,12 @@ def _tables_from_record_batches(  # noqa: C901
         if output_limit_reached(carry.num_rows):
             stopped_early = True
         else:
-            _append_group_to_size_limited_chunks(
+            emitted_rows += _append_group_to_size_limited_chunks(
                 carry,
                 max_batch_bytes=max_batch_bytes,
                 max_batch_rows=max_batch_rows,
                 chunks=chunks,
-                pending_groups=pending_groups,
-                pending_bytes=pending_bytes,
-                pending_rows=pending_rows,
+                acc=acc,
             )
 
     flush_pending()
@@ -186,7 +190,7 @@ def _reader_metadata(
     streaming_read: bool,
     stopped_early: bool,
 ) -> dict[str, Any]:
-    metadata = copy.deepcopy(metadata)
+    metadata = dict(metadata)
     lance_metadata = dict(metadata.get("lance", {}))
     lance_metadata["streaming_read"] = streaming_read
     lance_metadata["stopped_early"] = stopped_early
@@ -249,8 +253,11 @@ class InterleavedLanceReaderStage(LanceReaderStage):
                 msg = f"Lance fragment task {task.task_id} is not a valid InterleavedBatch"
                 raise ValueError(msg)
 
-        rows = sum(split.num_rows for split in splits)
-        bytes_ = sum(split.nbytes for split in splits)
+        rows = 0
+        bytes_ = 0
+        for split in splits:
+            rows += split.num_rows
+            bytes_ += split.nbytes
         self._log_metrics(
             {
                 "reader_process_seconds": time.perf_counter() - started,

--- a/nemo_curator/stages/interleaved/lance/reader.py
+++ b/nemo_curator/stages/interleaved/lance/reader.py
@@ -1,0 +1,336 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Lance reader for row-wise interleaved multimodal datasets."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from nemo_curator.stages.base import CompositeStage, ProcessingStage
+from nemo_curator.stages.text.io.reader.lance import LancePartitioningStage, LanceReaderStage
+from nemo_curator.tasks import EmptyTask, InterleavedBatch, LanceReadTask
+from nemo_curator.utils.lance import add_lance_metadata_columns
+
+if TYPE_CHECKING:
+    from nemo_curator.stages.text.io.reader.base import ReaderOutput
+
+
+_GROUP_COLUMN = "sample_id"
+
+
+def _validate_positive_optional(name: str, value: int | None) -> None:
+    if value is not None and value <= 0:
+        msg = f"{name} must be > 0, got {value}"
+        raise ValueError(msg)
+
+
+def _split_table_by_consecutive_group(table: pa.Table, group_column: str) -> list[pa.Table]:
+    """Split a table into consecutive group slices without reordering rows."""
+    if table.num_rows == 0:
+        return []
+    if group_column not in table.column_names:
+        msg = f"Group column '{group_column}' not found in table"
+        raise ValueError(msg)
+    if table.num_rows == 1:
+        return [table]
+
+    col = table[group_column].combine_chunks()
+    group_change = pc.not_equal(col.slice(1), col.slice(0, table.num_rows - 1))
+    group_change = pc.fill_null(group_change, False)
+    split_points = pc.indices_nonzero(group_change).to_pylist()
+    starts = [0, *(point + 1 for point in split_points)]
+    ends = [*(point + 1 for point in split_points), table.num_rows]
+    return [table.slice(start, end - start) for start, end in zip(starts, ends, strict=True)]
+
+
+def _append_group_to_size_limited_chunks(  # noqa: PLR0913
+    group: pa.Table,
+    *,
+    max_batch_bytes: int | None,
+    max_batch_rows: int | None,
+    chunks: list[pa.Table],
+    pending_groups: list[pa.Table],
+    pending_bytes: list[int],
+    pending_rows: list[int],
+) -> None:
+    """Append one whole group, flushing before it if it would exceed limits."""
+    group_bytes = group.nbytes
+    group_rows = group.num_rows
+    should_flush = bool(
+        pending_groups
+        and (
+            (max_batch_bytes is not None and pending_bytes[0] + group_bytes > max_batch_bytes)
+            or (max_batch_rows is not None and pending_rows[0] + group_rows > max_batch_rows)
+        )
+    )
+    if should_flush:
+        chunks.append(pa.concat_tables(pending_groups, promote_options="default"))
+        pending_groups.clear()
+        pending_bytes[0] = 0
+        pending_rows[0] = 0
+
+    pending_groups.append(group)
+    pending_bytes[0] += group_bytes
+    pending_rows[0] += group_rows
+
+
+def _tables_from_record_batches(  # noqa: C901
+    batches: object,
+    *,
+    group_column: str,
+    max_batch_bytes: int | None,
+    max_batch_rows: int | None,
+    max_output_rows: int | None,
+) -> tuple[list[pa.Table], bool]:
+    """Build size-limited tables without splitting consecutive groups.
+
+    The last group in each input scanner batch is carried forward because it
+    may continue in the next scanner batch. If ``max_output_rows`` stops the
+    stream early, the in-progress group is not emitted as a partial sample.
+    """
+    chunks: list[pa.Table] = []
+    pending_groups: list[pa.Table] = []
+    pending_bytes = [0]
+    pending_rows = [0]
+    carry: pa.Table | None = None
+    emitted_rows = 0
+    stopped_early = False
+
+    def flush_pending() -> None:
+        nonlocal emitted_rows
+        if not pending_groups:
+            return
+        chunk = pa.concat_tables(pending_groups, promote_options="default")
+        chunks.append(chunk)
+        emitted_rows += chunk.num_rows
+        pending_groups.clear()
+        pending_bytes[0] = 0
+        pending_rows[0] = 0
+
+    def output_limit_reached(next_group_rows: int) -> bool:
+        return max_output_rows is not None and emitted_rows + pending_rows[0] + next_group_rows > max_output_rows
+
+    for batch in batches:
+        table = pa.Table.from_batches([batch]) if isinstance(batch, pa.RecordBatch) else batch
+        if not isinstance(table, pa.Table) or table.num_rows == 0:
+            continue
+        if carry is not None and carry.num_rows:
+            table = pa.concat_tables([carry, table], promote_options="default")
+            carry = None
+
+        groups = _split_table_by_consecutive_group(table, group_column)
+        if not groups:
+            continue
+        complete_groups = groups[:-1]
+        carry = groups[-1]
+
+        for group in complete_groups:
+            if output_limit_reached(group.num_rows):
+                flush_pending()
+                stopped_early = True
+                break
+            _append_group_to_size_limited_chunks(
+                group,
+                max_batch_bytes=max_batch_bytes,
+                max_batch_rows=max_batch_rows,
+                chunks=chunks,
+                pending_groups=pending_groups,
+                pending_bytes=pending_bytes,
+                pending_rows=pending_rows,
+            )
+        if stopped_early:
+            break
+
+    if not stopped_early and carry is not None and carry.num_rows:
+        if output_limit_reached(carry.num_rows):
+            stopped_early = True
+        else:
+            _append_group_to_size_limited_chunks(
+                carry,
+                max_batch_bytes=max_batch_bytes,
+                max_batch_rows=max_batch_rows,
+                chunks=chunks,
+                pending_groups=pending_groups,
+                pending_bytes=pending_bytes,
+                pending_rows=pending_rows,
+            )
+
+    flush_pending()
+    return chunks, stopped_early
+
+
+@dataclass
+class InterleavedLanceReaderStage(LanceReaderStage):
+    """Read Lance fragments into validated ``InterleavedBatch`` objects."""
+
+    max_batch_bytes: int | None = None
+    max_batch_rows: int | None = None
+    streaming_read: bool = False
+    max_output_rows: int | None = None
+    name: str = "interleaved_lance_reader"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.fields is not None:
+            missing = sorted(InterleavedBatch.REQUIRED_COLUMNS - set(self.fields))
+            if missing:
+                msg = f"Interleaved Lance fields omit required columns: {missing}"
+                raise ValueError(msg)
+        _validate_positive_optional("max_batch_bytes", self.max_batch_bytes)
+        _validate_positive_optional("max_batch_rows", self.max_batch_rows)
+        _validate_positive_optional("max_output_rows", self.max_output_rows)
+
+    def process(self, task: LanceReadTask) -> InterleavedBatch | list[InterleavedBatch]:
+        started = time.perf_counter()
+        if self.streaming_read:
+            splits, metadata = self._stream_read_task(task)
+        else:
+            output: ReaderOutput = self.read_task(task, dict(self.read_kwargs or {}), self.fields)
+            self._validate_result(task, output.data)
+            splits, _ = _tables_from_record_batches(
+                [output.data],
+                group_column=_GROUP_COLUMN,
+                max_batch_bytes=self.max_batch_bytes,
+                max_batch_rows=self.max_batch_rows,
+                max_output_rows=self.max_output_rows,
+            )
+            metadata = output.metadata if output.metadata is not None else task._metadata
+
+        batches = [
+            InterleavedBatch(
+                dataset_name=task.dataset_name,
+                data=split,
+                _metadata=metadata,
+                _stage_perf=task._stage_perf,
+            )
+            for split in splits
+        ]
+        for batch in batches:
+            if batch.to_pyarrow().num_rows and not batch.validate():
+                msg = f"Lance fragment task {task.task_id} is not a valid InterleavedBatch"
+                raise ValueError(msg)
+
+        rows = sum(split.num_rows for split in splits)
+        bytes_ = sum(split.nbytes for split in splits)
+        self._log_metrics(
+            {
+                "reader_process_seconds": time.perf_counter() - started,
+                "reader_output_splits": float(len(splits)),
+                "reader_output_rows": float(rows),
+                "reader_output_bytes": float(bytes_),
+            }
+        )
+        if not batches:
+            return []
+        return batches if len(batches) > 1 else batches[0]
+
+    def _stream_read_task(self, task: LanceReadTask) -> tuple[list[pa.Table], dict[str, Any]]:
+        import lance
+        from lance.schema import schema_to_json
+
+        read_kwargs = dict(self.read_kwargs or {})
+        dataset_kwargs = dict(read_kwargs.pop("dataset_options", {}) or {})
+        dataset_kwargs["version"] = task.version
+        storage_options = read_kwargs.pop("storage_options", None)
+        if storage_options is not None:
+            dataset_kwargs["storage_options"] = storage_options
+
+        scanner_kwargs = self._scanner_kwargs(read_kwargs, self.fields)
+        dataset = lance.dataset(task.path, **dataset_kwargs)
+        fragments = [dataset.get_fragment(fragment_id) for fragment_id in task.data]
+        requested_columns = scanner_kwargs.get("columns")
+        blob_columns = [
+            field.name
+            for field in dataset.schema
+            if getattr(field.type, "extension_name", None) == "lance.blob.v2"
+            and (requested_columns is None or field.name in requested_columns)
+        ]
+        if blob_columns:
+            msg = "streaming InterleavedLanceReaderStage does not support lance.blob.v2 columns"
+            raise NotImplementedError(msg)
+        if self.include_lance_metadata:
+            scanner_kwargs["with_row_address"] = True
+            scanner_kwargs["with_row_id"] = True
+        scanner_kwargs["fragments"] = fragments
+
+        splits, stopped_early = _tables_from_record_batches(
+            dataset.scanner(**scanner_kwargs).to_batches(),
+            group_column=_GROUP_COLUMN,
+            max_batch_bytes=self.max_batch_bytes,
+            max_batch_rows=self.max_batch_rows,
+            max_output_rows=self.max_output_rows,
+        )
+        if not splits:
+            self._validate_result(task, pa.Table.from_pylist([]))
+        if self.include_lance_metadata:
+            splits = [add_lance_metadata_columns(split) for split in splits]
+
+        metadata = {
+            "source_files": [task.path],
+            "lance": {
+                "version": task.version,
+                "fragment_ids": list(task.data),
+                "schema": schema_to_json(dataset.schema),
+                "has_stable_row_ids": dataset.has_stable_row_ids,
+                "streaming_read": True,
+                "stopped_early": stopped_early,
+            },
+        }
+        return splits, metadata
+
+
+@dataclass
+class InterleavedLanceReader(CompositeStage[EmptyTask, InterleavedBatch]):
+    """Partition and read a Lance dataset as row-wise interleaved batches."""
+
+    path: str
+    fragments_per_partition: int = 1
+    fields: list[str] | None = None
+    max_batch_bytes: int | None = None
+    max_batch_rows: int | None = None
+    streaming_read: bool = False
+    max_output_rows: int | None = None
+    read_kwargs: dict[str, Any] | None = None
+    include_lance_metadata: bool = True
+    fragment_ids: list[int] | None = None
+    name: str = "interleaved_lance_reader"
+
+    def __post_init__(self) -> None:
+        super().__init__()
+        self.read_kwargs = {} if self.read_kwargs is None else dict(self.read_kwargs)
+
+    def decompose(self) -> list[ProcessingStage]:
+        return [
+            LancePartitioningStage(
+                path=self.path,
+                fragments_per_partition=self.fragments_per_partition,
+                fragment_ids=self.fragment_ids,
+                read_kwargs=self.read_kwargs,
+            ),
+            InterleavedLanceReaderStage(
+                fields=self.fields,
+                max_batch_bytes=self.max_batch_bytes,
+                max_batch_rows=self.max_batch_rows,
+                streaming_read=self.streaming_read,
+                max_output_rows=self.max_output_rows,
+                read_kwargs=self.read_kwargs,
+                include_lance_metadata=self.include_lance_metadata,
+            ),
+        ]

--- a/nemo_curator/stages/interleaved/lance/reader.py
+++ b/nemo_curator/stages/interleaved/lance/reader.py
@@ -17,17 +17,14 @@
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-import pyarrow as pa
-import pyarrow.compute as pc
-
+from nemo_curator.core.utils import split_table_by_group
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.interleaved.utils.schema import align_interleaved_table
 from nemo_curator.stages.text.io.reader.lance import LancePartitioningStage, LanceReaderStage
 from nemo_curator.tasks import EmptyTask, InterleavedBatch, LanceReadTask
-from nemo_curator.utils.lance import add_lance_metadata_columns
 
 if TYPE_CHECKING:
     from nemo_curator.stages.text.io.reader.base import ReaderOutput
@@ -43,175 +40,11 @@ def _validate_positive_optional(name: str, value: int | None) -> None:
 
 
 @dataclass
-class _BatchAccumulator:
-    pending_groups: list[pa.Table] = field(default_factory=list)
-    pending_bytes: int = 0
-    pending_rows: int = 0
-
-    def clear(self) -> None:
-        self.pending_groups.clear()
-        self.pending_bytes = 0
-        self.pending_rows = 0
-
-
-def _validated_group_column(table: pa.Table, group_column: str) -> pa.Array:
-    if group_column not in table.column_names:
-        msg = f"Group column '{group_column}' not found in table"
-        raise ValueError(msg)
-    chunked = table[group_column]
-    col = chunked.combine_chunks() if len(chunked.chunks) > 1 else chunked.chunks[0]
-    if pc.any(pc.is_null(col)).as_py():
-        msg = f"Group column '{group_column}' contains null values"
-        raise ValueError(msg)
-    return col
-
-
-def _split_table_by_consecutive_group(table: pa.Table, group_column: str) -> list[pa.Table]:
-    """Split a table into consecutive group slices without reordering rows."""
-    if table.num_rows == 0:
-        return []
-    col = _validated_group_column(table, group_column)
-    if table.num_rows == 1:
-        return [table]
-
-    group_change = pc.not_equal(col.slice(1), col.slice(0, table.num_rows - 1))
-    group_change = pc.fill_null(group_change, False)
-    split_points = pc.indices_nonzero(group_change).to_pylist()
-    starts = [0, *(point + 1 for point in split_points)]
-    ends = [*(point + 1 for point in split_points), table.num_rows]
-    return [table.slice(start, end - start) for start, end in zip(starts, ends, strict=True)]
-
-
-def _append_group_to_size_limited_chunks(
-    group: pa.Table,
-    *,
-    max_batch_bytes: int | None,
-    max_batch_rows: int | None,
-    chunks: list[pa.Table],
-    acc: _BatchAccumulator,
-) -> int:
-    """Append one whole group, flushing before it if it would exceed limits."""
-    group_bytes = group.nbytes
-    group_rows = group.num_rows
-    flushed_rows = 0
-    should_flush = bool(
-        acc.pending_groups
-        and (
-            (max_batch_bytes is not None and acc.pending_bytes + group_bytes > max_batch_bytes)
-            or (max_batch_rows is not None and acc.pending_rows + group_rows > max_batch_rows)
-        )
-    )
-    if should_flush:
-        chunk = pa.concat_tables(acc.pending_groups, promote_options="default")
-        chunks.append(chunk)
-        flushed_rows = chunk.num_rows
-        acc.clear()
-
-    acc.pending_groups.append(group)
-    acc.pending_bytes += group_bytes
-    acc.pending_rows += group_rows
-    return flushed_rows
-
-
-def _tables_from_record_batches(  # noqa: C901
-    batches: object,
-    *,
-    group_column: str,
-    max_batch_bytes: int | None,
-    max_batch_rows: int | None,
-    max_output_rows: int | None,
-) -> tuple[list[pa.Table], bool]:
-    """Build size-limited tables without splitting consecutive groups.
-
-    The last group in each input scanner batch is carried forward because it
-    may continue in the next scanner batch. If ``max_output_rows`` stops the
-    stream early, the in-progress group is not emitted as a partial sample.
-    """
-    chunks: list[pa.Table] = []
-    acc = _BatchAccumulator()
-    carry: pa.Table | None = None
-    emitted_rows = 0
-    stopped_early = False
-
-    def flush_pending() -> None:
-        nonlocal emitted_rows
-        if not acc.pending_groups:
-            return
-        chunk = pa.concat_tables(acc.pending_groups, promote_options="default")
-        chunks.append(chunk)
-        emitted_rows += chunk.num_rows
-        acc.clear()
-
-    def output_limit_reached(next_group_rows: int) -> bool:
-        return max_output_rows is not None and emitted_rows + acc.pending_rows + next_group_rows > max_output_rows
-
-    for batch in batches:
-        table = pa.Table.from_batches([batch]) if isinstance(batch, pa.RecordBatch) else batch
-        if not isinstance(table, pa.Table) or table.num_rows == 0:
-            continue
-        if carry is not None and carry.num_rows:
-            table = pa.concat_tables([carry, table], promote_options="default")
-            carry = None
-
-        groups = _split_table_by_consecutive_group(table, group_column)
-        if not groups:
-            continue
-        complete_groups = groups[:-1]
-        carry = groups[-1]
-
-        for group in complete_groups:
-            if output_limit_reached(group.num_rows):
-                flush_pending()
-                stopped_early = True
-                break
-            emitted_rows += _append_group_to_size_limited_chunks(
-                group,
-                max_batch_bytes=max_batch_bytes,
-                max_batch_rows=max_batch_rows,
-                chunks=chunks,
-                acc=acc,
-            )
-        if stopped_early:
-            break
-
-    if not stopped_early and carry is not None and carry.num_rows:
-        if output_limit_reached(carry.num_rows):
-            stopped_early = True
-        else:
-            emitted_rows += _append_group_to_size_limited_chunks(
-                carry,
-                max_batch_bytes=max_batch_bytes,
-                max_batch_rows=max_batch_rows,
-                chunks=chunks,
-                acc=acc,
-            )
-
-    flush_pending()
-    return chunks, stopped_early
-
-
-def _reader_metadata(
-    metadata: dict[str, Any],
-    *,
-    streaming_read: bool,
-    stopped_early: bool,
-) -> dict[str, Any]:
-    metadata = dict(metadata)
-    lance_metadata = dict(metadata.get("lance", {}))
-    lance_metadata["streaming_read"] = streaming_read
-    lance_metadata["stopped_early"] = stopped_early
-    metadata["lance"] = lance_metadata
-    return metadata
-
-
-@dataclass
 class InterleavedLanceReaderStage(LanceReaderStage):
     """Read Lance fragments into validated ``InterleavedBatch`` objects."""
 
     max_batch_bytes: int | None = None
     max_batch_rows: int | None = None
-    streaming_read: bool = False
-    max_output_rows: int | None = None
     name: str = "interleaved_lance_reader"
 
     def __post_init__(self) -> None:
@@ -223,36 +56,27 @@ class InterleavedLanceReaderStage(LanceReaderStage):
                 raise ValueError(msg)
         _validate_positive_optional("max_batch_bytes", self.max_batch_bytes)
         _validate_positive_optional("max_batch_rows", self.max_batch_rows)
-        _validate_positive_optional("max_output_rows", self.max_output_rows)
 
     def process(self, task: LanceReadTask) -> InterleavedBatch | list[InterleavedBatch]:
         started = time.perf_counter()
-        if self.streaming_read:
-            splits, metadata = self._stream_read_task(task)
-        else:
-            output: ReaderOutput = self.read_task(task, dict(self.read_kwargs or {}), self.fields)
-            _validated_group_column(output.data, _GROUP_COLUMN)
-            table = align_interleaved_table(output.data)
-            self._validate_result(task, table)
-            splits, stopped_early = _tables_from_record_batches(
-                [table],
-                group_column=_GROUP_COLUMN,
-                max_batch_bytes=self.max_batch_bytes,
-                max_batch_rows=self.max_batch_rows,
-                max_output_rows=self.max_output_rows,
-            )
-            metadata = _reader_metadata(
-                output.metadata if output.metadata is not None else task._metadata,
-                streaming_read=False,
-                stopped_early=stopped_early,
-            )
+        output: ReaderOutput = self.read_task(task, dict(self.read_kwargs or {}), self.fields)
+        table = align_interleaved_table(output.data)
+        self._validate_result(task, table)
+        splits = split_table_by_group(
+            table,
+            _GROUP_COLUMN,
+            max_batch_bytes=self.max_batch_bytes,
+            max_batch_rows=self.max_batch_rows,
+        )
+        output_rows = sum(split.num_rows for split in splits)
+        metadata = output.metadata if output.metadata is not None else task._metadata
 
         batches = [
             InterleavedBatch(
                 dataset_name=task.dataset_name,
                 data=split,
                 _metadata=metadata,
-                _stage_perf=task._stage_perf,
+                _stage_perf=list(task._stage_perf),
             )
             for split in splits
         ]
@@ -261,55 +85,17 @@ class InterleavedLanceReaderStage(LanceReaderStage):
                 msg = f"Lance fragment task {task.task_id} is not a valid InterleavedBatch"
                 raise ValueError(msg)
 
-        rows = 0
-        bytes_ = 0
-        for split in splits:
-            rows += split.num_rows
-            bytes_ += split.nbytes
         self._log_metrics(
             {
                 "reader_process_seconds": time.perf_counter() - started,
                 "reader_output_splits": float(len(splits)),
-                "reader_output_rows": float(rows),
-                "reader_output_bytes": float(bytes_),
+                "reader_output_rows": float(output_rows),
+                "reader_output_bytes": float(sum(split.nbytes for split in splits)),
             }
         )
         if not batches:
             return []
         return batches if len(batches) > 1 else batches[0]
-
-    def _stream_read_task(self, task: LanceReadTask) -> tuple[list[pa.Table], dict[str, Any]]:
-        dataset, scanner_kwargs, blob_columns = self._dataset_and_scanner_kwargs(
-            task,
-            dict(self.read_kwargs or {}),
-            self.fields,
-        )
-        if blob_columns:
-            msg = "streaming InterleavedLanceReaderStage does not support lance.blob.v2 columns"
-            raise NotImplementedError(msg)
-
-        splits, stopped_early = _tables_from_record_batches(
-            dataset.scanner(**scanner_kwargs).to_batches(),
-            group_column=_GROUP_COLUMN,
-            max_batch_bytes=self.max_batch_bytes,
-            max_batch_rows=self.max_batch_rows,
-            max_output_rows=self.max_output_rows,
-        )
-        if not splits:
-            self._validate_result(task, pa.Table.from_pylist([]))
-        if self.include_lance_metadata:
-            splits = [add_lance_metadata_columns(split) for split in splits]
-        splits = [align_interleaved_table(split) for split in splits]
-
-        metadata = self._metadata_for_task(
-            task,
-            dataset,
-            {
-                "streaming_read": True,
-                "stopped_early": stopped_early,
-            },
-        )
-        return splits, metadata
 
 
 @dataclass
@@ -321,8 +107,6 @@ class InterleavedLanceReader(CompositeStage[EmptyTask, InterleavedBatch]):
     fields: list[str] | None = None
     max_batch_bytes: int | None = None
     max_batch_rows: int | None = None
-    streaming_read: bool = False
-    max_output_rows: int | None = None
     read_kwargs: dict[str, Any] | None = None
     include_lance_metadata: bool = True
     fragment_ids: list[int] | None = None
@@ -344,8 +128,6 @@ class InterleavedLanceReader(CompositeStage[EmptyTask, InterleavedBatch]):
                 fields=self.fields,
                 max_batch_bytes=self.max_batch_bytes,
                 max_batch_rows=self.max_batch_rows,
-                streaming_read=self.streaming_read,
-                max_output_rows=self.max_output_rows,
                 read_kwargs=self.read_kwargs,
                 include_lance_metadata=self.include_lance_metadata,
             ),

--- a/nemo_curator/stages/interleaved/lance/reader.py
+++ b/nemo_curator/stages/interleaved/lance/reader.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import copy
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -24,7 +25,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
-from nemo_curator.stages.text.io.reader.lance import LancePartitioningStage, LanceReaderStage
+from nemo_curator.stages.text.io.reader.lance import LancePartitioningStage, LanceReaderStage, _pop_dataset_kwargs
 from nemo_curator.tasks import EmptyTask, InterleavedBatch, LanceReadTask
 from nemo_curator.utils.lance import add_lance_metadata_columns
 
@@ -48,10 +49,13 @@ def _split_table_by_consecutive_group(table: pa.Table, group_column: str) -> lis
     if group_column not in table.column_names:
         msg = f"Group column '{group_column}' not found in table"
         raise ValueError(msg)
+    col = table[group_column].combine_chunks()
+    if pc.any(pc.is_null(col)).as_py():
+        msg = f"Group column '{group_column}' contains null values"
+        raise ValueError(msg)
     if table.num_rows == 1:
         return [table]
 
-    col = table[group_column].combine_chunks()
     group_change = pc.not_equal(col.slice(1), col.slice(0, table.num_rows - 1))
     group_change = pc.fill_null(group_change, False)
     split_points = pc.indices_nonzero(group_change).to_pylist()
@@ -176,6 +180,20 @@ def _tables_from_record_batches(  # noqa: C901
     return chunks, stopped_early
 
 
+def _reader_metadata(
+    metadata: dict[str, Any],
+    *,
+    streaming_read: bool,
+    stopped_early: bool,
+) -> dict[str, Any]:
+    metadata = copy.deepcopy(metadata)
+    lance_metadata = dict(metadata.get("lance", {}))
+    lance_metadata["streaming_read"] = streaming_read
+    lance_metadata["stopped_early"] = stopped_early
+    metadata["lance"] = lance_metadata
+    return metadata
+
+
 @dataclass
 class InterleavedLanceReaderStage(LanceReaderStage):
     """Read Lance fragments into validated ``InterleavedBatch`` objects."""
@@ -204,14 +222,18 @@ class InterleavedLanceReaderStage(LanceReaderStage):
         else:
             output: ReaderOutput = self.read_task(task, dict(self.read_kwargs or {}), self.fields)
             self._validate_result(task, output.data)
-            splits, _ = _tables_from_record_batches(
+            splits, stopped_early = _tables_from_record_batches(
                 [output.data],
                 group_column=_GROUP_COLUMN,
                 max_batch_bytes=self.max_batch_bytes,
                 max_batch_rows=self.max_batch_rows,
                 max_output_rows=self.max_output_rows,
             )
-            metadata = output.metadata if output.metadata is not None else task._metadata
+            metadata = _reader_metadata(
+                output.metadata if output.metadata is not None else task._metadata,
+                streaming_read=False,
+                stopped_early=stopped_early,
+            )
 
         batches = [
             InterleavedBatch(
@@ -246,11 +268,8 @@ class InterleavedLanceReaderStage(LanceReaderStage):
         from lance.schema import schema_to_json
 
         read_kwargs = dict(self.read_kwargs or {})
-        dataset_kwargs = dict(read_kwargs.pop("dataset_options", {}) or {})
+        dataset_kwargs = _pop_dataset_kwargs(read_kwargs)
         dataset_kwargs["version"] = task.version
-        storage_options = read_kwargs.pop("storage_options", None)
-        if storage_options is not None:
-            dataset_kwargs["storage_options"] = storage_options
 
         scanner_kwargs = self._scanner_kwargs(read_kwargs, self.fields)
         dataset = lance.dataset(task.path, **dataset_kwargs)

--- a/nemo_curator/stages/interleaved/lance/reader.py
+++ b/nemo_curator/stages/interleaved/lance/reader.py
@@ -24,7 +24,8 @@ import pyarrow as pa
 import pyarrow.compute as pc
 
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
-from nemo_curator.stages.text.io.reader.lance import LancePartitioningStage, LanceReaderStage, _pop_dataset_kwargs
+from nemo_curator.stages.interleaved.utils.schema import align_interleaved_table
+from nemo_curator.stages.text.io.reader.lance import LancePartitioningStage, LanceReaderStage
 from nemo_curator.tasks import EmptyTask, InterleavedBatch, LanceReadTask
 from nemo_curator.utils.lance import add_lance_metadata_columns
 
@@ -53,10 +54,7 @@ class _BatchAccumulator:
         self.pending_rows = 0
 
 
-def _split_table_by_consecutive_group(table: pa.Table, group_column: str) -> list[pa.Table]:
-    """Split a table into consecutive group slices without reordering rows."""
-    if table.num_rows == 0:
-        return []
+def _validated_group_column(table: pa.Table, group_column: str) -> pa.Array:
     if group_column not in table.column_names:
         msg = f"Group column '{group_column}' not found in table"
         raise ValueError(msg)
@@ -65,6 +63,14 @@ def _split_table_by_consecutive_group(table: pa.Table, group_column: str) -> lis
     if pc.any(pc.is_null(col)).as_py():
         msg = f"Group column '{group_column}' contains null values"
         raise ValueError(msg)
+    return col
+
+
+def _split_table_by_consecutive_group(table: pa.Table, group_column: str) -> list[pa.Table]:
+    """Split a table into consecutive group slices without reordering rows."""
+    if table.num_rows == 0:
+        return []
+    col = _validated_group_column(table, group_column)
     if table.num_rows == 1:
         return [table]
 
@@ -225,9 +231,11 @@ class InterleavedLanceReaderStage(LanceReaderStage):
             splits, metadata = self._stream_read_task(task)
         else:
             output: ReaderOutput = self.read_task(task, dict(self.read_kwargs or {}), self.fields)
-            self._validate_result(task, output.data)
+            _validated_group_column(output.data, _GROUP_COLUMN)
+            table = align_interleaved_table(output.data)
+            self._validate_result(task, table)
             splits, stopped_early = _tables_from_record_batches(
-                [output.data],
+                [table],
                 group_column=_GROUP_COLUMN,
                 max_batch_bytes=self.max_batch_bytes,
                 max_batch_rows=self.max_batch_rows,
@@ -271,30 +279,14 @@ class InterleavedLanceReaderStage(LanceReaderStage):
         return batches if len(batches) > 1 else batches[0]
 
     def _stream_read_task(self, task: LanceReadTask) -> tuple[list[pa.Table], dict[str, Any]]:
-        import lance
-        from lance.schema import schema_to_json
-
-        read_kwargs = dict(self.read_kwargs or {})
-        dataset_kwargs = _pop_dataset_kwargs(read_kwargs)
-        dataset_kwargs["version"] = task.version
-
-        scanner_kwargs = self._scanner_kwargs(read_kwargs, self.fields)
-        dataset = lance.dataset(task.path, **dataset_kwargs)
-        fragments = [dataset.get_fragment(fragment_id) for fragment_id in task.data]
-        requested_columns = scanner_kwargs.get("columns")
-        blob_columns = [
-            field.name
-            for field in dataset.schema
-            if getattr(field.type, "extension_name", None) == "lance.blob.v2"
-            and (requested_columns is None or field.name in requested_columns)
-        ]
+        dataset, scanner_kwargs, blob_columns = self._dataset_and_scanner_kwargs(
+            task,
+            dict(self.read_kwargs or {}),
+            self.fields,
+        )
         if blob_columns:
             msg = "streaming InterleavedLanceReaderStage does not support lance.blob.v2 columns"
             raise NotImplementedError(msg)
-        if self.include_lance_metadata:
-            scanner_kwargs["with_row_address"] = True
-            scanner_kwargs["with_row_id"] = True
-        scanner_kwargs["fragments"] = fragments
 
         splits, stopped_early = _tables_from_record_batches(
             dataset.scanner(**scanner_kwargs).to_batches(),
@@ -307,18 +299,16 @@ class InterleavedLanceReaderStage(LanceReaderStage):
             self._validate_result(task, pa.Table.from_pylist([]))
         if self.include_lance_metadata:
             splits = [add_lance_metadata_columns(split) for split in splits]
+        splits = [align_interleaved_table(split) for split in splits]
 
-        metadata = {
-            "source_files": [task.path],
-            "lance": {
-                "version": task.version,
-                "fragment_ids": list(task.data),
-                "schema": schema_to_json(dataset.schema),
-                "has_stable_row_ids": dataset.has_stable_row_ids,
+        metadata = self._metadata_for_task(
+            task,
+            dataset,
+            {
                 "streaming_read": True,
                 "stopped_early": stopped_early,
             },
-        }
+        )
         return splits, metadata
 
 

--- a/nemo_curator/stages/interleaved/utils/schema.py
+++ b/nemo_curator/stages/interleaved/utils/schema.py
@@ -108,3 +108,15 @@ def align_table(table: pa.Table, target: pa.Schema) -> pa.Table:
         else:
             arrays.append(pa.nulls(table.num_rows, type=field.type))
     return pa.table(arrays, schema=target)
+
+
+def align_interleaved_table(table: pa.Table, schema: pa.Schema | None = None) -> pa.Table:
+    """Reconcile or strictly align an interleaved Arrow table.
+
+    With ``schema=None``, reserved interleaved columns are cast to the canonical
+    types while passthrough columns are preserved. With an explicit schema, the
+    table is padded, reordered, and cast exactly to that schema.
+    """
+    if schema is not None:
+        return align_table(table, schema)
+    return table.cast(reconcile_schema(table.schema))

--- a/nemo_curator/stages/text/io/reader/lance.py
+++ b/nemo_curator/stages/text/io/reader/lance.py
@@ -152,12 +152,22 @@ class LanceReaderStage(BaseReader):
             scanner_kwargs["columns"] = fields
         return scanner_kwargs
 
-    def read_task(
+    def _requested_blob_columns(self, dataset: object, requested_columns: list[str] | None) -> list[str]:
+        """Return requested Lance blob-v2 column names."""
+        return [
+            field.name
+            for field in dataset.schema
+            if getattr(field.type, "extension_name", None) == "lance.blob.v2"
+            and (requested_columns is None or field.name in requested_columns)
+        ]
+
+    def _dataset_and_scanner_kwargs(
         self,
         task: LanceReadTask,
         read_kwargs: dict[str, Any] | None,
         fields: list[str] | None,
-    ) -> ReaderOutput:
+    ) -> tuple[Any, dict[str, Any], list[str]]:
+        """Open the pinned Lance dataset and build scanner kwargs for a read task."""
         read_kwargs = dict(read_kwargs or {})
         dataset_kwargs = _pop_dataset_kwargs(read_kwargs)
         dataset_kwargs["version"] = task.version
@@ -165,36 +175,52 @@ class LanceReaderStage(BaseReader):
         dataset = lance.dataset(task.path, **dataset_kwargs)
         fragments = [dataset.get_fragment(fragment_id) for fragment_id in task.data]
         requested_columns = scanner_kwargs.get("columns")
-        # Blob v2 scans return storage descriptors instead of payload bytes.
-        # Materialize requested blobs separately and align them by row address.
-        has_requested_blobs = any(
-            getattr(field.type, "extension_name", None) == "lance.blob.v2"
-            and (requested_columns is None or field.name in requested_columns)
-            for field in dataset.schema
-        )
-        if self.include_lance_metadata or has_requested_blobs:
+        blob_columns = self._requested_blob_columns(dataset, requested_columns)
+        if self.include_lance_metadata or blob_columns:
             scanner_kwargs["with_row_address"] = True
         if self.include_lance_metadata:
             scanner_kwargs["with_row_id"] = True
         scanner_kwargs["fragments"] = fragments
+        return dataset, scanner_kwargs, blob_columns
+
+    def _metadata_for_task(
+        self,
+        task: LanceReadTask,
+        dataset: object,
+        extra_lance_metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Build common Lance read metadata for downstream batches."""
+        lance_metadata = {
+            "version": task.version,
+            "fragment_ids": list(task.data),
+            "schema": schema_to_json(dataset.schema),
+            "has_stable_row_ids": dataset.has_stable_row_ids,
+        }
+        if extra_lance_metadata:
+            lance_metadata.update(extra_lance_metadata)
+        return {
+            "source_files": [task.path],
+            "lance": lance_metadata,
+        }
+
+    def read_task(
+        self,
+        task: LanceReadTask,
+        read_kwargs: dict[str, Any] | None,
+        fields: list[str] | None,
+    ) -> ReaderOutput:
+        dataset, scanner_kwargs, blob_columns = self._dataset_and_scanner_kwargs(task, read_kwargs, fields)
+        # Blob v2 scans return storage descriptors instead of payload bytes.
+        # Materialize requested blobs separately and align them by row address.
         table = dataset.scanner(**scanner_kwargs).to_table()
-        if has_requested_blobs:
+        if blob_columns:
             table = materialize_lance_blob_columns(dataset, table)
         if self.include_lance_metadata:
             table = add_lance_metadata_columns(table)
-        elif has_requested_blobs and "_rowaddr" in table.column_names:
+        elif blob_columns and "_rowaddr" in table.column_names:
             table = table.drop_columns(["_rowaddr"])
 
-        metadata = {
-            "source_files": [task.path],
-            "lance": {
-                "version": task.version,
-                "fragment_ids": list(task.data),
-                "schema": schema_to_json(dataset.schema),
-                "has_stable_row_ids": dataset.has_stable_row_ids,
-            },
-        }
-        return ReaderOutput(table, metadata)
+        return ReaderOutput(table, self._metadata_for_task(task, dataset))
 
 
 @dataclass

--- a/tests/stages/interleaved/test_interleaved_lance_reader.py
+++ b/tests/stages/interleaved/test_interleaved_lance_reader.py
@@ -55,6 +55,10 @@ def _write_interleaved_dataset(path: Path, rows: list[dict[str, object]], *, max
     )
 
 
+def _nullable_sample_id_schema() -> pa.Schema:
+    return pa.schema([pa.field("sample_id", pa.string(), nullable=True), *list(INTERLEAVED_SCHEMA)[1:]])
+
+
 def _single_fragment_task(dataset_path: Path) -> LanceReadTask:
     return LancePartitioningStage(path=str(dataset_path), fragments_per_partition=1).process(EmptyTask())[0]
 
@@ -127,6 +131,21 @@ def test_interleaved_lance_reader_splits_without_splitting_sample_ids(tmp_path: 
     ]
 
 
+def test_interleaved_lance_reader_rejects_null_sample_ids(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "null-sample-id.lance"
+    row = _row("doc-a", 0, "text", "a0")
+    row["sample_id"] = None
+    table = pa.Table.from_pylist([row], schema=_nullable_sample_id_schema())
+    lance.write_dataset(table, str(dataset_path), mode="create")
+    task = _single_fragment_task(dataset_path)
+
+    with pytest.raises(ValueError, match="contains null values"):
+        InterleavedLanceReaderStage(
+            fields=list(INTERLEAVED_SCHEMA.names),
+            include_lance_metadata=False,
+        ).process(task)
+
+
 def test_interleaved_lance_reader_streaming_carries_sample_across_scanner_batches(tmp_path: Path) -> None:
     dataset_path = tmp_path / "streaming.lance"
     rows = [
@@ -180,6 +199,28 @@ def test_interleaved_lance_reader_streaming_respects_max_output_rows_without_par
     assert tables[0]["sample_id"].combine_chunks().to_pylist() == ["doc-a", "doc-a"]
 
 
+def test_interleaved_lance_reader_non_streaming_records_stopped_early_metadata(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "limited-non-streaming.lance"
+    rows = [
+        _row("doc-a", 0, "text", "a0"),
+        _row("doc-a", 1, "image"),
+        _row("doc-b", 0, "text", "b0"),
+        _row("doc-b", 1, "image"),
+    ]
+    _write_interleaved_dataset(dataset_path, rows)
+    task = _single_fragment_task(dataset_path)
+
+    result = InterleavedLanceReaderStage(
+        fields=list(INTERLEAVED_SCHEMA.names),
+        max_output_rows=3,
+        include_lance_metadata=False,
+    ).process(task)
+
+    assert result._metadata["lance"]["streaming_read"] is False
+    assert result._metadata["lance"]["stopped_early"] is True
+    assert _tables(result)[0]["sample_id"].combine_chunks().to_pylist() == ["doc-a", "doc-a"]
+
+
 def test_interleaved_lance_reader_adds_lance_metadata_columns(tmp_path: Path) -> None:
     dataset_path = tmp_path / "metadata.lance"
     rows = [_row("doc-a", 0, "text", "a0"), _row("doc-a", 1, "image")]
@@ -215,3 +256,23 @@ def test_interleaved_lance_reader_streaming_rejects_blob_columns(tmp_path: Path)
 
     with pytest.raises(NotImplementedError, match=r"does not support lance\.blob\.v2"):
         InterleavedLanceReaderStage(fields=list(schema.names), streaming_read=True).process(task)
+
+
+def test_interleaved_lance_reader_streaming_honors_top_level_version_read_kwarg(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "streaming-version.lance"
+    rows = [_row("doc-a", 0, "text", "a0"), _row("doc-a", 1, "image")]
+    _write_interleaved_dataset(dataset_path, rows)
+    version = lance.dataset(str(dataset_path)).version
+    partitioner, reader = InterleavedLanceReader(
+        path=str(dataset_path),
+        fields=list(INTERLEAVED_SCHEMA.names),
+        read_kwargs={"version": version, "scanner_options": {"batch_size": 1}},
+        streaming_read=True,
+        include_lance_metadata=False,
+    ).decompose()
+    task = partitioner.process(EmptyTask())[0]
+
+    result = reader.process(task)
+
+    assert _tables(result)[0]["sample_id"].combine_chunks().to_pylist() == ["doc-a", "doc-a"]
+    assert result._metadata["lance"]["version"] == version

--- a/tests/stages/interleaved/test_interleaved_lance_reader.py
+++ b/tests/stages/interleaved/test_interleaved_lance_reader.py
@@ -79,8 +79,6 @@ def test_interleaved_lance_reader_decomposes() -> None:
         fields=list(INTERLEAVED_SCHEMA.names),
         max_batch_bytes=256 * 1024 * 1024,
         max_batch_rows=1024,
-        streaming_read=True,
-        max_output_rows=10_000,
         fragments_per_partition=2,
         fragment_ids=[1],
     ).decompose()
@@ -90,14 +88,12 @@ def test_interleaved_lance_reader_decomposes() -> None:
     assert reader.fields == list(INTERLEAVED_SCHEMA.names)
     assert reader.max_batch_bytes == 256 * 1024 * 1024
     assert reader.max_batch_rows == 1024
-    assert reader.streaming_read is True
-    assert reader.max_output_rows == 10_000
     assert reader.include_lance_metadata is True
 
 
 @pytest.mark.parametrize(
     "field",
-    ["max_batch_bytes", "max_batch_rows", "max_output_rows"],
+    ["max_batch_bytes", "max_batch_rows"],
 )
 def test_interleaved_lance_reader_rejects_non_positive_limits(field: str) -> None:
     with pytest.raises(ValueError, match=f"{field} must be > 0"):
@@ -129,6 +125,9 @@ def test_interleaved_lance_reader_splits_without_splitting_sample_ids(tmp_path: 
         ["doc-b", "doc-b"],
         ["doc-c", "doc-c"],
     ]
+    batches = result if isinstance(result, list) else [result]
+    assert all(batch._stage_perf is not task._stage_perf for batch in batches)
+    assert len({id(batch._stage_perf) for batch in batches}) == len(batches)
 
 
 def test_interleaved_lance_reader_rejects_null_sample_ids(tmp_path: Path) -> None:
@@ -139,114 +138,11 @@ def test_interleaved_lance_reader_rejects_null_sample_ids(tmp_path: Path) -> Non
     lance.write_dataset(table, str(dataset_path), mode="create")
     task = _single_fragment_task(dataset_path)
 
-    with pytest.raises(ValueError, match="contains null values"):
+    with pytest.raises(ValueError, match="null values"):
         InterleavedLanceReaderStage(
             fields=list(INTERLEAVED_SCHEMA.names),
             include_lance_metadata=False,
         ).process(task)
-
-
-def test_interleaved_lance_reader_streaming_carries_sample_across_scanner_batches(tmp_path: Path) -> None:
-    dataset_path = tmp_path / "streaming.lance"
-    rows = [
-        _row("doc-a", 0, "text", "a0"),
-        _row("doc-a", 1, "text", "a1"),
-        _row("doc-a", 2, "image"),
-        _row("doc-b", 0, "text", "b0"),
-        _row("doc-b", 1, "image"),
-    ]
-    _write_interleaved_dataset(dataset_path, rows, max_rows_per_group=1)
-    task = _single_fragment_task(dataset_path)
-
-    result = InterleavedLanceReaderStage(
-        fields=list(INTERLEAVED_SCHEMA.names),
-        read_kwargs={"scanner_options": {"batch_size": 1}},
-        streaming_read=True,
-        max_batch_rows=3,
-        include_lance_metadata=False,
-    ).process(task)
-
-    tables = _tables(result)
-    assert [table["sample_id"].combine_chunks().to_pylist() for table in tables] == [
-        ["doc-a", "doc-a", "doc-a"],
-        ["doc-b", "doc-b"],
-    ]
-
-
-def test_interleaved_lance_reader_streaming_respects_max_output_rows_without_partial_sample(
-    tmp_path: Path,
-) -> None:
-    dataset_path = tmp_path / "limited.lance"
-    rows = [
-        _row("doc-a", 0, "text", "a0"),
-        _row("doc-a", 1, "image"),
-        _row("doc-b", 0, "text", "b0"),
-        _row("doc-b", 1, "image"),
-    ]
-    _write_interleaved_dataset(dataset_path, rows, max_rows_per_group=1)
-    task = _single_fragment_task(dataset_path)
-
-    result = InterleavedLanceReaderStage(
-        fields=list(INTERLEAVED_SCHEMA.names),
-        read_kwargs={"scanner_options": {"batch_size": 1}},
-        streaming_read=True,
-        max_output_rows=3,
-        include_lance_metadata=False,
-    ).process(task)
-
-    tables = _tables(result)
-    assert len(tables) == 1
-    assert tables[0]["sample_id"].combine_chunks().to_pylist() == ["doc-a", "doc-a"]
-
-
-def test_interleaved_lance_reader_non_streaming_records_stopped_early_metadata(tmp_path: Path) -> None:
-    dataset_path = tmp_path / "limited-non-streaming.lance"
-    rows = [
-        _row("doc-a", 0, "text", "a0"),
-        _row("doc-a", 1, "image"),
-        _row("doc-b", 0, "text", "b0"),
-        _row("doc-b", 1, "image"),
-    ]
-    _write_interleaved_dataset(dataset_path, rows)
-    task = _single_fragment_task(dataset_path)
-
-    result = InterleavedLanceReaderStage(
-        fields=list(INTERLEAVED_SCHEMA.names),
-        max_output_rows=3,
-        include_lance_metadata=False,
-    ).process(task)
-
-    assert result._metadata["lance"]["streaming_read"] is False
-    assert result._metadata["lance"]["stopped_early"] is True
-    assert _tables(result)[0]["sample_id"].combine_chunks().to_pylist() == ["doc-a", "doc-a"]
-
-
-def test_interleaved_lance_reader_max_output_rows_counts_size_limited_flushes(tmp_path: Path) -> None:
-    dataset_path = tmp_path / "limited-after-flush.lance"
-    rows = [
-        _row("doc-a", 0, "text", "a0"),
-        _row("doc-a", 1, "image"),
-        _row("doc-b", 0, "text", "b0"),
-        _row("doc-b", 1, "image"),
-        _row("doc-c", 0, "text", "c0"),
-        _row("doc-c", 1, "image"),
-    ]
-    _write_interleaved_dataset(dataset_path, rows)
-    task = _single_fragment_task(dataset_path)
-
-    result = InterleavedLanceReaderStage(
-        fields=list(INTERLEAVED_SCHEMA.names),
-        max_batch_rows=2,
-        max_output_rows=4,
-        include_lance_metadata=False,
-    ).process(task)
-
-    tables = _tables(result)
-    assert sum(table.num_rows for table in tables) == 4
-    assert [table["sample_id"].combine_chunks().to_pylist() for table in tables] == [
-        ["doc-a", "doc-a"],
-        ["doc-b", "doc-b"],
-    ]
 
 
 def test_interleaved_lance_reader_adds_lance_metadata_columns(tmp_path: Path) -> None:
@@ -266,28 +162,8 @@ def test_interleaved_lance_reader_adds_lance_metadata_columns(tmp_path: Path) ->
     assert result._metadata["lance"]["has_stable_row_ids"] is False
 
 
-def test_interleaved_lance_reader_streaming_rejects_blob_columns(tmp_path: Path) -> None:
-    dataset_path = tmp_path / "blob.lance"
-    schema = INTERLEAVED_SCHEMA.append(lance.blob_field("payload"))
-    row = _row("doc-a", 0, "text", "a0")
-    table = pa.Table.from_pylist([row], schema=INTERLEAVED_SCHEMA).append_column(
-        "payload",
-        lance.blob_array([b"payload"]),
-    )
-    lance.write_dataset(
-        table.cast(schema),
-        str(dataset_path),
-        mode="create",
-        data_storage_version="2.2",
-    )
-    task = _single_fragment_task(dataset_path)
-
-    with pytest.raises(NotImplementedError, match=r"does not support lance\.blob\.v2"):
-        InterleavedLanceReaderStage(fields=list(schema.names), streaming_read=True).process(task)
-
-
-def test_interleaved_lance_reader_streaming_honors_top_level_version_read_kwarg(tmp_path: Path) -> None:
-    dataset_path = tmp_path / "streaming-version.lance"
+def test_interleaved_lance_reader_honors_top_level_version_read_kwarg(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "version.lance"
     rows = [_row("doc-a", 0, "text", "a0"), _row("doc-a", 1, "image")]
     _write_interleaved_dataset(dataset_path, rows)
     version = lance.dataset(str(dataset_path)).version
@@ -295,7 +171,6 @@ def test_interleaved_lance_reader_streaming_honors_top_level_version_read_kwarg(
         path=str(dataset_path),
         fields=list(INTERLEAVED_SCHEMA.names),
         read_kwargs={"version": version, "scanner_options": {"batch_size": 1}},
-        streaming_read=True,
         include_lance_metadata=False,
     ).decompose()
     task = partitioner.process(EmptyTask())[0]

--- a/tests/stages/interleaved/test_interleaved_lance_reader.py
+++ b/tests/stages/interleaved/test_interleaved_lance_reader.py
@@ -221,6 +221,34 @@ def test_interleaved_lance_reader_non_streaming_records_stopped_early_metadata(t
     assert _tables(result)[0]["sample_id"].combine_chunks().to_pylist() == ["doc-a", "doc-a"]
 
 
+def test_interleaved_lance_reader_max_output_rows_counts_size_limited_flushes(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "limited-after-flush.lance"
+    rows = [
+        _row("doc-a", 0, "text", "a0"),
+        _row("doc-a", 1, "image"),
+        _row("doc-b", 0, "text", "b0"),
+        _row("doc-b", 1, "image"),
+        _row("doc-c", 0, "text", "c0"),
+        _row("doc-c", 1, "image"),
+    ]
+    _write_interleaved_dataset(dataset_path, rows)
+    task = _single_fragment_task(dataset_path)
+
+    result = InterleavedLanceReaderStage(
+        fields=list(INTERLEAVED_SCHEMA.names),
+        max_batch_rows=2,
+        max_output_rows=4,
+        include_lance_metadata=False,
+    ).process(task)
+
+    tables = _tables(result)
+    assert sum(table.num_rows for table in tables) == 4
+    assert [table["sample_id"].combine_chunks().to_pylist() for table in tables] == [
+        ["doc-a", "doc-a"],
+        ["doc-b", "doc-b"],
+    ]
+
+
 def test_interleaved_lance_reader_adds_lance_metadata_columns(tmp_path: Path) -> None:
     dataset_path = tmp_path / "metadata.lance"
     rows = [_row("doc-a", 0, "text", "a0"), _row("doc-a", 1, "image")]

--- a/tests/stages/interleaved/test_interleaved_lance_reader.py
+++ b/tests/stages/interleaved/test_interleaved_lance_reader.py
@@ -27,6 +27,7 @@ from nemo_curator.stages.text.io.reader.lance import (
 )
 from nemo_curator.tasks import EmptyTask, InterleavedBatch
 from nemo_curator.tasks.interleaved import INTERLEAVED_SCHEMA
+from nemo_curator.utils.performance_utils import StagePerfStats
 
 lance = pytest.importorskip("lance")
 
@@ -68,9 +69,16 @@ def _tables(result: InterleavedBatch | list[InterleavedBatch]) -> list[pa.Table]
     return [batch.to_pyarrow() for batch in batches]
 
 
-def test_interleaved_lance_reader_validates_required_fields() -> None:
-    with pytest.raises(ValueError, match="omit required columns"):
-        InterleavedLanceReader(path="example.lance", fields=["sample_id"]).decompose()
+def test_interleaved_lance_reader_stage_reports_missing_required_fields() -> None:
+    fields = ["sample_id"]
+    missing = sorted(InterleavedBatch.REQUIRED_COLUMNS - set(fields))
+
+    with pytest.raises(ValueError, match="omit required columns") as exc_info:
+        InterleavedLanceReaderStage(fields=fields)
+
+    error = str(exc_info.value)
+    assert "omit required columns" in error
+    assert all(field in error for field in missing)
 
 
 def test_interleaved_lance_reader_decomposes() -> None:
@@ -112,6 +120,7 @@ def test_interleaved_lance_reader_splits_without_splitting_sample_ids(tmp_path: 
     ]
     _write_interleaved_dataset(dataset_path, rows)
     task = _single_fragment_task(dataset_path)
+    task._stage_perf = [StagePerfStats(stage_name="upstream")]
 
     result = InterleavedLanceReaderStage(
         fields=list(INTERLEAVED_SCHEMA.names),
@@ -126,6 +135,7 @@ def test_interleaved_lance_reader_splits_without_splitting_sample_ids(tmp_path: 
         ["doc-c", "doc-c"],
     ]
     batches = result if isinstance(result, list) else [result]
+    assert all(batch._stage_perf == task._stage_perf for batch in batches)
     assert all(batch._stage_perf is not task._stage_perf for batch in batches)
     assert len({id(batch._stage_perf) for batch in batches}) == len(batches)
 
@@ -164,18 +174,26 @@ def test_interleaved_lance_reader_adds_lance_metadata_columns(tmp_path: Path) ->
 
 def test_interleaved_lance_reader_honors_top_level_version_read_kwarg(tmp_path: Path) -> None:
     dataset_path = tmp_path / "version.lance"
-    rows = [_row("doc-a", 0, "text", "a0"), _row("doc-a", 1, "image")]
-    _write_interleaved_dataset(dataset_path, rows)
-    version = lance.dataset(str(dataset_path)).version
+    old_rows = [_row("doc-old", 0, "text", "old"), _row("doc-old", 1, "image")]
+    _write_interleaved_dataset(dataset_path, old_rows)
+    old_version = lance.dataset(str(dataset_path)).version
+    new_rows = [_row("doc-new", 0, "text", "new"), _row("doc-new", 1, "image")]
+    lance.write_dataset(
+        pa.Table.from_pylist(new_rows, schema=INTERLEAVED_SCHEMA),
+        str(dataset_path),
+        mode="overwrite",
+        max_rows_per_file=len(new_rows),
+    )
     partitioner, reader = InterleavedLanceReader(
         path=str(dataset_path),
         fields=list(INTERLEAVED_SCHEMA.names),
-        read_kwargs={"version": version, "scanner_options": {"batch_size": 1}},
+        read_kwargs={"version": old_version, "scanner_options": {"batch_size": 1}},
         include_lance_metadata=False,
     ).decompose()
     task = partitioner.process(EmptyTask())[0]
 
     result = reader.process(task)
 
-    assert _tables(result)[0]["sample_id"].combine_chunks().to_pylist() == ["doc-a", "doc-a"]
-    assert result._metadata["lance"]["version"] == version
+    assert task.version == old_version
+    assert _tables(result)[0]["sample_id"].combine_chunks().to_pylist() == ["doc-old", "doc-old"]
+    assert result._metadata["lance"]["version"] == old_version

--- a/tests/stages/interleaved/test_interleaved_lance_reader.py
+++ b/tests/stages/interleaved/test_interleaved_lance_reader.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+from nemo_curator.stages.interleaved.lance import InterleavedLanceReader, InterleavedLanceReaderStage
+from nemo_curator.stages.text.io.reader.lance import (
+    LANCE_FRAGID_COLUMN,
+    LANCE_ROWADDR_COLUMN,
+    LANCE_ROWID_COLUMN,
+    LancePartitioningStage,
+    LanceReadTask,
+)
+from nemo_curator.tasks import EmptyTask, InterleavedBatch
+from nemo_curator.tasks.interleaved import INTERLEAVED_SCHEMA
+
+lance = pytest.importorskip("lance")
+
+
+def _row(sample_id: str, position: int, modality: str, text: str | None = None) -> dict[str, object]:
+    return {
+        "sample_id": sample_id,
+        "position": position,
+        "modality": modality,
+        "content_type": "text/plain" if modality == "text" else None,
+        "text_content": text,
+        "binary_content": None,
+        "source_ref": None,
+        "materialize_error": None,
+    }
+
+
+def _write_interleaved_dataset(path: Path, rows: list[dict[str, object]], *, max_rows_per_group: int = 2) -> None:
+    table = pa.Table.from_pylist(rows, schema=INTERLEAVED_SCHEMA)
+    lance.write_dataset(
+        table,
+        str(path),
+        mode="create",
+        max_rows_per_file=len(rows),
+        max_rows_per_group=max_rows_per_group,
+    )
+
+
+def _single_fragment_task(dataset_path: Path) -> LanceReadTask:
+    return LancePartitioningStage(path=str(dataset_path), fragments_per_partition=1).process(EmptyTask())[0]
+
+
+def _tables(result: InterleavedBatch | list[InterleavedBatch]) -> list[pa.Table]:
+    batches = result if isinstance(result, list) else [result]
+    return [batch.to_pyarrow() for batch in batches]
+
+
+def test_interleaved_lance_reader_validates_required_fields() -> None:
+    with pytest.raises(ValueError, match="omit required columns"):
+        InterleavedLanceReader(path="example.lance", fields=["sample_id"]).decompose()
+
+
+def test_interleaved_lance_reader_decomposes() -> None:
+    partitioner, reader = InterleavedLanceReader(
+        path="example.lance",
+        fields=list(INTERLEAVED_SCHEMA.names),
+        max_batch_bytes=256 * 1024 * 1024,
+        max_batch_rows=1024,
+        streaming_read=True,
+        max_output_rows=10_000,
+        fragments_per_partition=2,
+        fragment_ids=[1],
+    ).decompose()
+
+    assert partitioner.fragments_per_partition == 2
+    assert partitioner.fragment_ids == [1]
+    assert reader.fields == list(INTERLEAVED_SCHEMA.names)
+    assert reader.max_batch_bytes == 256 * 1024 * 1024
+    assert reader.max_batch_rows == 1024
+    assert reader.streaming_read is True
+    assert reader.max_output_rows == 10_000
+    assert reader.include_lance_metadata is True
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["max_batch_bytes", "max_batch_rows", "max_output_rows"],
+)
+def test_interleaved_lance_reader_rejects_non_positive_limits(field: str) -> None:
+    with pytest.raises(ValueError, match=f"{field} must be > 0"):
+        InterleavedLanceReaderStage(**{field: 0})
+
+
+def test_interleaved_lance_reader_splits_without_splitting_sample_ids(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "interleaved.lance"
+    rows = [
+        _row("doc-a", 0, "text", "a0"),
+        _row("doc-a", 1, "image"),
+        _row("doc-b", 0, "text", "b0"),
+        _row("doc-b", 1, "image"),
+        _row("doc-c", 0, "text", "c0"),
+        _row("doc-c", 1, "image"),
+    ]
+    _write_interleaved_dataset(dataset_path, rows)
+    task = _single_fragment_task(dataset_path)
+
+    result = InterleavedLanceReaderStage(
+        fields=list(INTERLEAVED_SCHEMA.names),
+        max_batch_rows=3,
+        include_lance_metadata=False,
+    ).process(task)
+
+    tables = _tables(result)
+    assert [table["sample_id"].combine_chunks().to_pylist() for table in tables] == [
+        ["doc-a", "doc-a"],
+        ["doc-b", "doc-b"],
+        ["doc-c", "doc-c"],
+    ]
+
+
+def test_interleaved_lance_reader_streaming_carries_sample_across_scanner_batches(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "streaming.lance"
+    rows = [
+        _row("doc-a", 0, "text", "a0"),
+        _row("doc-a", 1, "text", "a1"),
+        _row("doc-a", 2, "image"),
+        _row("doc-b", 0, "text", "b0"),
+        _row("doc-b", 1, "image"),
+    ]
+    _write_interleaved_dataset(dataset_path, rows, max_rows_per_group=1)
+    task = _single_fragment_task(dataset_path)
+
+    result = InterleavedLanceReaderStage(
+        fields=list(INTERLEAVED_SCHEMA.names),
+        read_kwargs={"scanner_options": {"batch_size": 1}},
+        streaming_read=True,
+        max_batch_rows=3,
+        include_lance_metadata=False,
+    ).process(task)
+
+    tables = _tables(result)
+    assert [table["sample_id"].combine_chunks().to_pylist() for table in tables] == [
+        ["doc-a", "doc-a", "doc-a"],
+        ["doc-b", "doc-b"],
+    ]
+
+
+def test_interleaved_lance_reader_streaming_respects_max_output_rows_without_partial_sample(
+    tmp_path: Path,
+) -> None:
+    dataset_path = tmp_path / "limited.lance"
+    rows = [
+        _row("doc-a", 0, "text", "a0"),
+        _row("doc-a", 1, "image"),
+        _row("doc-b", 0, "text", "b0"),
+        _row("doc-b", 1, "image"),
+    ]
+    _write_interleaved_dataset(dataset_path, rows, max_rows_per_group=1)
+    task = _single_fragment_task(dataset_path)
+
+    result = InterleavedLanceReaderStage(
+        fields=list(INTERLEAVED_SCHEMA.names),
+        read_kwargs={"scanner_options": {"batch_size": 1}},
+        streaming_read=True,
+        max_output_rows=3,
+        include_lance_metadata=False,
+    ).process(task)
+
+    tables = _tables(result)
+    assert len(tables) == 1
+    assert tables[0]["sample_id"].combine_chunks().to_pylist() == ["doc-a", "doc-a"]
+
+
+def test_interleaved_lance_reader_adds_lance_metadata_columns(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "metadata.lance"
+    rows = [_row("doc-a", 0, "text", "a0"), _row("doc-a", 1, "image")]
+    _write_interleaved_dataset(dataset_path, rows)
+    task = _single_fragment_task(dataset_path)
+
+    result = InterleavedLanceReaderStage(fields=list(INTERLEAVED_SCHEMA.names)).process(task)
+    table = _tables(result)[0]
+
+    assert LANCE_ROWID_COLUMN in table.column_names
+    assert LANCE_ROWADDR_COLUMN in table.column_names
+    assert LANCE_FRAGID_COLUMN in table.column_names
+    assert result._metadata["lance"]["version"] == task.version
+    assert result._metadata["lance"]["fragment_ids"] == task.data
+    assert result._metadata["lance"]["has_stable_row_ids"] is False
+
+
+def test_interleaved_lance_reader_streaming_rejects_blob_columns(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "blob.lance"
+    schema = INTERLEAVED_SCHEMA.append(lance.blob_field("payload"))
+    row = _row("doc-a", 0, "text", "a0")
+    table = pa.Table.from_pylist([row], schema=INTERLEAVED_SCHEMA).append_column(
+        "payload",
+        lance.blob_array([b"payload"]),
+    )
+    lance.write_dataset(
+        table.cast(schema),
+        str(dataset_path),
+        mode="create",
+        data_storage_version="2.2",
+    )
+    task = _single_fragment_task(dataset_path)
+
+    with pytest.raises(NotImplementedError, match=r"does not support lance\.blob\.v2"):
+        InterleavedLanceReaderStage(fields=list(schema.names), streaming_read=True).process(task)

--- a/tests/stages/interleaved/test_multimodal_core.py
+++ b/tests/stages/interleaved/test_multimodal_core.py
@@ -21,7 +21,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from nemo_curator.core.utils import split_table_by_group_max_bytes
+from nemo_curator.core.utils import split_table_by_group, split_table_by_group_max_bytes
 from nemo_curator.stages.interleaved.io.reader import InterleavedWebdatasetReader
 from nemo_curator.stages.interleaved.stages import (
     BaseInterleavedAnnotatorStage,
@@ -421,9 +421,28 @@ def test_split_table_multiple_groups_split() -> None:
 def test_split_table_preserves_group_integrity() -> None:
     table = pa.table({"g": ["a", "b", "a", "b"], "v": [1, 2, 3, 4]})
     result = split_table_by_group_max_bytes(table, "g", 1)
+    assert pa.concat_tables(result).equals(table)
     for chunk in result:
         groups = chunk["g"].to_pylist()
         assert len(set(groups)) == 1 or all(g == groups[0] for g in groups)
+
+
+def test_split_table_supports_row_limits() -> None:
+    table = pa.table({"g": ["a", "a", "b", "b", "c", "c"], "v": [1, 2, 3, 4, 5, 6]})
+    result = split_table_by_group(
+        table,
+        "g",
+        max_batch_rows=3,
+    )
+
+    assert [chunk["g"].to_pylist() for chunk in result] == [["a", "a"], ["b", "b"], ["c", "c"]]
+
+
+def test_split_table_rejects_null_groups() -> None:
+    table = pa.table({"g": ["a", None], "v": [1, 2]})
+
+    with pytest.raises(ValueError, match="contains null values"):
+        split_table_by_group(table, "g", max_batch_rows=1)
 
 
 # --- basic_row_validity_mask tests ---

--- a/tests/stages/interleaved/test_multimodal_core.py
+++ b/tests/stages/interleaved/test_multimodal_core.py
@@ -21,7 +21,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from nemo_curator.core.utils import split_table_by_group, split_table_by_group_max_bytes
+from nemo_curator.core.utils import split_table_by_group
 from nemo_curator.stages.interleaved.io.reader import InterleavedWebdatasetReader
 from nemo_curator.stages.interleaved.stages import (
     BaseInterleavedAnnotatorStage,
@@ -373,19 +373,19 @@ def test_aspect_ratio_filter_works_on_png_images() -> None:
     assert out["position"].tolist() == [0, 1]
 
 
-# --- split_table_by_group_max_bytes tests ---
+# --- split_table_by_group tests ---
 
 
 def test_split_table_none_max_bytes() -> None:
     table = pa.table({"g": ["a", "a", "b"], "v": [1, 2, 3]})
-    result = split_table_by_group_max_bytes(table, "g", None)
+    result = split_table_by_group(table, "g", max_batch_bytes=None)
     assert len(result) == 1
     assert result[0].num_rows == 3
 
 
 def test_split_table_empty_table() -> None:
     table = pa.table({"g": pa.array([], type=pa.string()), "v": pa.array([], type=pa.int64())})
-    result = split_table_by_group_max_bytes(table, "g", 100)
+    result = split_table_by_group(table, "g", max_batch_bytes=100)
     assert len(result) == 1
     assert result[0].num_rows == 0
 
@@ -393,18 +393,18 @@ def test_split_table_empty_table() -> None:
 def test_split_table_invalid_max_bytes() -> None:
     table = pa.table({"g": ["a"], "v": [1]})
     with pytest.raises(ValueError, match="max_batch_bytes must be > 0"):
-        split_table_by_group_max_bytes(table, "g", 0)
+        split_table_by_group(table, "g", max_batch_bytes=0)
 
 
 def test_split_table_missing_column() -> None:
     table = pa.table({"g": ["a"], "v": [1]})
     with pytest.raises(ValueError, match="not found in table"):
-        split_table_by_group_max_bytes(table, "missing", 100)
+        split_table_by_group(table, "missing", max_batch_bytes=100)
 
 
 def test_split_table_single_large_group() -> None:
     table = pa.table({"g": ["a"] * 100, "v": list(range(100))})
-    result = split_table_by_group_max_bytes(table, "g", 1)
+    result = split_table_by_group(table, "g", max_batch_bytes=1)
     assert len(result) == 1
     assert result[0].num_rows == 100
 
@@ -412,7 +412,7 @@ def test_split_table_single_large_group() -> None:
 def test_split_table_multiple_groups_split() -> None:
     table = pa.table({"g": ["a", "a", "b", "b", "c", "c"], "v": [1, 2, 3, 4, 5, 6]})
     small_limit = table.slice(0, 2).nbytes + 1
-    result = split_table_by_group_max_bytes(table, "g", small_limit)
+    result = split_table_by_group(table, "g", max_batch_bytes=small_limit)
     assert len(result) >= 2
     total_rows = sum(t.num_rows for t in result)
     assert total_rows == 6
@@ -420,7 +420,7 @@ def test_split_table_multiple_groups_split() -> None:
 
 def test_split_table_preserves_group_integrity() -> None:
     table = pa.table({"g": ["a", "b", "a", "b"], "v": [1, 2, 3, 4]})
-    result = split_table_by_group_max_bytes(table, "g", 1)
+    result = split_table_by_group(table, "g", max_batch_bytes=1)
     assert pa.concat_tables(result).equals(table)
     for chunk in result:
         groups = chunk["g"].to_pylist()


### PR DESCRIPTION
 ## Summary

  Adds an `InterleavedLanceReader` for row-wise interleaved multimodal Lance datasets.

  The reader builds on Curator's existing `LancePartitioningStage` and
  `LanceReaderStage`, then splits each resulting Arrow table into validated
  `InterleavedBatch` outputs while preserving row order and `sample_id`
  document boundaries.

  ## Changes

  - Added `nemo_curator.stages.interleaved.lance.InterleavedLanceReader`
  - Added `InterleavedLanceReaderStage`
  - Reuses `LanceReaderStage.read_task()` for:
    - Dataset and scanner configuration
    - Pinned Lance versions
    - Blob materialization
    - Optional Lance metadata columns
  - Supports document-aware output batching with:
    - `max_batch_bytes`
    - `max_batch_rows`
  - Supports:
    - `fragment_ids`
    - `fragments_per_partition`
    - Field projection and Lance read options
  - Preserves source row order and never splits consecutive rows belonging
    to the same `sample_id`
  - Validates required `InterleavedBatch` fields and rejects null `sample_id`
    values
  - Exports the reader through the interleaved stage package

  ## Tests

  Added unit coverage for:

  - Required field validation
  - Reader decomposition/config propagation
  - Invalid batch/output limits
  - Row-count based splitting without splitting `sample_id`
  - Streaming reads where one sample spans scanner batches
  - `max_output_rows` behavior without emitting partial samples
  - Lance metadata columns
  - Rejection of unsupported streaming blob columns