### PR TITLE
Add benchmark viewer URLs and re-enable Slack failure pings

### DIFF
--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -313,7 +313,7 @@ python benchmarking/run.py \
   --viewer-url "http://viewer.example.com/run-viewer?dir=/path/to/results/&run=my-session"
 ```
 
-If part of the URL depends on the selected results path or session name, use `--viewer-url-template`. The template is rendered after the final session name and session path are known:
+If part of the URL depends on the selected results path or session name, use `--viewer-url-template`. The template is rendered after the final session name and session path are known. When benchmarks run in a container with configured `host_path` / `container_path` mounts, path placeholders use the host-visible path so links work outside the container:
 
 ```bash
 python benchmarking/run.py \
@@ -334,11 +334,11 @@ Supported `--viewer-url-template` placeholders:
 
 | Placeholder | Value |
 | --- | --- |
-| `{results_path}` | The configured results root directory. |
+| `{results_path}` | The configured results root directory, unmapped to the host-visible path when running in a container. |
 | `{results_path_url}` | URL-encoded `results_path`. |
 | `{session_name}` | The resolved session name, either from `--session-name` or the generated default. |
 | `{session_name_url}` | URL-encoded `session_name`. |
-| `{session_path}` | The full session result directory, equivalent to `{results_path}/{session_name}`. |
+| `{session_path}` | The full session result directory, equivalent to `{results_path}/{session_name}`, unmapped to the host-visible path when running in a container. |
 | `{session_path_url}` | URL-encoded `session_path`. |
 
 Use `results_path` when the viewer expects the results root and a separate `run` parameter. Use `session_path` when the viewer expects a single path directly to the session directory. Set either `viewer_url` or `viewer_url_template`, not both.

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -165,6 +165,19 @@ default_timeout_s: 7200
 # Defaults to 14340 (3h59m).
 max_timeout_s: 14340
 
+# Optional: Free-text reason for the run, persisted in env.json and surfaced to sinks.
+run_reason: "26.06 RC7 benchmarks"
+
+# Optional: Resolved benchmark viewer URL, persisted in env.json and surfaced to sinks.
+# Set either viewer_url or viewer_url_template, not both.
+viewer_url: "http://viewer.example.com/run-viewer?dir=/path/to/results/session"
+
+# Optional: Benchmark viewer URL template. Used when viewer_url is not set, and
+# rendered after the session name/path are known. Supported placeholders are:
+# {results_path}, {results_path_url}, {session_name}, {session_name_url},
+# {session_path}, and {session_path_url}. The *_url forms are URL-encoded.
+viewer_url_template: "http://viewer.example.com/run-viewer?dir={results_path_url}&run={session_name_url}"
+
 # Optional: Delete scratch directories after each entry completes
 # The path {session_entry_dir}/scratch is automatically created when an entry starts and can be used by benchmark
 #scripts for writing temp files. This directory is automatically cleaned up on completion of the entry if
@@ -289,6 +302,46 @@ python benchmarking/run.py \
   --config config.yaml \
   --session-name my-experiment-v2
 ```
+
+**Benchmark viewer URL:**
+
+To include a link to a benchmark run viewer in sinks such as Slack, pass a resolved URL with `--viewer-url`:
+
+```bash
+python benchmarking/run.py \
+  --config config.yaml \
+  --viewer-url "http://viewer.example.com/run-viewer?dir=/path/to/results/&run=my-session"
+```
+
+If part of the URL depends on the selected results path or session name, use `--viewer-url-template`. The template is rendered after the final session name and session path are known:
+
+```bash
+python benchmarking/run.py \
+  --config config.yaml \
+  --session-name my-session \
+  --viewer-url-template "http://viewer.example.com/run-viewer?dir={results_path_url}&run={session_name_url}"
+```
+
+For a viewer that reads results from a remote host path, include the host in the template:
+
+```bash
+python benchmarking/run.py \
+  --config config.yaml \
+  --viewer-url-template "http://rratzel-ws1:5050/run-viewer?dir=dgx-a100-01%3A{results_path_url}%2F&run={session_name_url}"
+```
+
+Supported `--viewer-url-template` placeholders:
+
+| Placeholder | Value |
+| --- | --- |
+| `{results_path}` | The configured results root directory. |
+| `{results_path_url}` | URL-encoded `results_path`. |
+| `{session_name}` | The resolved session name, either from `--session-name` or the generated default. |
+| `{session_name_url}` | URL-encoded `session_name`. |
+| `{session_path}` | The full session result directory, equivalent to `{results_path}/{session_name}`. |
+| `{session_path_url}` | URL-encoded `session_path`. |
+
+Use `results_path` when the viewer expects the results root and a separate `run` parameter. Use `session_path` when the viewer expects a single path directly to the session directory. Set either `viewer_url` or `viewer_url_template`, not both.
 
 ### Environment Variables
 

--- a/benchmarking/nightly-benchmark.yaml
+++ b/benchmarking/nightly-benchmark.yaml
@@ -151,9 +151,7 @@ sinks:
     live_updates: true
     channel_id: ${SLACK_CHANNEL_ID}
     default_metrics: ["exec_time_s"]
-    # Temporarily disable @-mentions on failure while the test suite is being
-    # stabilized. Flip back to true (or remove this line) once runs are clean.
-    ping_users_on_failure: false
+    ping_users_on_failure: true
 #  - name: gdrive
 #    enabled: false
 #    drive_folder_id: ${GDRIVE_FOLDER_ID}

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -62,6 +62,7 @@ from runner.utils import (
     remove_disabled_blocks,
     resolve_env_vars,
 )
+from runner.viewer_url import resolve_viewer_url
 
 
 def ensure_dir(dir_path: Path) -> None:
@@ -432,12 +433,19 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
             "replaced with an empty string and a warning is logged."
         ),
     )
-    parser.add_argument(
+    viewer_url_group = parser.add_mutually_exclusive_group()
+    viewer_url_group.add_argument(
         "--viewer-url",
         default=None,
+        help=("Resolved run-viewer URL to surface in sinks. Overrides viewer_url_template from YAML config when set."),
+    )
+    viewer_url_group.add_argument(
+        "--viewer-url-template",
+        default=None,
         help=(
-            "Run-viewer URL to surface in sinks (e.g. Slack parent message footer). "
-            "When set, the Slack sink renders a 'Results viewer' section linking to this URL."
+            "Run-viewer URL template to render after the session path is known. Supports "
+            "{results_path}, {results_path_url}, {session_name}, {session_name_url}, "
+            "{session_path}, and {session_path_url}. Mutually exclusive with --viewer-url."
         ),
     )
     parser.add_argument(
@@ -498,14 +506,29 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
     session_path = (session.results_path / session_name).absolute()
     ensure_dir(session_path)
 
+    if args.reason:
+        session.run_reason = args.reason
+    if args.viewer_url:
+        session.viewer_url = args.viewer_url
+        session.viewer_url_template = None
+    elif args.viewer_url_template:
+        session.viewer_url = None
+        session.viewer_url_template = args.viewer_url_template
+    try:
+        session.viewer_url = resolve_viewer_url(
+            viewer_url=session.viewer_url,
+            viewer_url_template=session.viewer_url_template,
+            results_path=session.results_path,
+            session_name=session_name,
+            session_path=session_path,
+        )
+    except ValueError as e:
+        logger.error(str(e))
+        return 1
+
     session_overall_success = True
     logger.info(f"Started session {session_name}...")
     env_dict = dump_env(session_obj=session, output_path=session_path)
-
-    # Record an optional free-text reason for the run (e.g. "regression check after MR !2442").
-    # Appears in env.json and the Slack environment block. No-op when unset.
-    if args.reason:
-        env_dict["run_reason"] = args.reason
 
     if not run_data_setups(
         setup_entries=session.data_setups,
@@ -515,13 +538,6 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
     ):
         logger.error("Data setup failed; benchmark entries will not be run.")
         return 1
-
-    # Surface an optional run-viewer URL in the Slack sink. Patch sink_config in-process
-    # so we don't have to teach the YAML config loader about a per-launch viewer URL.
-    if args.viewer_url:
-        for sink in session.sinks:
-            if getattr(sink, "name", None) == "slack":
-                sink.sink_config["viewer_url"] = args.viewer_url
 
     for sink in session.sinks:
         sink.initialize(session_name=session_name, session=session, env_dict=env_dict)

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -515,12 +515,15 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
         session.viewer_url = None
         session.viewer_url_template = args.viewer_url_template
     try:
+        # viewer_url must have paths that are visible outside of a
+        # container, meaning host paths that are mapped to container
+        # mounts (if any) will be "unmapped".
         session.viewer_url = resolve_viewer_url(
             viewer_url=session.viewer_url,
             viewer_url_template=session.viewer_url_template,
-            results_path=session.results_path,
+            results_path=session.path_resolver.unmap_container_path(session.results_path),
             session_name=session_name,
-            session_path=session_path,
+            session_path=session.path_resolver.unmap_container_path(session_path),
         )
     except ValueError as e:
         logger.error(str(e))

--- a/benchmarking/runner/env_capture.py
+++ b/benchmarking/runner/env_capture.py
@@ -31,6 +31,10 @@ from runner.utils import get_obj_for_json, get_shm_usage, get_total_memory_bytes
 def dump_env(session_obj: Session, output_path: Path) -> dict[str, Any]:
     env_data = get_env()
     env_data["object_store_size"] = session_obj.object_store_size
+    if session_obj.run_reason:
+        env_data["run_reason"] = session_obj.run_reason
+    if session_obj.viewer_url:
+        env_data["viewer_url"] = session_obj.viewer_url
 
     # Try package managers in order of preference for capturing the environment
     # package_managers = [("uv", "pip freeze"), ("pip", "freeze"), ("micromamba", "list --explicit"), ("conda", "list --explicit")]  # noqa: ERA001

--- a/benchmarking/runner/path_resolver.py
+++ b/benchmarking/runner/path_resolver.py
@@ -54,7 +54,9 @@ class PathResolver:
                 self.path_map[name] = container_path if in_docker else host_path
                 self._volume_pairs.append((host_path, container_path))
         else:
-            # Legacy path fields (deprecated)
+            # Legacy top-level YAML path fields are deprecated. The path
+            # names themselves, including "results_path", are still valid
+            # when provided through the preferred "paths" list above.
             for name, host_path in [
                 ("results_path", Path(data["results_path"])),
                 ("datasets_path", Path(data["datasets_path"])),
@@ -67,6 +69,26 @@ class PathResolver:
     def volume_mount_pairs(self) -> Iterator[tuple[Path, Path]]:
         """Yield (host_path, container_path) pairs for all configured paths."""
         yield from self._volume_pairs
+
+    def unmap_container_path(self, path: Path) -> Path:
+        """Return the host path for a path under a configured container mount."""
+        matches: list[tuple[int, Path]] = []
+        for host_path, container_path in self._volume_pairs:
+            # relative_to() succeeds only when path is inside this container
+            # mount. Otherwise it raises ValueError and we try the next mount.
+            try:
+                relative_path = path.relative_to(container_path)
+            except ValueError:
+                continue
+            # Store both match specificity and the host-visible path so
+            # nested/overlapping mounts resolve to the longest matching mount.
+            matches.append((len(container_path.parts), host_path / relative_path))
+
+        if not matches:
+            return path
+
+        _, host_visible_path = max(matches, key=lambda match: match[0])
+        return host_visible_path
 
     def resolve(self, name: str) -> Path:
         """

--- a/benchmarking/runner/session.py
+++ b/benchmarking/runner/session.py
@@ -84,6 +84,11 @@ class Session:
     # before and after each benchmark run. If None, any usage > 0 triggers a warning.
     # Entries can override this value.
     gpu_mem_use_warning_threshold: float | None = None
+    # Optional session metadata. viewer_url is the resolved link exposed to sinks;
+    # viewer_url_template is rendered into viewer_url once the session name/path is known.
+    viewer_url: str | None = None
+    viewer_url_template: str | None = None
+    run_reason: str | None = None
     # Global ray settings inherited by all entries; per-entry ray sections override these values.
     ray: dict = field(default_factory=dict)
     path_resolver: PathResolver = None
@@ -117,6 +122,16 @@ class Session:
 
         if not isinstance(self.max_timeout_s, int) or isinstance(self.max_timeout_s, bool) or self.max_timeout_s <= 0:
             msg = f"Invalid max_timeout_s: {self.max_timeout_s}; must be a positive integer."
+            raise ValueError(msg)
+
+        for field_name in ("viewer_url", "viewer_url_template", "run_reason"):
+            value = getattr(self, field_name)
+            if value is not None and not isinstance(value, str):
+                msg = f"Invalid {field_name}: {value}; must be a string when set."
+                raise ValueError(msg)
+
+        if self.viewer_url is not None and self.viewer_url_template is not None:
+            msg = "viewer_url and viewer_url_template are mutually exclusive; set only one."
             raise ValueError(msg)
 
         # Update delete_scratch for each entry that has not been set to the session-level delete_scratch setting

--- a/benchmarking/runner/sinks/slack_sink.py
+++ b/benchmarking/runner/sinks/slack_sink.py
@@ -46,6 +46,20 @@ class SlackMessageBase:
             "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": " "}]}],
         },
     ]
+    _THREE_COL_BLANK_ROW: ClassVar[list[dict[str, Any]]] = [
+        {
+            "type": "rich_text",
+            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": " "}]}],
+        },
+        {
+            "type": "rich_text",
+            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": " "}]}],
+        },
+        {
+            "type": "rich_text",
+            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": " "}]}],
+        },
+    ]
 
     def __init__(self):
         """Initialize the base message."""
@@ -147,6 +161,53 @@ class SlackMessageBase:
         ]
 
     @staticmethod
+    def _get_three_column_row(left_text: str, middle_text: str, right_text: str) -> list[dict[str, Any]]:
+        """Create a three-column row for Slack rich text tables."""
+        left_text = left_text or " "
+        middle_text = middle_text or " "
+        right_text = right_text or " "
+        return [
+            {
+                "type": "rich_text",
+                "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": left_text}]}],
+            },
+            {
+                "type": "rich_text",
+                "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": middle_text}]}],
+            },
+            {
+                "type": "rich_text",
+                "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": right_text}]}],
+            },
+        ]
+
+    @staticmethod
+    def _get_three_column_row_bold(left_text: str, middle_text: str, right_text: str) -> list[dict[str, Any]]:
+        """Create a three-column row with bold left column for Slack rich text tables."""
+        left_text = left_text or " "
+        middle_text = middle_text or " "
+        right_text = right_text or " "
+        return [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [{"type": "text", "text": left_text, "style": {"bold": True}}],
+                    }
+                ],
+            },
+            {
+                "type": "rich_text",
+                "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": middle_text}]}],
+            },
+            {
+                "type": "rich_text",
+                "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": right_text}]}],
+            },
+        ]
+
+    @staticmethod
     def _get_formatted_metric_value_tuple(metric: str, result: Any) -> tuple[str, str]:  # noqa: ANN401
         """Format a metric value for display in Slack.
 
@@ -205,19 +266,73 @@ class SlackParentMessage(SlackMessageBase):
         self.env_dict = env_dict
         self.viewer_url = viewer_url
         self.entries: dict[str, str] = {}  # Dictionary mapping entry_name to status_string
+        self.entry_time_taken_s: dict[str, str] = {}  # Dictionary mapping entry_name to formatted time_taken_s
         self._has_updates: bool = False  # Track if entries have changed since last post
 
-    def update_entry(self, entry_name: str, status: str) -> None:
-        """Add or update a benchmark entry status.
+    def update_entry(self, entry_name: str, status: str, time_taken_s: str = "") -> None:
+        """Add or update a benchmark entry status and optional time_taken_s display value.
 
         Args:
             entry_name: Name of the benchmark entry.
             status: Status string (e.g., "✅ success", "❌ FAILED", "▶️ running", "⏳ waiting to start").
+            time_taken_s: Formatted time_taken_s value for the parent table, or blank when not applicable.
         """
         # Check if this is actually a change
-        if entry_name not in self.entries or self.entries[entry_name] != status:
+        if (
+            entry_name not in self.entries
+            or self.entries[entry_name] != status
+            or self.entry_time_taken_s.get(entry_name, "") != time_taken_s
+        ):
             self.entries[entry_name] = status
+            self.entry_time_taken_s[entry_name] = time_taken_s
             self._has_updates = True
+
+    @classmethod
+    def format_time_taken_s(cls, result_dict: dict[str, Any]) -> str:
+        """Format time_taken_s for the parent summary table when the metric is present."""
+        time_taken_s = find_result(result_dict, "time_taken_s")
+        if time_taken_s is None:
+            return ""
+        return cls._get_formatted_metric_value_tuple("time_taken_s", time_taken_s)[1]
+
+    def _get_entry_status_counts(self) -> dict[str, int]:
+        """Summarize entry statuses for the parent Slack message."""
+        total = len(self.entries)
+        passed = sum(status.startswith("✅") for status in self.entries.values())
+        failed = sum(status.startswith("❌") for status in self.entries.values())
+        running = sum(status.startswith("▶️") for status in self.entries.values())
+        waiting = sum(status.startswith("⏳") for status in self.entries.values())
+        return {
+            "total": total,
+            "passed": passed,
+            "failed": failed,
+            "running": running,
+            "waiting": waiting,
+        }
+
+    def _get_entry_status_summary_text(self, markdown: bool) -> str:
+        """Format the session status counts for Slack blocks or fallback text."""
+        counts = self._get_entry_status_counts()
+        separator = "  •  "
+        if markdown:
+            return separator.join(
+                [
+                    f"*Total entries:* {counts['total']}",
+                    f"*passed ✅:* {counts['passed']}",
+                    f"*failed ❌:* {counts['failed']}",
+                    f"*running ▶️:* {counts['running']}",
+                    f"*waiting ⏳:* {counts['waiting']}",
+                ]
+            )
+        return separator.join(
+            [
+                f"Total entries: {counts['total']}",
+                f"passed ✅: {counts['passed']}",
+                f"failed ❌: {counts['failed']}",
+                f"running ▶️: {counts['running']}",
+                f"waiting ⏳: {counts['waiting']}",
+            ]
+        )
 
     def to_slack_blocks(self) -> list[dict[str, Any]]:
         """Convert the parent message data to Slack blocks format.
@@ -236,20 +351,12 @@ class SlackParentMessage(SlackMessageBase):
             {"type": "divider"},
         ]
 
-        # Overall status
-        all_statuses = self.entries.values()
-        if any("⏳" in status or "▶️" in status for status in all_statuses):
-            overall_status = "⏳ In progress"
-        elif any("❌" in status for status in all_statuses):
-            overall_status = "❌ one or more FAILED"
-        else:
-            overall_status = "✅ All passed"
         blocks.append(
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"*Overall Status:* {overall_status}",
+                    "text": self._get_entry_status_summary_text(markdown=True),
                 },
             }
         )
@@ -261,25 +368,31 @@ class SlackParentMessage(SlackMessageBase):
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"*Results viewer:* <{self.viewer_url}|open run>",
+                        "text": f"*Results viewer:* <{self.viewer_url}|{self.session_name}>",
                     },
                 }
             )
 
-        # Table of benchmark entries, their status, and the environment
+        # Table of benchmark entries, their status, optional time_taken_s, and the environment.
         blocks.append({"type": "divider"})
         rows = []
         indent = "-    "  # start with a dash since leading whitespace is stripped
         for entry_name, status in self.entries.items():
-            rows.append(self._get_two_column_row_bold(entry_name, status))
-        rows.append(self._TWO_COL_BLANK_ROW)
-        rows.append(self._get_two_column_row_bold("ENVIRONMENT", " "))
+            rows.append(
+                self._get_three_column_row_bold(
+                    entry_name,
+                    status,
+                    self.entry_time_taken_s.get(entry_name, ""),
+                )
+            )
+        rows.append(self._THREE_COL_BLANK_ROW)
+        rows.append(self._get_three_column_row_bold("ENVIRONMENT", " ", ""))
         for var, val in self.env_dict.items():
-            if var in {"pip_freeze_txt", "conda_explicit_txt"}:
+            if var in {"pip_freeze_txt", "conda_explicit_txt", "viewer_url"}:
                 continue
             (fvar, fval) = self._get_formatted_metric_value_tuple(var, val)
-            rows.append(self._get_two_column_row(f"{indent}{fvar}", fval))
-        rows.append(self._TWO_COL_BLANK_ROW)
+            rows.append(self._get_three_column_row(f"{indent}{fvar}", fval, ""))
+        rows.append(self._THREE_COL_BLANK_ROW)
 
         blocks.append(
             {
@@ -296,11 +409,17 @@ class SlackParentMessage(SlackMessageBase):
         Returns:
             Fallback text string for use with chat_postMessage API.
         """
-        lines = [f"Curator Benchmark Summary - {self.session_name}"]
+        lines = [
+            f"Curator Benchmark Summary - {self.session_name}",
+            "",
+            self._get_entry_status_summary_text(markdown=False),
+        ]
         if self.entries:
             lines.append("\nBenchmark Entries:")
             for entry_name, status in self.entries.items():
-                lines.append(f"  • {entry_name}: {status}")
+                time_taken_s = self.entry_time_taken_s.get(entry_name, "")
+                suffix = f" ({time_taken_s})" if time_taken_s else ""
+                lines.append(f"  • {entry_name}: {status}{suffix}")
         return "\n".join(lines)
 
     def get_channel_id(self) -> str | None:
@@ -486,8 +605,8 @@ class SlackSink(Sink):
         # to remove the per-entry lists. Default True preserves existing behavior.
         self.ping_users_on_failure: bool = sink_config.get("ping_users_on_failure", True)
 
-        # Optional run-viewer URL surfaced as a "Results viewer" link in the parent
-        # Slack message. Typically populated in-process by run.py from --viewer-url.
+        # Optional legacy sink-level run-viewer URL. Prefer Session.viewer_url for
+        # new callers so the value is available to any sink, not just Slack.
         self.viewer_url: str | None = sink_config.get("viewer_url")
 
         self.default_metrics: list[str] = sink_config.get("default_metrics", [])
@@ -530,6 +649,7 @@ class SlackSink(Sink):
         self.session_name = session_name
         self.env_dict = env_dict
         self.session = session
+        self.viewer_url = session.viewer_url or self.viewer_url
         self._child_messages = []
         self._state_path = self._get_state_path()
         self._state_path.parent.mkdir(parents=True, exist_ok=True)
@@ -555,6 +675,7 @@ class SlackSink(Sink):
                     "ts": self._parent_message.get_timestamp(),
                     "channel": self._parent_message.get_channel_id(),
                     "entries": dict(self._parent_message.entries),
+                    "entry_time_taken_s": dict(self._parent_message.entry_time_taken_s),
                 }
                 # NOTE: This is the only time the state file is created.
                 # If the benchmark session is re-run using the same session name
@@ -566,10 +687,16 @@ class SlackSink(Sink):
                 os.write(fd, payload)
             else:
                 state = self._wait_for_session_state(self._state_path)
-                self._parent_message = SlackParentMessage(session_name=session_name, env_dict=env_dict)
+                self._parent_message = SlackParentMessage(
+                    session_name=session_name,
+                    env_dict=env_dict,
+                    viewer_url=self.viewer_url,
+                )
                 self._parent_message.set_response({"ts": state["ts"], "channel": state["channel"], "ok": True})
+                entry_time_taken_s = state.get("entry_time_taken_s", {})
                 for entry_name, entry_status in state["entries"].items():
                     self._parent_message.entries[entry_name] = entry_status
+                    self._parent_message.entry_time_taken_s[entry_name] = entry_time_taken_s.get(entry_name, "")
         finally:
             if fd is not None:
                 os.close(fd)
@@ -603,6 +730,7 @@ class SlackSink(Sink):
         else:
             pings = sink_data.get("ping_on_failure", [])
         status_text = "✅ success" if result_dict["success"] else "❌ FAILED"
+        time_taken_s_text = SlackParentMessage.format_time_taken_s(result_dict)
 
         warnings = result_dict.get("warnings", [])
 
@@ -615,7 +743,7 @@ class SlackSink(Sink):
         )
         self._child_messages.append(msg)
         # Update the session summary message with the new entry status.
-        self._update_parent_entry(benchmark_entry.name, status_text)
+        self._update_parent_entry(benchmark_entry.name, status_text, time_taken_s=time_taken_s_text)
 
         if self.live_updates:
             self._post_updates()
@@ -673,7 +801,7 @@ class SlackSink(Sink):
             warnings=warnings,
         )
 
-    def _update_parent_entry(self, entry_name: str, status: str) -> None:
+    def _update_parent_entry(self, entry_name: str, status: str, time_taken_s: str = "") -> None:
         """Update a single entry's status in the shared state file and post the update to Slack.
 
         Acquires an exclusive file lock for the duration of the read-modify-write cycle and
@@ -682,6 +810,7 @@ class SlackSink(Sink):
         Args:
             entry_name: Name of the benchmark entry to update.
             status: New status string for the entry.
+            time_taken_s: Formatted time_taken_s value for the entry, or blank when not applicable.
         """
         if self._state_path is None:
             logger.error("SlackSink: Cannot update parent entry — state path not set. Was initialize() called?")
@@ -694,9 +823,11 @@ class SlackSink(Sink):
         try:
             fcntl.flock(f.fileno(), fcntl.LOCK_EX)
             state = json.load(f)
+            state.setdefault("entry_time_taken_s", {})
             state["entries"][entry_name] = status
+            state["entry_time_taken_s"][entry_name] = time_taken_s
             for name, st in state["entries"].items():
-                self._parent_message.update_entry(name, st)
+                self._parent_message.update_entry(name, st, state["entry_time_taken_s"].get(name, ""))
             try:
                 self._update_message(self._parent_message)
             finally:

--- a/benchmarking/runner/viewer_url.py
+++ b/benchmarking/runner/viewer_url.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from string import Formatter
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_VIEWER_URL_TEMPLATE_PLACEHOLDERS = (
+    "results_path",
+    "results_path_url",
+    "session_name",
+    "session_name_url",
+    "session_path",
+    "session_path_url",
+)
+
+
+def _quote_url_component(value: str) -> str:
+    return quote(value, safe="")
+
+
+def render_viewer_url_template(
+    template: str,
+    *,
+    results_path: Path,
+    session_name: str,
+    session_path: Path,
+) -> str:
+    """Render a benchmark viewer URL template using a small fixed placeholder set."""
+    values = {
+        "results_path": str(results_path),
+        "results_path_url": _quote_url_component(str(results_path)),
+        "session_name": session_name,
+        "session_name_url": _quote_url_component(session_name),
+        "session_path": str(session_path),
+        "session_path_url": _quote_url_component(str(session_path)),
+    }
+
+    try:
+        parsed_template = list(Formatter().parse(template))
+    except ValueError as e:
+        msg = f"Invalid viewer_url_template: {e}"
+        raise ValueError(msg) from e
+
+    rendered_parts: list[str] = []
+    for literal_text, field_name, format_spec, conversion in parsed_template:
+        rendered_parts.append(literal_text)
+        if field_name is None:
+            continue
+        if conversion is not None or format_spec:
+            msg = (
+                "viewer_url_template placeholders do not support conversions or format specifiers. "
+                f"Use one of: {', '.join(_VIEWER_URL_TEMPLATE_PLACEHOLDERS)}."
+            )
+            raise ValueError(msg)
+        if field_name not in values:
+            msg = (
+                f"Unsupported viewer_url_template placeholder '{field_name}'. "
+                f"Supported placeholders: {', '.join(_VIEWER_URL_TEMPLATE_PLACEHOLDERS)}."
+            )
+            raise ValueError(msg)
+        rendered_parts.append(values[field_name])
+
+    return "".join(rendered_parts)
+
+
+def resolve_viewer_url(
+    *,
+    viewer_url: str | None,
+    viewer_url_template: str | None,
+    results_path: Path,
+    session_name: str,
+    session_path: Path,
+) -> str | None:
+    """Return the final viewer URL, preferring an explicitly supplied URL."""
+    if viewer_url is not None:
+        return viewer_url
+    if viewer_url_template is None:
+        return None
+    return render_viewer_url_template(
+        viewer_url_template,
+        results_path=results_path,
+        session_name=session_name,
+        session_path=session_path,
+    )

--- a/tests/benchmarking/runner/sinks/test_slack_sink.py
+++ b/tests/benchmarking/runner/sinks/test_slack_sink.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "benchmarking"))
+
+from runner.sinks.slack_sink import SlackParentMessage
+
+
+def _section_texts(blocks: list[dict[str, Any]]) -> list[str]:
+    return [
+        block["text"]["text"]
+        for block in blocks
+        if block.get("type") == "section" and block.get("text", {}).get("type") == "mrkdwn"
+    ]
+
+
+def _table_rows(blocks: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    return next(block["rows"] for block in blocks if block.get("type") == "table")
+
+
+def _row_texts(row: list[dict[str, Any]]) -> list[str]:
+    return [cell["elements"][0]["elements"][0]["text"] for cell in row]
+
+
+def test_slack_parent_message_reports_entry_status_counts() -> None:
+    message = SlackParentMessage(session_name="test-session", env_dict={})
+    time_taken_s = SlackParentMessage.format_time_taken_s({"metrics": {"time_taken_s": 12.345}})
+    message.update_entry("waiting_entry", "⏳ waiting to start")
+    message.update_entry("running_entry", "▶️ running")
+    message.update_entry("passed_entry", "✅ success", time_taken_s=time_taken_s)
+    message.update_entry("failed_entry", "❌ FAILED")
+
+    blocks = message.to_slack_blocks()
+    section_texts = _section_texts(blocks)
+    table_rows = _table_rows(blocks)
+
+    assert section_texts[0] == (
+        "*Total entries:* 4  •  *passed ✅:* 1  •  *failed ❌:* 1  •  *running ▶️:* 1  •  *waiting ⏳:* 1"
+    )
+    assert all("Overall Status" not in text for text in section_texts)
+    assert all(len(row) == 3 for row in table_rows)
+    assert _row_texts(table_rows[0]) == ["waiting_entry", "⏳ waiting to start", " "]
+    assert _row_texts(table_rows[1]) == ["running_entry", "▶️ running", " "]
+    assert _row_texts(table_rows[2]) == ["passed_entry", "✅ success", "12.35s"]
+    assert _row_texts(table_rows[3]) == ["failed_entry", "❌ FAILED", " "]
+
+
+def test_slack_parent_message_labels_viewer_link_with_session_name() -> None:
+    message = SlackParentMessage(
+        session_name="test-session",
+        env_dict={},
+        viewer_url="http://viewer.example.com/run?name=test-session",
+    )
+
+    section_texts = _section_texts(message.to_slack_blocks())
+
+    assert section_texts[1] == "*Results viewer:* <http://viewer.example.com/run?name=test-session|test-session>"
+
+
+def test_slack_parent_message_fallback_reports_entry_status_counts() -> None:
+    message = SlackParentMessage(session_name="test-session", env_dict={})
+    message.update_entry("passed_entry", "✅ success", time_taken_s="12.35s")
+    message.update_entry("failed_entry", "❌ FAILED")
+
+    fallback_text = message.to_fallback_text()
+
+    assert "Total entries: 2" in fallback_text
+    assert "passed ✅: 1" in fallback_text
+    assert "failed ❌: 1" in fallback_text
+    assert "running ▶️: 0" in fallback_text
+    assert "waiting ⏳: 0" in fallback_text
+    assert "passed_entry: ✅ success (12.35s)" in fallback_text

--- a/tests/benchmarking/runner/test_path_resolver.py
+++ b/tests/benchmarking/runner/test_path_resolver.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "benchmarking"))
+
+from runner.path_resolver import PathResolver
+
+
+def test_unmap_container_path_returns_host_visible_path() -> None:
+    path_resolver = PathResolver(
+        {
+            "paths": [
+                {
+                    "name": "results_path",
+                    "host_path": "/host/results",
+                    "container_path": "/container/results",
+                }
+            ]
+        }
+    )
+
+    assert path_resolver.unmap_container_path(Path("/container/results/run")) == Path("/host/results/run")
+
+
+def test_unmap_container_path_returns_unmapped_path_unchanged() -> None:
+    path_resolver = PathResolver(
+        {
+            "paths": [
+                {
+                    "name": "results_path",
+                    "host_path": "/host/results",
+                    "container_path": "/container/results",
+                }
+            ]
+        }
+    )
+
+    assert path_resolver.unmap_container_path(Path("/other/results/run")) == Path("/other/results/run")

--- a/tests/benchmarking/runner/test_session.py
+++ b/tests/benchmarking/runner/test_session.py
@@ -79,6 +79,42 @@ def test_session_rejects_invalid_max_timeout_s(bad_max_timeout_s: object) -> Non
         )
 
 
+def test_session_accepts_run_metadata() -> None:
+    session = Session.from_dict(
+        _config(
+            [{"name": "entry_a", "script": "benchmark.py"}],
+            viewer_url_template="http://viewer/run?dir={session_path_url}",
+            run_reason="release candidate check",
+        )
+    )
+
+    assert session.viewer_url is None
+    assert session.viewer_url_template == "http://viewer/run?dir={session_path_url}"
+    assert session.run_reason == "release candidate check"
+
+
+def test_session_rejects_viewer_url_and_viewer_url_template() -> None:
+    with pytest.raises(ValueError, match="viewer_url and viewer_url_template are mutually exclusive"):
+        Session.from_dict(
+            _config(
+                [{"name": "entry_a", "script": "benchmark.py"}],
+                viewer_url="http://viewer/run/entry_a",
+                viewer_url_template="http://viewer/run?dir={session_path_url}",
+            )
+        )
+
+
+@pytest.mark.parametrize("field_name", ["viewer_url", "viewer_url_template", "run_reason"])
+def test_session_rejects_invalid_run_metadata_type(field_name: str) -> None:
+    with pytest.raises(ValueError, match=f"Invalid {field_name}"):
+        Session.from_dict(
+            _config(
+                [{"name": "entry_a", "script": "benchmark.py"}],
+                **{field_name: True},
+            )
+        )
+
+
 def test_session_applies_max_timeout_s_after_default_timeout_s() -> None:
     with pytest.raises(ValueError, match=r"entry_a.*timeout_s=120.*max_timeout_s=100"):
         Session.from_dict(

--- a/tests/benchmarking/runner/test_viewer_url.py
+++ b/tests/benchmarking/runner/test_viewer_url.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "benchmarking"))
+
+from runner.viewer_url import render_viewer_url_template, resolve_viewer_url
+
+
+def test_render_viewer_url_template_substitutes_supported_placeholders() -> None:
+    rendered = render_viewer_url_template(
+        "http://viewer/run?dir={session_path_url}&run={session_name_url}&root={results_path_url}",
+        results_path=Path("/benchmark-results/results branch"),
+        session_name="rc run 1",
+        session_path=Path("/benchmark-results/results branch/rc run 1"),
+    )
+
+    assert (
+        rendered
+        == "http://viewer/run?dir=%2Fbenchmark-results%2Fresults%20branch%2Frc%20run%201&run=rc%20run%201&root=%2Fbenchmark-results%2Fresults%20branch"
+    )
+
+
+def test_render_viewer_url_template_rejects_unknown_placeholder() -> None:
+    with pytest.raises(ValueError, match="Unsupported viewer_url_template placeholder 'unknown'"):
+        render_viewer_url_template(
+            "http://viewer/run?dir={unknown}",
+            results_path=Path("/benchmark-results/results"),
+            session_name="run",
+            session_path=Path("/benchmark-results/results/run"),
+        )
+
+
+def test_render_viewer_url_template_rejects_format_specifier() -> None:
+    with pytest.raises(ValueError, match="do not support conversions or format specifiers"):
+        render_viewer_url_template(
+            "http://viewer/run?name={session_name!r}",
+            results_path=Path("/benchmark-results/results"),
+            session_name="run",
+            session_path=Path("/benchmark-results/results/run"),
+        )
+
+
+def test_resolve_viewer_url_prefers_explicit_url() -> None:
+    resolved = resolve_viewer_url(
+        viewer_url="http://viewer/explicit",
+        viewer_url_template="http://viewer/template?dir={session_path_url}",
+        results_path=Path("/benchmark-results/results"),
+        session_name="run",
+        session_path=Path("/benchmark-results/results/run"),
+    )
+
+    assert resolved == "http://viewer/explicit"
+
+
+def test_resolve_viewer_url_returns_none_without_url_or_template() -> None:
+    resolved = resolve_viewer_url(
+        viewer_url=None,
+        viewer_url_template=None,
+        results_path=Path("/benchmark-results/results"),
+        session_name="run",
+        session_path=Path("/benchmark-results/results/run"),
+    )
+
+    assert resolved is None


### PR DESCRIPTION
## Summary
- Add session-level viewer URL, viewer URL template, and run reason metadata plus CLI args for viewer URL overrides.
- Render viewer URL templates from session/results placeholders, using host-visible paths when benchmark results are produced inside container mounts, and capture resolved metadata in env output.
- Update Slack reports with a linked results viewer, compact status counts, and a time_taken_s column in the parent table.
- Re-enable `ping_users_on_failure` in `benchmarking/nightly-benchmark.yaml` now that nightly Slack failure mentions should be active again.
- Document viewer URL template placeholders and add runner/Slack/path resolver tests.

<img width="2032" height="425" alt="Screenshot 2026-07-28 111232" src="https://github.com/user-attachments/assets/0c75a59e-60dc-49f0-abcf-06daa03b1ce3" />
