### PR TITLE
Add more custom metrics to minhash stage

### DIFF
--- a/nemo_curator/stages/deduplication/fuzzy/minhash.py
+++ b/nemo_curator/stages/deduplication/fuzzy/minhash.py
@@ -311,19 +311,22 @@ class MinHashStage(ProcessingStage[FileGroupTask, FileGroupTask], DeduplicationI
         read_kwargs = self.read_kwargs.copy()
 
         # Read input file based on format
-        if self.read_format == "jsonl":
-            df = self.read_jsonl(filepath=task.data, columns=[self.text_field], assign_id=True, **read_kwargs)
-        elif self.read_format == "parquet":
-            df = self.read_parquet(filepath=task.data, columns=[self.text_field], assign_id=True, **read_kwargs)
-        else:
-            msg = f"Unsupported read format: {self.read_format}"
-            raise ValueError(msg)
+        with self._time_metric("minhash_read_time"):
+            if self.read_format == "jsonl":
+                df = self.read_jsonl(filepath=task.data, columns=[self.text_field], assign_id=True, **read_kwargs)
+            elif self.read_format == "parquet":
+                df = self.read_parquet(filepath=task.data, columns=[self.text_field], assign_id=True, **read_kwargs)
+            else:
+                msg = f"Unsupported read format: {self.read_format}"
+                raise ValueError(msg)
 
         result_df = df[[CURATOR_DEDUP_ID_STR]]
-        result_df[self.minhash_field] = self.minhash_processor.compute_minhashes(df[self.text_field])
+        with self._time_metric("minhash_compute_time"):
+            result_df[self.minhash_field] = self.minhash_processor.compute_minhashes(df[self.text_field])
 
         # Write output file
-        self.write_parquet(df=result_df, filepath=output_file, **self.write_kwargs)
+        with self._time_metric("minhash_write_time"):
+            self.write_parquet(df=result_df, filepath=output_file, **self.write_kwargs)
 
         # Return FileGroupTask with output file
         return FileGroupTask(

--- a/tests/stages/deduplication/fuzzy/test_minhash_stage.py
+++ b/tests/stages/deduplication/fuzzy/test_minhash_stage.py
@@ -157,6 +157,12 @@ class TestMinHashStage:
         stage.setup()
         output_task = stage.process(input_task)
 
+        # Verify detailed stage timings are recorded
+        assert all(
+            stage._custom_metrics[metric] > 0
+            for metric in ("minhash_read_time", "minhash_compute_time", "minhash_write_time")
+        )
+
         # Verify output task structure
         assert isinstance(output_task, FileGroupTask)
         assert len(output_task.data) == 1


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Adds more metrics to track the read, minhash and write time that can provide more complete stats in benchmarks

Closes NMCUR-187

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
